### PR TITLE
feat: manufacturer typeahead for new stock form (issue #5)

### DIFF
--- a/frollz-api/src/stock/stock.controller.spec.ts
+++ b/frollz-api/src/stock/stock.controller.spec.ts
@@ -30,6 +30,7 @@ describe('StockController', () => {
             update: jest.fn(),
             remove: jest.fn(),
             getBrands: jest.fn(),
+            getManufacturers: jest.fn(),
           },
         },
       ],
@@ -63,6 +64,33 @@ describe('StockController', () => {
       service.getBrands.mockResolvedValue([]);
 
       const result = await controller.getBrands('zzz');
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getManufacturers', () => {
+    it('should return manufacturers from the service', async () => {
+      service.getManufacturers.mockResolvedValue(['Kodak', 'Konica']);
+
+      const result = await controller.getManufacturers('ko');
+
+      expect(service.getManufacturers).toHaveBeenCalledWith('ko');
+      expect(result).toEqual(['Kodak', 'Konica']);
+    });
+
+    it('should pass empty string when q is undefined', async () => {
+      service.getManufacturers.mockResolvedValue([]);
+
+      await controller.getManufacturers(undefined as any);
+
+      expect(service.getManufacturers).toHaveBeenCalledWith('');
+    });
+
+    it('should return an empty array when no manufacturers match', async () => {
+      service.getManufacturers.mockResolvedValue([]);
+
+      const result = await controller.getManufacturers('zzz');
 
       expect(result).toEqual([]);
     });

--- a/frollz-api/src/stock/stock.controller.ts
+++ b/frollz-api/src/stock/stock.controller.ts
@@ -31,6 +31,13 @@ export class StockController {
     return this.stockService.getBrands(q ?? '');
   }
 
+  @Get('manufacturers')
+  @ApiOperation({ summary: 'Get distinct manufacturer names matching a query' })
+  @ApiResponse({ status: 200, description: 'Matching manufacturer names', type: [String] })
+  getManufacturers(@Query('q') q: string): Promise<string[]> {
+    return this.stockService.getManufacturers(q ?? '');
+  }
+
   @Get(':key')
   @ApiOperation({ summary: 'Get a stock by key' })
   @ApiResponse({ status: 200, description: 'Stock retrieved successfully', type: Stock })

--- a/frollz-api/src/stock/stock.service.spec.ts
+++ b/frollz-api/src/stock/stock.service.spec.ts
@@ -84,4 +84,55 @@ describe('StockService', () => {
       );
     });
   });
+
+  describe('getManufacturers', () => {
+    it('should query using CONTAINS on manufacturer with the provided query', async () => {
+      mockCursor.all.mockResolvedValue([]);
+
+      await service.getManufacturers('kod');
+
+      expect(databaseService.query).toHaveBeenCalledWith(
+        expect.stringContaining('CONTAINS'),
+        { query: 'kod' },
+      );
+    });
+
+    it('should filter on the manufacturer field', async () => {
+      mockCursor.all.mockResolvedValue([]);
+
+      await service.getManufacturers('kod');
+
+      expect(databaseService.query).toHaveBeenCalledWith(
+        expect.stringContaining('stock.manufacturer'),
+        expect.anything(),
+      );
+    });
+
+    it('should use DISTINCT to avoid duplicate manufacturer names', async () => {
+      mockCursor.all.mockResolvedValue([]);
+
+      await service.getManufacturers('kod');
+
+      expect(databaseService.query).toHaveBeenCalledWith(
+        expect.stringContaining('DISTINCT'),
+        expect.anything(),
+      );
+    });
+
+    it('should return matching manufacturer names from the cursor', async () => {
+      mockCursor.all.mockResolvedValue(['Kodak', 'Konica']);
+
+      const result = await service.getManufacturers('ko');
+
+      expect(result).toEqual(['Kodak', 'Konica']);
+    });
+
+    it('should return an empty array when no manufacturers match', async () => {
+      mockCursor.all.mockResolvedValue([]);
+
+      const result = await service.getManufacturers('zzz');
+
+      expect(result).toEqual([]);
+    });
+  });
 });

--- a/frollz-api/src/stock/stock.service.ts
+++ b/frollz-api/src/stock/stock.service.ts
@@ -79,4 +79,14 @@ export class StockService {
     );
     return await cursor.all();
   }
+
+  async getManufacturers(query: string): Promise<string[]> {
+    const cursor = await this.databaseService.query(
+      `FOR stock IN stocks
+       FILTER CONTAINS(LOWER(stock.manufacturer), LOWER(@query))
+       RETURN DISTINCT stock.manufacturer`,
+      { query },
+    );
+    return await cursor.all();
+  }
 }

--- a/frollz-ui/src/components/TypeaheadInput.vue
+++ b/frollz-ui/src/components/TypeaheadInput.vue
@@ -35,11 +35,11 @@
 
 <script setup lang="ts">
 import { ref, computed } from 'vue'
-import { stockApi } from '@/services/api-client'
 import { buildSuggestions } from '@/utils/brandSuggestions'
 
 const props = defineProps<{
   modelValue: string
+  fetchOptions: (query: string) => Promise<string[]>
 }>()
 
 const emit = defineEmits<{
@@ -51,30 +51,29 @@ const inputValue = computed({
   set: (val: string) => emit('update:modelValue', val),
 })
 
-const dbBrands = ref<string[]>([])
+const dbOptions = ref<string[]>([])
 const isOpen = ref(false)
 const highlightedIndex = ref(-1)
 let debounceTimer: ReturnType<typeof setTimeout> | null = null
 
-const suggestions = computed(() => buildSuggestions(inputValue.value, dbBrands.value))
+const suggestions = computed(() => buildSuggestions(inputValue.value, dbOptions.value))
 
 const onInput = () => {
   isOpen.value = true
   highlightedIndex.value = -1
   if (debounceTimer) clearTimeout(debounceTimer)
-  debounceTimer = setTimeout(() => fetchBrands(), 200)
+  debounceTimer = setTimeout(() => fetchOptions(), 200)
 }
 
-const fetchBrands = async () => {
+const fetchOptions = async () => {
   if (!inputValue.value.trim()) {
-    dbBrands.value = []
+    dbOptions.value = []
     return
   }
   try {
-    const response = await stockApi.getBrands(inputValue.value)
-    dbBrands.value = response.data
+    dbOptions.value = await props.fetchOptions(inputValue.value)
   } catch {
-    dbBrands.value = []
+    dbOptions.value = []
   }
 }
 

--- a/frollz-ui/src/services/api-client.ts
+++ b/frollz-ui/src/services/api-client.ts
@@ -22,6 +22,7 @@ export const stockApi = {
     api.patch<Stock>(`/stocks/${key}`, data),
   delete: (key: string) => api.delete(`/stocks/${key}`),
   getBrands: (q: string) => api.get<string[]>('/stocks/brands', { params: { q } }),
+  getManufacturers: (q: string) => api.get<string[]>('/stocks/manufacturers', { params: { q } }),
 }
 
 // Tag API

--- a/frollz-ui/src/views/StocksView.vue
+++ b/frollz-ui/src/views/StocksView.vue
@@ -57,8 +57,9 @@
           <div class="space-y-4">
             <div>
               <label class="block text-sm font-medium text-gray-700 mb-1">Brand <span class="text-red-500">*</span></label>
-              <BrandTypeahead
+              <TypeaheadInput
                 v-model="form.brand"
+                :fetchOptions="(q) => stockApi.getBrands(q).then(r => r.data)"
                 required
                 placeholder="e.g. Portra 400"
                 class="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
@@ -66,9 +67,9 @@
             </div>
             <div>
               <label class="block text-sm font-medium text-gray-700 mb-1">Manufacturer <span class="text-red-500">*</span></label>
-              <input
+              <TypeaheadInput
                 v-model="form.manufacturer"
-                type="text"
+                :fetchOptions="(q) => stockApi.getManufacturers(q).then(r => r.data)"
                 required
                 placeholder="e.g. Kodak"
                 class="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
@@ -164,7 +165,7 @@ import { ref, onMounted, computed } from 'vue'
 import { stockApi, filmFormatApi, tagApi, stockTagApi } from '@/services/api-client'
 import type { Stock, FilmFormat, Tag } from '@/types'
 import { Process } from '@/types'
-import BrandTypeahead from '@/components/BrandTypeahead.vue'
+import TypeaheadInput from '@/components/TypeaheadInput.vue'
 
 const stocks = ref<Stock[]>([])
 const formats = ref<FilmFormat[]>([])


### PR DESCRIPTION
Closes #5

## Summary
- Adds `GET /stocks/manufacturers?q=` endpoint — distinct manufacturer names via case-insensitive CONTAINS
- Refactors `BrandTypeahead.vue` → generic `TypeaheadInput.vue` that accepts a `fetchOptions` prop, so both Brand and Manufacturer fields share the same component
- `StocksView` passes `stockApi.getBrands` and `stockApi.getManufacturers` as fetch functions to the two typeahead inputs
- Dropdown ordering is identical to Brand: (1) title case, (2) exact typed value, (3) DB matches — deduplicated

## Test plan
- [ ] Backend: `npm test` in `frollz-api` — 73 tests pass (8 new for `getManufacturers`)
- [ ] Frontend: `npm test` in `frollz-ui` — 14 vitest tests pass (unchanged; logic is shared via `buildSuggestions`)
- [ ] Manual: open Add Stock modal, type in Manufacturer field and verify dropdown suggestions appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)