### PR TITLE
feat: speed typeahead for new film stock (issue #6)

### DIFF
--- a/frollz-api/src/stock/stock.controller.spec.ts
+++ b/frollz-api/src/stock/stock.controller.spec.ts
@@ -31,6 +31,7 @@ describe('StockController', () => {
             remove: jest.fn(),
             getBrands: jest.fn(),
             getManufacturers: jest.fn(),
+            getSpeeds: jest.fn(),
           },
         },
       ],
@@ -91,6 +92,33 @@ describe('StockController', () => {
       service.getManufacturers.mockResolvedValue([]);
 
       const result = await controller.getManufacturers('zzz');
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getSpeeds', () => {
+    it('should return speeds from the service', async () => {
+      service.getSpeeds.mockResolvedValue([400, 800]);
+
+      const result = await controller.getSpeeds('4');
+
+      expect(service.getSpeeds).toHaveBeenCalledWith('4');
+      expect(result).toEqual([400, 800]);
+    });
+
+    it('should pass empty string when q is undefined', async () => {
+      service.getSpeeds.mockResolvedValue([]);
+
+      await controller.getSpeeds(undefined as any);
+
+      expect(service.getSpeeds).toHaveBeenCalledWith('');
+    });
+
+    it('should return an empty array when no speeds match', async () => {
+      service.getSpeeds.mockResolvedValue([]);
+
+      const result = await controller.getSpeeds('999');
 
       expect(result).toEqual([]);
     });

--- a/frollz-api/src/stock/stock.controller.ts
+++ b/frollz-api/src/stock/stock.controller.ts
@@ -38,6 +38,13 @@ export class StockController {
     return this.stockService.getManufacturers(q ?? '');
   }
 
+  @Get('speeds')
+  @ApiOperation({ summary: 'Get distinct speed values matching a query' })
+  @ApiResponse({ status: 200, description: 'Matching speed values', type: [Number] })
+  getSpeeds(@Query('q') q: string): Promise<number[]> {
+    return this.stockService.getSpeeds(q ?? '');
+  }
+
   @Get(':key')
   @ApiOperation({ summary: 'Get a stock by key' })
   @ApiResponse({ status: 200, description: 'Stock retrieved successfully', type: Stock })

--- a/frollz-api/src/stock/stock.service.spec.ts
+++ b/frollz-api/src/stock/stock.service.spec.ts
@@ -135,4 +135,55 @@ describe('StockService', () => {
       expect(result).toEqual([]);
     });
   });
+
+  describe('getSpeeds', () => {
+    it('should query using CONTAINS on speed with the provided query', async () => {
+      mockCursor.all.mockResolvedValue([]);
+
+      await service.getSpeeds('40');
+
+      expect(databaseService.query).toHaveBeenCalledWith(
+        expect.stringContaining('CONTAINS'),
+        { query: '40' },
+      );
+    });
+
+    it('should convert speed to string for matching', async () => {
+      mockCursor.all.mockResolvedValue([]);
+
+      await service.getSpeeds('40');
+
+      expect(databaseService.query).toHaveBeenCalledWith(
+        expect.stringContaining('TO_STRING'),
+        expect.anything(),
+      );
+    });
+
+    it('should use DISTINCT to avoid duplicate speed values', async () => {
+      mockCursor.all.mockResolvedValue([]);
+
+      await service.getSpeeds('40');
+
+      expect(databaseService.query).toHaveBeenCalledWith(
+        expect.stringContaining('DISTINCT'),
+        expect.anything(),
+      );
+    });
+
+    it('should return matching speeds from the cursor', async () => {
+      mockCursor.all.mockResolvedValue([400, 800]);
+
+      const result = await service.getSpeeds('4');
+
+      expect(result).toEqual([400, 800]);
+    });
+
+    it('should return an empty array when no speeds match', async () => {
+      mockCursor.all.mockResolvedValue([]);
+
+      const result = await service.getSpeeds('999');
+
+      expect(result).toEqual([]);
+    });
+  });
 });

--- a/frollz-api/src/stock/stock.service.ts
+++ b/frollz-api/src/stock/stock.service.ts
@@ -89,4 +89,14 @@ export class StockService {
     );
     return await cursor.all();
   }
+
+  async getSpeeds(query: string): Promise<number[]> {
+    const cursor = await this.databaseService.query(
+      `FOR stock IN stocks
+       FILTER CONTAINS(TO_STRING(stock.speed), @query)
+       RETURN DISTINCT stock.speed`,
+      { query },
+    );
+    return await cursor.all();
+  }
 }

--- a/frollz-ui/src/components/SpeedTypeaheadInput.vue
+++ b/frollz-ui/src/components/SpeedTypeaheadInput.vue
@@ -1,0 +1,131 @@
+<template>
+  <div class="relative">
+    <input
+      :value="rawInput"
+      type="text"
+      inputmode="numeric"
+      v-bind="$attrs"
+      @input="onInput"
+      @keydown.escape.prevent="close"
+      @keydown.down.prevent="moveDown"
+      @keydown.up.prevent="moveUp"
+      @keydown.enter.prevent="selectHighlighted"
+      @blur="onBlur"
+      @focus="onFocus"
+    />
+    <ul
+      v-if="isOpen && suggestions.length > 0"
+      class="absolute z-10 mt-1 w-full bg-white border border-gray-200 rounded-md shadow-lg max-h-60 overflow-auto"
+    >
+      <li
+        v-for="(suggestion, i) in suggestions"
+        :key="suggestion"
+        @mousedown.prevent="select(suggestion)"
+        class="px-3 py-2 text-sm cursor-pointer"
+        :class="
+          i === highlightedIndex
+            ? 'bg-primary-50 text-primary-700'
+            : 'text-gray-900 hover:bg-gray-50'
+        "
+      >
+        {{ suggestion }}
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+import { buildSpeedSuggestions } from '@/utils/speedSuggestions'
+
+const props = defineProps<{
+  modelValue: number | undefined
+  fetchOptions: (query: string) => Promise<number[]>
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: number | undefined]
+}>()
+
+const rawInput = ref(props.modelValue !== undefined ? String(props.modelValue) : '')
+
+watch(
+  () => props.modelValue,
+  (newVal) => {
+    const str = newVal !== undefined ? String(newVal) : ''
+    if (rawInput.value !== str) {
+      rawInput.value = str
+    }
+  },
+)
+
+const dbOptions = ref<number[]>([])
+const isOpen = ref(false)
+const highlightedIndex = ref(-1)
+let debounceTimer: ReturnType<typeof setTimeout> | null = null
+
+const suggestions = computed(() => buildSpeedSuggestions(rawInput.value, dbOptions.value))
+
+const onInput = (event: Event) => {
+  const val = (event.target as HTMLInputElement).value
+  const numeric = val.replace(/\D/g, '')
+  rawInput.value = numeric
+  ;(event.target as HTMLInputElement).value = numeric
+
+  emit('update:modelValue', numeric ? Number(numeric) : undefined)
+
+  isOpen.value = true
+  highlightedIndex.value = -1
+  if (debounceTimer) clearTimeout(debounceTimer)
+  debounceTimer = setTimeout(() => fetchOptions(), 200)
+}
+
+const fetchOptions = async () => {
+  if (!rawInput.value.trim()) {
+    dbOptions.value = []
+    return
+  }
+  try {
+    dbOptions.value = await props.fetchOptions(rawInput.value)
+  } catch {
+    dbOptions.value = []
+  }
+}
+
+const select = (value: number) => {
+  rawInput.value = String(value)
+  emit('update:modelValue', value)
+  close()
+}
+
+const close = () => {
+  isOpen.value = false
+  highlightedIndex.value = -1
+}
+
+const onBlur = () => {
+  setTimeout(() => close(), 150)
+}
+
+const onFocus = () => {
+  if (rawInput.value.trim()) {
+    isOpen.value = true
+  }
+}
+
+const moveDown = () => {
+  if (!isOpen.value) return
+  highlightedIndex.value = Math.min(highlightedIndex.value + 1, suggestions.value.length - 1)
+}
+
+const moveUp = () => {
+  if (!isOpen.value) return
+  highlightedIndex.value = Math.max(highlightedIndex.value - 1, -1)
+}
+
+const selectHighlighted = () => {
+  if (highlightedIndex.value >= 0 && highlightedIndex.value < suggestions.value.length) {
+    select(suggestions.value[highlightedIndex.value])
+  }
+}
+</script>

--- a/frollz-ui/src/services/api-client.ts
+++ b/frollz-ui/src/services/api-client.ts
@@ -23,6 +23,7 @@ export const stockApi = {
   delete: (key: string) => api.delete(`/stocks/${key}`),
   getBrands: (q: string) => api.get<string[]>('/stocks/brands', { params: { q } }),
   getManufacturers: (q: string) => api.get<string[]>('/stocks/manufacturers', { params: { q } }),
+  getSpeeds: (q: string) => api.get<number[]>('/stocks/speeds', { params: { q } }),
 }
 
 // Tag API

--- a/frollz-ui/src/utils/__tests__/speedSuggestions.spec.ts
+++ b/frollz-ui/src/utils/__tests__/speedSuggestions.spec.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { buildSpeedSuggestions } from '../speedSuggestions'
+
+describe('buildSpeedSuggestions', () => {
+  it('returns an empty array when the query is empty', () => {
+    expect(buildSpeedSuggestions('', [])).toEqual([])
+  })
+
+  it('returns an empty array when the query is only whitespace', () => {
+    expect(buildSpeedSuggestions('   ', [])).toEqual([])
+  })
+
+  it('returns an empty array when the query is non-numeric', () => {
+    expect(buildSpeedSuggestions('abc', [])).toEqual([])
+  })
+
+  it('places the typed numeric value first', () => {
+    const result = buildSpeedSuggestions('40', [])
+    expect(result[0]).toBe(40)
+  })
+
+  it('appends DB speeds after the typed value', () => {
+    const result = buildSpeedSuggestions('4', [400, 800])
+    expect(result).toContain(400)
+    expect(result).toContain(800)
+    expect(result.indexOf(4)).toBeLessThan(result.indexOf(400))
+  })
+
+  it('does not duplicate a DB speed that matches the typed value', () => {
+    const result = buildSpeedSuggestions('400', [400, 800])
+    expect(result.filter(s => s === 400)).toHaveLength(1)
+  })
+
+  it('includes all non-duplicate DB speeds', () => {
+    const result = buildSpeedSuggestions('4', [400, 800, 1600])
+    expect(result).toContain(400)
+    expect(result).toContain(800)
+    expect(result).toContain(1600)
+  })
+
+  it('handles a query with leading/trailing whitespace', () => {
+    const result = buildSpeedSuggestions(' 400 ', [])
+    expect(result[0]).toBe(400)
+  })
+})

--- a/frollz-ui/src/utils/speedSuggestions.ts
+++ b/frollz-ui/src/utils/speedSuggestions.ts
@@ -1,0 +1,26 @@
+/**
+ * Builds the ordered list of speed suggestions for the typeahead dropdown:
+ *  1. The typed numeric value
+ *  2. DB speeds that match but aren't already in the list
+ *
+ * Returns an empty array when the query is blank or non-numeric.
+ */
+export function buildSpeedSuggestions(query: string, dbSpeeds: number[]): number[] {
+  if (!query.trim() || !/^\d+$/.test(query.trim())) return []
+
+  const typedNumber = Number(query.trim())
+  const seen = new Set<number>()
+  const result: number[] = []
+
+  result.push(typedNumber)
+  seen.add(typedNumber)
+
+  for (const speed of dbSpeeds) {
+    if (!seen.has(speed)) {
+      result.push(speed)
+      seen.add(speed)
+    }
+  }
+
+  return result
+}

--- a/frollz-ui/src/views/StocksView.vue
+++ b/frollz-ui/src/views/StocksView.vue
@@ -101,9 +101,9 @@
             </div>
             <div>
               <label class="block text-sm font-medium text-gray-700 mb-1">Speed (ISO) <span class="text-red-500">*</span></label>
-              <input
-                v-model.number="form.speed"
-                type="number"
+              <SpeedTypeaheadInput
+                v-model="form.speed"
+                :fetchOptions="(q: string) => stockApi.getSpeeds(q).then(r => r.data)"
                 required
                 min="1"
                 placeholder="e.g. 400"
@@ -166,6 +166,7 @@ import { stockApi, filmFormatApi, tagApi, stockTagApi } from '@/services/api-cli
 import type { Stock, FilmFormat, Tag } from '@/types'
 import { Process } from '@/types'
 import TypeaheadInput from '@/components/TypeaheadInput.vue'
+import SpeedTypeaheadInput from '@/components/SpeedTypeaheadInput.vue'
 
 const stocks = ref<Stock[]>([])
 const formats = ref<FilmFormat[]>([])


### PR DESCRIPTION
Closes #6

## Summary
- **Backend**: `getSpeeds(query)` service method using AQL `CONTAINS(TO_STRING(stock.speed), @query)` with `DISTINCT`; new `GET /stocks/speeds?q=` endpoint placed before `/:key` to avoid routing collision
- **Frontend**: `buildSpeedSuggestions` util (typed number first, then DB matches); `SpeedTypeaheadInput.vue` component with numeric-only input enforcement, debounced API lookup, and keyboard navigation; `StocksView.vue` speed field replaced with the new component
- **Tests**: 5 new service tests, 3 new controller tests, 8 new util tests (all green — 81 API / 22 UI total)

## Test plan
- [x] Run `npm test` in `frollz-api` — all 81 tests pass
- [x] Run `npm test -- --run` in `frollz-ui` — all 22 tests pass
- [x] Open Add Stock modal, type a number in Speed field — dropdown appears with typed value first, followed by any matching speeds from the DB
- [x] Non-numeric keystrokes are stripped from the speed input
- [x] Selecting a suggestion from the dropdown sets the speed value

🤖 Generated with [Claude Code](https://claude.com/claude-code)