### PR TITLE
feat: create a film roll from a stock (issue #12)

### DIFF
--- a/frollz-api/src/roll/roll.controller.ts
+++ b/frollz-api/src/roll/roll.controller.ts
@@ -17,6 +17,13 @@ export class RollController {
     return this.rollService.create(createRollDto);
   }
 
+  @Get('next-id')
+  @ApiOperation({ summary: 'Get the next roll ID' })
+  @ApiResponse({ status: 200, description: 'Next roll ID' })
+  getNextId(): Promise<string> {
+    return this.rollService.getNextId();
+  }
+
   @Get()
   @ApiOperation({ summary: 'Get all rolls' })
   @ApiResponse({ status: 200, description: 'Rolls retrieved successfully', type: [Roll] })

--- a/frollz-api/src/roll/roll.service.ts
+++ b/frollz-api/src/roll/roll.service.ts
@@ -39,6 +39,15 @@ export class RollService {
     return { ...roll, _key: result._key };
   }
 
+  async getNextId(): Promise<string> {
+    const cursor = await this.databaseService.query(`
+      RETURN LENGTH(rolls)
+    `);
+    const results = await cursor.all();
+    const count = results[0] as number;
+    return String(count + 1).padStart(5, '0');
+  }
+
   async findAll(): Promise<Roll[]> {
     const cursor = await this.databaseService.query(`
       FOR roll IN rolls

--- a/frollz-ui/src/services/api-client.ts
+++ b/frollz-ui/src/services/api-client.ts
@@ -59,9 +59,10 @@ export const stockTagApi = {
 export const rollApi = {
   getAll: () => api.get<Roll[]>('/rolls'),
   getById: (key: string) => api.get<Roll>(`/rolls/${key}`),
-  create: (data: Omit<Roll, '_key' | 'createdAt' | 'updatedAt'>) => 
+  getNextId: () => api.get<string>('/rolls/next-id'),
+  create: (data: Omit<Roll, '_key' | 'createdAt' | 'updatedAt'>) =>
     api.post<Roll>('/rolls', data),
-  update: (key: string, data: Partial<Roll>) => 
+  update: (key: string, data: Partial<Roll>) =>
     api.patch<Roll>(`/rolls/${key}`, data),
   delete: (key: string) => api.delete(`/rolls/${key}`),
 }

--- a/frollz-ui/src/views/RollsView.vue
+++ b/frollz-ui/src/views/RollsView.vue
@@ -2,7 +2,7 @@
   <div>
     <div class="flex justify-between items-center mb-8">
       <h1 class="text-3xl font-bold text-gray-900">Rolls</h1>
-      <button @click="showModal = true" class="bg-primary-600 text-white px-4 py-2 rounded-md hover:bg-primary-700 font-medium">
+      <button @click="openAddRoll()" class="bg-primary-600 text-white px-4 py-2 rounded-md hover:bg-primary-700 font-medium">
         Add Roll
       </button>
     </div>
@@ -77,6 +77,15 @@
         <h2 class="text-xl font-bold text-gray-900 mb-4">Add Roll</h2>
         <form @submit.prevent="handleSubmit">
           <div class="space-y-4">
+            <div>
+              <label class="block text-sm font-medium text-gray-700 mb-1">Roll ID <span class="text-red-500">*</span></label>
+              <input
+                v-model="form.rollId"
+                type="text"
+                required
+                class="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+              />
+            </div>
             <div>
               <label class="block text-sm font-medium text-gray-700 mb-1">Stock <span class="text-red-500">*</span></label>
               <select
@@ -172,9 +181,12 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
+import { useRoute } from 'vue-router'
 import { rollApi, stockApi } from '@/services/api-client'
 import type { Roll, Stock } from '@/types'
 import { RollState, ObtainmentMethod } from '@/types'
+
+const route = useRoute()
 
 const rolls = ref<Roll[]>([])
 const stocks = ref<Stock[]>([])
@@ -189,6 +201,7 @@ const obtainmentMethodOptions = Object.values(ObtainmentMethod)
 const today = new Date().toISOString().slice(0, 10)
 
 const emptyForm = () => ({
+  rollId: '',
   stockKey: '',
   state: RollState.SHELFED,
   dateObtained: today,
@@ -236,7 +249,7 @@ const handleSubmit = async () => {
   error.value = ''
   try {
     const payload: Omit<Roll, '_key' | 'createdAt' | 'updatedAt'> = {
-      rollId: '',
+      rollId: form.value.rollId,
       stockKey: form.value.stockKey,
       state: form.value.state,
       dateObtained: new Date(form.value.dateObtained),
@@ -275,8 +288,20 @@ const loadStocks = async () => {
   }
 }
 
-onMounted(() => {
-  loadRolls()
-  loadStocks()
+const openAddRoll = async (stockKey?: string) => {
+  const nextId = await rollApi.getNextId()
+  form.value.rollId = nextId.data
+  if (stockKey) {
+    form.value.stockKey = stockKey
+  }
+  showModal.value = true
+}
+
+onMounted(async () => {
+  await Promise.all([loadRolls(), loadStocks()])
+  const stockKey = route.query.stockKey as string | undefined
+  if (stockKey) {
+    await openAddRoll(stockKey)
+  }
 })
 </script>

--- a/frollz-ui/src/views/StocksView.vue
+++ b/frollz-ui/src/views/StocksView.vue
@@ -18,6 +18,7 @@
               <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Process</th>
               <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Speed</th>
               <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Tags</th>
+              <th class="px-6 py-3"></th>
             </tr>
           </thead>
           <tbody class="bg-white divide-y divide-gray-200">
@@ -42,6 +43,13 @@
                     {{ tag.value }}
                   </span>
                 </div>
+              </td>
+              <td class="px-6 py-4 whitespace-nowrap text-right">
+                <button
+                  @click="createRoll(stock._key!)"
+                  class="text-primary-600 hover:text-primary-800 font-bold text-lg leading-none"
+                  title="Add roll from this stock"
+                >+</button>
               </td>
             </tr>
           </tbody>
@@ -169,11 +177,14 @@
 
 <script setup lang="ts">
 import { ref, onMounted, computed, watch } from 'vue'
+import { useRouter } from 'vue-router'
 import { stockApi, filmFormatApi, tagApi, stockTagApi } from '@/services/api-client'
 import type { Stock, FilmFormat, Tag } from '@/types'
 import { Process, FormFactor } from '@/types'
 import TypeaheadInput from '@/components/TypeaheadInput.vue'
 import SpeedTypeaheadInput from '@/components/SpeedTypeaheadInput.vue'
+
+const router = useRouter()
 
 const stocks = ref<Stock[]>([])
 const formats = ref<FilmFormat[]>([])
@@ -227,6 +238,10 @@ const toggleTag = (tagKey: string) => {
   } else {
     selectedTagKeys.value.splice(idx, 1)
   }
+}
+
+const createRoll = (stockKey: string) => {
+  router.push({ name: 'rolls', query: { stockKey } })
 }
 
 const closeModal = () => {


### PR DESCRIPTION
## Summary

Implements [issue #12](https://github.com/joshholl/frollz/issues/12) — Create a Film Roll from a Stock.

- Every row on the Stocks page now has a **"+" button** that navigates to the Rolls page with that stock pre-selected
- The Add Roll form gains a **Roll ID field**, pre-populated with the next sequential ID (5-digit, zero-padded, e.g. `00001`)
- New `GET /api/rolls/next-id` endpoint returns `count + 1` left-padded to 5 digits
- Arriving at `/rolls?stockKey=<key>` automatically opens the Add Roll modal with the stock pre-selected and the next ID filled in

## Test plan

- [ ] Navigate to the Stocks page — confirm each row has a "+" button
- [ ] Click "+" on any stock — confirm the Rolls page opens with the Add Roll modal visible, the correct stock pre-selected, and a 5-digit roll ID pre-populated
- [ ] Confirm the Roll ID field is editable
- [ ] Submit the form and confirm the roll is created with the provided ID
- [ ] Click "Add Roll" directly from the Rolls page — confirm the modal opens with the next ID pre-populated and no stock pre-selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)