### PR TITLE
feat: film stock sorting (issue #13)

### DIFF
--- a/frollz-ui/src/views/StocksView.vue
+++ b/frollz-ui/src/views/StocksView.vue
@@ -12,11 +12,26 @@
         <table class="min-w-full">
           <thead class="bg-gray-50">
             <tr>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Brand</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Manufacturer</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Format</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Process</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Speed</th>
+              <th
+                @click="setSort('brand')"
+                :class="['px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none', sortField === 'brand' ? 'bg-gray-200' : '']"
+              >Brand {{ sortField === 'brand' ? (sortDirection === 'asc' ? '↑' : '↓') : '' }}</th>
+              <th
+                @click="setSort('manufacturer')"
+                :class="['px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none', sortField === 'manufacturer' ? 'bg-gray-200' : '']"
+              >Manufacturer {{ sortField === 'manufacturer' ? (sortDirection === 'asc' ? '↑' : '↓') : '' }}</th>
+              <th
+                @click="setSort('format')"
+                :class="['px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none', sortField === 'format' ? 'bg-gray-200' : '']"
+              >Format {{ sortField === 'format' ? (sortDirection === 'asc' ? '↑' : '↓') : '' }}</th>
+              <th
+                @click="setSort('process')"
+                :class="['px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none', sortField === 'process' ? 'bg-gray-200' : '']"
+              >Process {{ sortField === 'process' ? (sortDirection === 'asc' ? '↑' : '↓') : '' }}</th>
+              <th
+                @click="setSort('speed')"
+                :class="['px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none', sortField === 'speed' ? 'bg-gray-200' : '']"
+              >Speed {{ sortField === 'speed' ? (sortDirection === 'asc' ? '↑' : '↓') : '' }}</th>
               <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Tags</th>
               <th class="px-6 py-3"></th>
             </tr>
@@ -196,6 +211,19 @@ const submitting = ref(false)
 const error = ref('')
 const selectedTagKeys = ref<string[]>([])
 
+type SortField = 'brand' | 'manufacturer' | 'format' | 'process' | 'speed'
+const sortField = ref<SortField>('brand')
+const sortDirection = ref<'asc' | 'desc'>('asc')
+
+const setSort = (field: SortField) => {
+  if (sortField.value === field) {
+    sortDirection.value = sortDirection.value === 'asc' ? 'desc' : 'asc'
+  } else {
+    sortField.value = field
+    sortDirection.value = 'asc'
+  }
+}
+
 const processOptions = Object.values(Process)
 
 const emptyForm = () => ({
@@ -223,11 +251,15 @@ watch(() => form.value.process, () => {
 
 const sortedStocks = computed(() => {
   return stocks.value.slice().sort((a, b) => {
-    const brandA = a.brand.toLowerCase()
-    const brandB = b.brand.toLowerCase()
-    if (brandA < brandB) return -1
-    if (brandA > brandB) return 1
-    return 0
+    let result: number
+    if (sortField.value === 'speed') {
+      result = (a.speed ?? 0) - (b.speed ?? 0)
+    } else {
+      const aVal = (a[sortField.value] ?? '').toString().toLowerCase()
+      const bVal = (b[sortField.value] ?? '').toString().toLowerCase()
+      result = aVal.localeCompare(bVal)
+    }
+    return sortDirection.value === 'asc' ? result : -result
   })
 })
 

--- a/frollz-ui/src/views/__tests__/StocksView.spec.ts
+++ b/frollz-ui/src/views/__tests__/StocksView.spec.ts
@@ -175,6 +175,117 @@ describe('StocksView', () => {
     })
   })
 
+  describe('sorting', () => {
+    const multiStocks = [
+      { _key: 'stock-a', brand: 'Zebra Film', manufacturer: 'Alpha Corp', format: '35mm', process: Process.C_41, speed: 200 },
+      { _key: 'stock-b', brand: 'Alpha Film', manufacturer: 'Zebra Corp', format: '120', process: Process.E_6, speed: 400 },
+      { _key: 'stock-c', brand: 'Mango Film', manufacturer: 'Mango Corp', format: 'I-Type', process: Process.INSTANT, speed: 100 },
+    ]
+
+    beforeEach(() => {
+      vi.mocked(stockApi.getAll).mockResolvedValue({ data: multiStocks } as any)
+    })
+
+    it('should default sort by brand ascending', async () => {
+      const wrapper = mount(StocksView)
+      await flushPromises()
+
+      const vm = wrapper.vm as any
+      expect(vm.sortField).toBe('brand')
+      expect(vm.sortDirection).toBe('asc')
+      const brands = vm.sortedStocks.map((s: any) => s.brand)
+      expect(brands).toEqual(['Alpha Film', 'Mango Film', 'Zebra Film'])
+    })
+
+    it('should sort by a different field when setSort is called', async () => {
+      const wrapper = mount(StocksView)
+      await flushPromises()
+
+      const vm = wrapper.vm as any
+      vm.setSort('manufacturer')
+      await wrapper.vm.$nextTick()
+
+      expect(vm.sortField).toBe('manufacturer')
+      expect(vm.sortDirection).toBe('asc')
+      const manufacturers = vm.sortedStocks.map((s: any) => s.manufacturer)
+      expect(manufacturers).toEqual(['Alpha Corp', 'Mango Corp', 'Zebra Corp'])
+    })
+
+    it('should toggle sort direction when the same field is clicked again', async () => {
+      const wrapper = mount(StocksView)
+      await flushPromises()
+
+      const vm = wrapper.vm as any
+      vm.setSort('brand') // already brand/asc, should flip to desc
+      await wrapper.vm.$nextTick()
+
+      expect(vm.sortDirection).toBe('desc')
+      const brands = vm.sortedStocks.map((s: any) => s.brand)
+      expect(brands).toEqual(['Zebra Film', 'Mango Film', 'Alpha Film'])
+    })
+
+    it('should reset to ascending when switching to a new field', async () => {
+      const wrapper = mount(StocksView)
+      await flushPromises()
+
+      const vm = wrapper.vm as any
+      vm.setSort('brand') // flip to desc
+      vm.setSort('speed') // new field → should be asc
+      await wrapper.vm.$nextTick()
+
+      expect(vm.sortField).toBe('speed')
+      expect(vm.sortDirection).toBe('asc')
+      const speeds = vm.sortedStocks.map((s: any) => s.speed)
+      expect(speeds).toEqual([100, 200, 400])
+    })
+
+    it('should sort numerically by speed', async () => {
+      const wrapper = mount(StocksView)
+      await flushPromises()
+
+      const vm = wrapper.vm as any
+      vm.setSort('speed')
+      await wrapper.vm.$nextTick()
+
+      const speeds = vm.sortedStocks.map((s: any) => s.speed)
+      expect(speeds).toEqual([100, 200, 400])
+
+      vm.setSort('speed') // desc
+      await wrapper.vm.$nextTick()
+      expect(vm.sortedStocks.map((s: any) => s.speed)).toEqual([400, 200, 100])
+    })
+
+    it('should apply darker background class to active sort column header', async () => {
+      const wrapper = mount(StocksView)
+      await flushPromises()
+
+      const vm = wrapper.vm as any
+      vm.setSort('manufacturer')
+      await wrapper.vm.$nextTick()
+
+      const headers = wrapper.findAll('th')
+      const manufacturerHeader = headers[1]
+      expect(manufacturerHeader.classes()).toContain('bg-gray-200')
+      expect(headers[0].classes()).not.toContain('bg-gray-200')
+    })
+
+    it('should show sort direction indicator on active column header', async () => {
+      const wrapper = mount(StocksView)
+      await flushPromises()
+
+      // Default: brand asc
+      const headers = wrapper.findAll('th')
+      expect(headers[0].text()).toContain('↑')
+      expect(headers[1].text()).not.toMatch(/[↑↓]/)
+
+      const vm = wrapper.vm as any
+      vm.setSort('brand') // flip to desc
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.findAll('th')[0].text()).toContain('↓')
+    })
+  })
+
   describe('multiple format creation', () => {
     it('should call API with multiple format keys', async () => {
       const mockCreatedStocks = [


### PR DESCRIPTION
## Summary
- Clicking any column header (Brand, Manufacturer, Format, Process, Speed) sorts stocks by that field
- Active sort column header gets `bg-gray-200` background (darker shade)
- Sort direction indicator (↑ / ↓) displayed next to the active column name
- Clicking the same column again toggles asc/desc; clicking a new column resets to asc
- Only one field sorted at a time; Tags column is not sortable

## Test plan
- [x] All 38 existing and new unit tests pass
- [x] New sorting tests cover: default sort, field switching, direction toggle, numeric speed sort, header background class, direction indicator

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)