### PR TITLE
feat: mark film as loaded (issue #21)

### DIFF
--- a/frollz-api/src/roll/dto/create-roll.dto.ts
+++ b/frollz-api/src/roll/dto/create-roll.dto.ts
@@ -45,4 +45,9 @@ export class CreateRollDto {
   @ApiProperty({ default: 0 })
   @IsNumber()
   timesExposedToXrays: number;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsString()
+  loadedInto?: string;
 }

--- a/frollz-api/src/roll/entities/roll.entity.ts
+++ b/frollz-api/src/roll/entities/roll.entity.ts
@@ -3,7 +3,7 @@ import { ApiProperty } from '@nestjs/swagger';
 export enum RollState {
   FROZEN = 'Frozen',
   REFRIGERATED = 'Refrigerated',
-  SHELFED = 'Shelfed',
+  SHELFED = 'Shelved',
   LOADED = 'Loaded',
   FINISHED = 'Finished',
   DEVELOPED = 'Developed',
@@ -44,6 +44,9 @@ export class Roll {
 
   @ApiProperty({ default: 0 })
   timesExposedToXrays: number;
+
+  @ApiProperty({ required: false })
+  loadedInto?: string;
 
   @ApiProperty({ required: false })
   createdAt?: Date;

--- a/frollz-ui/src/types/index.ts
+++ b/frollz-ui/src/types/index.ts
@@ -73,7 +73,7 @@ export interface StockTag {
 export enum RollState {
   FROZEN = 'Frozen',
   REFRIGERATED = 'Refrigerated',
-  SHELFED = 'Shelfed',
+  SHELFED = 'Shelved',
   LOADED = 'Loaded',
   FINISHED = 'Finished',
   DEVELOPED = 'Developed',
@@ -95,6 +95,7 @@ export interface Roll {
   obtainedFrom: string
   expirationDate?: Date
   timesExposedToXrays: number
+  loadedInto?: string
   createdAt?: Date
   updatedAt?: Date
 }

--- a/frollz-ui/src/views/RollsView.vue
+++ b/frollz-ui/src/views/RollsView.vue
@@ -13,7 +13,7 @@
           <option value="">All States</option>
           <option value="Frozen">Frozen</option>
           <option value="Refrigerated">Refrigerated</option>
-          <option value="Shelfed">Shelfed</option>
+          <option value="Shelved">Shelved</option>
           <option value="Loaded">Loaded</option>
           <option value="Finished">Finished</option>
           <option value="Developed">Developed</option>
@@ -41,6 +41,7 @@
               <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                 X-Ray Exposures
               </th>
+              <th class="px-6 py-3"></th>
             </tr>
           </thead>
           <tbody class="bg-white divide-y divide-gray-200">
@@ -65,9 +66,50 @@
               <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                 {{ roll.timesExposedToXrays }}
               </td>
+              <td class="px-6 py-4 whitespace-nowrap text-right">
+                <button
+                  v-if="canLoad(roll.state)"
+                  @click="openLoadModal(roll)"
+                  class="px-3 py-1 text-xs font-medium text-yellow-700 border border-yellow-400 rounded hover:bg-yellow-50"
+                >Load</button>
+              </td>
             </tr>
           </tbody>
         </table>
+      </div>
+    </div>
+
+    <!-- Load Roll Modal -->
+    <div v-if="loadTarget" class="fixed inset-0 bg-gray-500 bg-opacity-75 flex items-center justify-center z-50">
+      <div class="bg-white rounded-lg shadow-xl p-6 w-full max-w-md">
+        <h2 class="text-xl font-bold text-gray-900 mb-4">Load Roll</h2>
+        <form @submit.prevent="handleLoad">
+          <div>
+            <label class="block text-sm font-medium text-gray-700 mb-1">
+              What will this roll be loaded into? <span class="text-red-500">*</span>
+            </label>
+            <input
+              v-model="loadedInto"
+              type="text"
+              required
+              placeholder="e.g. Nikon F3"
+              class="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+            />
+          </div>
+          <div v-if="loadError" class="mt-3 text-sm text-red-600">{{ loadError }}</div>
+          <div class="flex justify-end gap-3 mt-6">
+            <button
+              type="button"
+              @click="closeLoadModal"
+              class="px-4 py-2 border border-gray-300 rounded-md text-sm text-gray-700 hover:bg-gray-50"
+            >Cancel</button>
+            <button
+              type="submit"
+              :disabled="loadSubmitting"
+              class="px-4 py-2 bg-yellow-600 text-white rounded-md text-sm hover:bg-yellow-700 disabled:opacity-50"
+            >{{ loadSubmitting ? 'Loading...' : 'Load' }}</button>
+          </div>
+        </form>
       </div>
     </div>
 
@@ -226,11 +268,48 @@ const formatDate = (date: Date | string) => {
   return new Date(date as string).toLocaleDateString()
 }
 
+const LOADABLE_STATES = new Set([RollState.FROZEN, RollState.REFRIGERATED, RollState.SHELFED])
+
+const canLoad = (state: RollState) => LOADABLE_STATES.has(state)
+
+const loadTarget = ref<Roll | null>(null)
+const loadedInto = ref('')
+const loadSubmitting = ref(false)
+const loadError = ref('')
+
+const openLoadModal = (roll: Roll) => {
+  loadTarget.value = roll
+  loadedInto.value = ''
+  loadError.value = ''
+}
+
+const closeLoadModal = () => {
+  loadTarget.value = null
+}
+
+const handleLoad = async () => {
+  if (!loadTarget.value) return
+  loadSubmitting.value = true
+  loadError.value = ''
+  try {
+    await rollApi.update(loadTarget.value._key!, {
+      state: RollState.LOADED,
+      loadedInto: loadedInto.value,
+    })
+    closeLoadModal()
+    await loadRolls()
+  } catch (e) {
+    loadError.value = 'Failed to load roll. Please try again.'
+  } finally {
+    loadSubmitting.value = false
+  }
+}
+
 const getStateColor = (state: RollState) => {
   const colors: Record<string, string> = {
     Frozen: 'bg-blue-100 text-blue-800',
     Refrigerated: 'bg-cyan-100 text-cyan-800',
-    Shelfed: 'bg-gray-100 text-gray-800',
+    Shelved: 'bg-gray-100 text-gray-800',
     Loaded: 'bg-yellow-100 text-yellow-800',
     Finished: 'bg-green-100 text-green-800',
     Developed: 'bg-purple-100 text-purple-800',

--- a/frollz-ui/src/views/__tests__/RollsView.spec.ts
+++ b/frollz-ui/src/views/__tests__/RollsView.spec.ts
@@ -1,0 +1,158 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createRouter, createMemoryHistory } from 'vue-router'
+import RollsView from '@/views/RollsView.vue'
+import { rollApi, stockApi } from '@/services/api-client'
+import { RollState, ObtainmentMethod } from '@/types'
+
+vi.mock('@/services/api-client', () => ({
+  rollApi: {
+    getAll: vi.fn(),
+    getNextId: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+  },
+  stockApi: {
+    getAll: vi.fn(),
+  },
+}))
+
+const router = createRouter({ history: createMemoryHistory(), routes: [{ path: '/', component: RollsView }] })
+
+const makeRoll = (key: string, state: RollState) => ({
+  _key: key,
+  rollId: `roll-${key}`,
+  stockKey: 'stock1',
+  state,
+  dateObtained: new Date('2024-01-01'),
+  obtainmentMethod: ObtainmentMethod.PURCHASE,
+  obtainedFrom: 'B&H',
+  timesExposedToXrays: 0,
+})
+
+describe('RollsView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(rollApi.getAll).mockResolvedValue({ data: [] } as any)
+    vi.mocked(rollApi.getNextId).mockResolvedValue({ data: '00001' } as any)
+    vi.mocked(stockApi.getAll).mockResolvedValue({ data: [] } as any)
+  })
+
+  describe('shelved spelling', () => {
+    it('should display "Shelved" state correctly', async () => {
+      vi.mocked(rollApi.getAll).mockResolvedValue({
+        data: [makeRoll('r1', RollState.SHELFED)],
+      } as any)
+
+      const wrapper = mount(RollsView, { global: { plugins: [router] } })
+      await flushPromises()
+
+      expect(wrapper.text()).toContain('Shelved')
+      expect(wrapper.text()).not.toContain('Shelfed')
+    })
+
+    it('should use "Shelved" in the filter dropdown', async () => {
+      const wrapper = mount(RollsView, { global: { plugins: [router] } })
+      await flushPromises()
+
+      const options = wrapper.findAll('option')
+      const labels = options.map(o => o.text())
+      expect(labels).toContain('Shelved')
+      expect(labels).not.toContain('Shelfed')
+    })
+  })
+
+  describe('canLoad', () => {
+    it.each([RollState.FROZEN, RollState.REFRIGERATED, RollState.SHELFED])(
+      'should show Load button for %s state',
+      async (state) => {
+        vi.mocked(rollApi.getAll).mockResolvedValue({ data: [makeRoll('r1', state)] } as any)
+
+        const wrapper = mount(RollsView, { global: { plugins: [router] } })
+        await flushPromises()
+
+        expect(wrapper.text()).toContain('Load')
+      }
+    )
+
+    it.each([RollState.LOADED, RollState.FINISHED, RollState.DEVELOPED])(
+      'should not show Load button for %s state',
+      async (state) => {
+        vi.mocked(rollApi.getAll).mockResolvedValue({ data: [makeRoll('r1', state)] } as any)
+
+        const wrapper = mount(RollsView, { global: { plugins: [router] } })
+        await flushPromises()
+
+        const loadButtons = wrapper.findAll('button').filter(b => b.text() === 'Load')
+        expect(loadButtons).toHaveLength(0)
+      }
+    )
+  })
+
+  describe('load modal', () => {
+    it('should open load modal when Load button is clicked', async () => {
+      vi.mocked(rollApi.getAll).mockResolvedValue({
+        data: [makeRoll('r1', RollState.SHELFED)],
+      } as any)
+
+      const wrapper = mount(RollsView, { global: { plugins: [router] } })
+      await flushPromises()
+
+      const vm = wrapper.vm as any
+      vm.openLoadModal(makeRoll('r1', RollState.SHELFED))
+      await wrapper.vm.$nextTick()
+
+      expect(vm.loadTarget).not.toBeNull()
+      expect(wrapper.text()).toContain('What will this roll be loaded into?')
+    })
+
+    it('should close load modal on cancel', async () => {
+      const wrapper = mount(RollsView, { global: { plugins: [router] } })
+      await flushPromises()
+
+      const vm = wrapper.vm as any
+      vm.openLoadModal(makeRoll('r1', RollState.SHELFED))
+      vm.closeLoadModal()
+      await wrapper.vm.$nextTick()
+
+      expect(vm.loadTarget).toBeNull()
+    })
+
+    it('should call rollApi.update with Loaded state and loadedInto on submit', async () => {
+      vi.mocked(rollApi.update).mockResolvedValue({ data: {} } as any)
+
+      const wrapper = mount(RollsView, { global: { plugins: [router] } })
+      await flushPromises()
+
+      const vm = wrapper.vm as any
+      vm.openLoadModal(makeRoll('r1', RollState.SHELFED))
+      vm.loadedInto = 'Nikon F3'
+
+      await vm.handleLoad()
+      await flushPromises()
+
+      expect(rollApi.update).toHaveBeenCalledWith('r1', {
+        state: RollState.LOADED,
+        loadedInto: 'Nikon F3',
+      })
+    })
+
+    it('should close modal and reload rolls after successful load', async () => {
+      vi.mocked(rollApi.update).mockResolvedValue({ data: {} } as any)
+
+      const wrapper = mount(RollsView, { global: { plugins: [router] } })
+      await flushPromises()
+
+      const vm = wrapper.vm as any
+      vm.openLoadModal(makeRoll('r1', RollState.SHELFED))
+      vm.loadedInto = 'Nikon F3'
+
+      await vm.handleLoad()
+      await flushPromises()
+
+      expect(vm.loadTarget).toBeNull()
+      expect(rollApi.getAll).toHaveBeenCalledTimes(2)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- **Fix typo**: "Shelfed" → "Shelved" throughout backend entity, frontend types, filter dropdown, and state colour map
- **New `loadedInto` field** added to `Roll` entity and `CreateRollDto` (optional string)
- **Load button** appears on any roll currently in Frozen, Refrigerated, or Shelved state; hidden for Loaded, Finished, and Developed
- **Load modal** prompts "What will this roll be loaded into?" (required); on confirm calls `PATCH /rolls/:key` with `{ state: 'Loaded', loadedInto: '...' }`

## Test plan
- [x] 78 frontend tests pass (12 new RollsView tests)
- [x] 87 backend tests pass
- [x] Tests cover: Shelved spelling in display and filter, Load button visibility for all 6 states, modal open/close, API call payload, post-load reload

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)