### PR TITLE
feat: sortable columns for film rolls (issue #23)

### DIFF
--- a/frollz-ui/src/views/RollsView.vue
+++ b/frollz-ui/src/views/RollsView.vue
@@ -26,21 +26,26 @@
         <table class="min-w-full">
           <thead class="bg-gray-50">
             <tr>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                Roll ID
-              </th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                State
-              </th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                Date Obtained
-              </th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                Obtained From
-              </th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                X-Ray Exposures
-              </th>
+              <th
+                @click="setSort('rollId')"
+                :class="['px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none', sortField === 'rollId' ? 'bg-gray-200' : '']"
+              >Roll ID {{ sortField === 'rollId' ? (sortDirection === 'asc' ? '↑' : '↓') : '' }}</th>
+              <th
+                @click="setSort('state')"
+                :class="['px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none', sortField === 'state' ? 'bg-gray-200' : '']"
+              >State {{ sortField === 'state' ? (sortDirection === 'asc' ? '↑' : '↓') : '' }}</th>
+              <th
+                @click="setSort('dateObtained')"
+                :class="['px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none', sortField === 'dateObtained' ? 'bg-gray-200' : '']"
+              >Date Obtained {{ sortField === 'dateObtained' ? (sortDirection === 'asc' ? '↑' : '↓') : '' }}</th>
+              <th
+                @click="setSort('obtainedFrom')"
+                :class="['px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none', sortField === 'obtainedFrom' ? 'bg-gray-200' : '']"
+              >Obtained From {{ sortField === 'obtainedFrom' ? (sortDirection === 'asc' ? '↑' : '↓') : '' }}</th>
+              <th
+                @click="setSort('timesExposedToXrays')"
+                :class="['px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer select-none', sortField === 'timesExposedToXrays' ? 'bg-gray-200' : '']"
+              >X-Ray Exposures {{ sortField === 'timesExposedToXrays' ? (sortDirection === 'asc' ? '↑' : '↓') : '' }}</th>
               <th class="px-6 py-3"></th>
             </tr>
           </thead>
@@ -240,6 +245,19 @@ const error = ref('')
 const rollStateOptions = Object.values(RollState)
 const obtainmentMethodOptions = Object.values(ObtainmentMethod)
 
+type SortField = 'rollId' | 'state' | 'dateObtained' | 'obtainedFrom' | 'timesExposedToXrays'
+const sortField = ref<SortField>('rollId')
+const sortDirection = ref<'asc' | 'desc'>('asc')
+
+const setSort = (field: SortField) => {
+  if (sortField.value === field) {
+    sortDirection.value = sortDirection.value === 'asc' ? 'desc' : 'asc'
+  } else {
+    sortField.value = field
+    sortDirection.value = 'asc'
+  }
+}
+
 const today = new Date().toISOString().slice(0, 10)
 
 const emptyForm = () => ({
@@ -256,8 +274,23 @@ const emptyForm = () => ({
 const form = ref(emptyForm())
 
 const filteredRolls = computed(() => {
-  if (!filterState.value) return rolls.value
-  return rolls.value.filter(roll => roll.state === filterState.value)
+  const base = filterState.value
+    ? rolls.value.filter(roll => roll.state === filterState.value)
+    : rolls.value
+
+  return base.slice().sort((a, b) => {
+    let cmp: number
+    if (sortField.value === 'timesExposedToXrays') {
+      cmp = a.timesExposedToXrays - b.timesExposedToXrays
+    } else if (sortField.value === 'dateObtained') {
+      cmp = new Date(a.dateObtained as string).getTime() - new Date(b.dateObtained as string).getTime()
+    } else {
+      const aVal = (a[sortField.value] ?? '').toString().toLowerCase()
+      const bVal = (b[sortField.value] ?? '').toString().toLowerCase()
+      cmp = aVal.localeCompare(bVal)
+    }
+    return sortDirection.value === 'asc' ? cmp : -cmp
+  })
 })
 
 const sortedStocks = computed(() => {

--- a/frollz-ui/src/views/__tests__/RollsView.spec.ts
+++ b/frollz-ui/src/views/__tests__/RollsView.spec.ts
@@ -20,7 +20,7 @@ vi.mock('@/services/api-client', () => ({
 
 const router = createRouter({ history: createMemoryHistory(), routes: [{ path: '/', component: RollsView }] })
 
-const makeRoll = (key: string, state: RollState) => ({
+const makeRoll = (key: string, state: RollState, overrides: Record<string, any> = {}) => ({
   _key: key,
   rollId: `roll-${key}`,
   stockKey: 'stock1',
@@ -29,6 +29,7 @@ const makeRoll = (key: string, state: RollState) => ({
   obtainmentMethod: ObtainmentMethod.PURCHASE,
   obtainedFrom: 'B&H',
   timesExposedToXrays: 0,
+  ...overrides,
 })
 
 describe('RollsView', () => {
@@ -88,6 +89,127 @@ describe('RollsView', () => {
         expect(loadButtons).toHaveLength(0)
       }
     )
+  })
+
+  describe('sorting', () => {
+    const multiRolls = [
+      makeRoll('c', RollState.SHELFED, { rollId: 'roll-c', obtainedFrom: 'Amazon', dateObtained: new Date('2024-03-01'), timesExposedToXrays: 3 }),
+      makeRoll('a', RollState.FROZEN,  { rollId: 'roll-a', obtainedFrom: 'B&H',    dateObtained: new Date('2024-01-01'), timesExposedToXrays: 0 }),
+      makeRoll('b', RollState.LOADED,  { rollId: 'roll-b', obtainedFrom: 'Moment', dateObtained: new Date('2024-02-01'), timesExposedToXrays: 1 }),
+    ]
+
+    beforeEach(() => {
+      vi.mocked(rollApi.getAll).mockResolvedValue({ data: multiRolls } as any)
+    })
+
+    it('should default sort by rollId ascending', async () => {
+      const wrapper = mount(RollsView, { global: { plugins: [router] } })
+      await flushPromises()
+
+      const vm = wrapper.vm as any
+      expect(vm.sortField).toBe('rollId')
+      expect(vm.sortDirection).toBe('asc')
+      expect(vm.filteredRolls.map((r: any) => r.rollId)).toEqual(['roll-a', 'roll-b', 'roll-c'])
+    })
+
+    it('should sort by a different field when setSort is called', async () => {
+      const wrapper = mount(RollsView, { global: { plugins: [router] } })
+      await flushPromises()
+
+      const vm = wrapper.vm as any
+      vm.setSort('obtainedFrom')
+      await wrapper.vm.$nextTick()
+
+      expect(vm.sortField).toBe('obtainedFrom')
+      expect(vm.sortDirection).toBe('asc')
+      expect(vm.filteredRolls.map((r: any) => r.obtainedFrom)).toEqual(['Amazon', 'B&H', 'Moment'])
+    })
+
+    it('should toggle sort direction when the same field is clicked again', async () => {
+      const wrapper = mount(RollsView, { global: { plugins: [router] } })
+      await flushPromises()
+
+      const vm = wrapper.vm as any
+      vm.setSort('rollId') // already rollId/asc → flip to desc
+      await wrapper.vm.$nextTick()
+
+      expect(vm.sortDirection).toBe('desc')
+      expect(vm.filteredRolls.map((r: any) => r.rollId)).toEqual(['roll-c', 'roll-b', 'roll-a'])
+    })
+
+    it('should reset to ascending when switching to a new field', async () => {
+      const wrapper = mount(RollsView, { global: { plugins: [router] } })
+      await flushPromises()
+
+      const vm = wrapper.vm as any
+      vm.setSort('rollId') // flip to desc
+      vm.setSort('obtainedFrom') // new field → asc
+      await wrapper.vm.$nextTick()
+
+      expect(vm.sortField).toBe('obtainedFrom')
+      expect(vm.sortDirection).toBe('asc')
+    })
+
+    it('should sort numerically by timesExposedToXrays', async () => {
+      const wrapper = mount(RollsView, { global: { plugins: [router] } })
+      await flushPromises()
+
+      const vm = wrapper.vm as any
+      vm.setSort('timesExposedToXrays')
+      await wrapper.vm.$nextTick()
+
+      expect(vm.filteredRolls.map((r: any) => r.timesExposedToXrays)).toEqual([0, 1, 3])
+
+      vm.setSort('timesExposedToXrays') // desc
+      await wrapper.vm.$nextTick()
+      expect(vm.filteredRolls.map((r: any) => r.timesExposedToXrays)).toEqual([3, 1, 0])
+    })
+
+    it('should sort chronologically by dateObtained', async () => {
+      const wrapper = mount(RollsView, { global: { plugins: [router] } })
+      await flushPromises()
+
+      const vm = wrapper.vm as any
+      vm.setSort('dateObtained')
+      await wrapper.vm.$nextTick()
+
+      // Compare timestamps to avoid timezone-dependent string formatting
+      const timestamps = vm.filteredRolls.map((r: any) => new Date(r.dateObtained).getTime())
+      expect(timestamps).toEqual([...timestamps].sort((a: number, b: number) => a - b))
+
+      vm.setSort('dateObtained') // desc
+      await wrapper.vm.$nextTick()
+      const timestampsDesc = vm.filteredRolls.map((r: any) => new Date(r.dateObtained).getTime())
+      expect(timestampsDesc).toEqual([...timestampsDesc].sort((a: number, b: number) => b - a))
+    })
+
+    it('should apply darker background on the active sort column header', async () => {
+      const wrapper = mount(RollsView, { global: { plugins: [router] } })
+      await flushPromises()
+
+      const vm = wrapper.vm as any
+      vm.setSort('state')
+      await wrapper.vm.$nextTick()
+
+      const headers = wrapper.findAll('th')
+      expect(headers[1].classes()).toContain('bg-gray-200')
+      expect(headers[0].classes()).not.toContain('bg-gray-200')
+    })
+
+    it('should show sort direction indicator next to the active column', async () => {
+      const wrapper = mount(RollsView, { global: { plugins: [router] } })
+      await flushPromises()
+
+      // Default: rollId asc
+      expect(wrapper.findAll('th')[0].text()).toContain('↑')
+      expect(wrapper.findAll('th')[1].text()).not.toMatch(/[↑↓]/)
+
+      const vm = wrapper.vm as any
+      vm.setSort('rollId') // flip to desc
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.findAll('th')[0].text()).toContain('↓')
+    })
   })
 
   describe('load modal', () => {


### PR DESCRIPTION
## Summary
- All five visible columns are now sortable: Roll ID, State, Date Obtained, Obtained From, X-Ray Exposures
- Active sort column header gets `bg-gray-200` background
- ↑ / ↓ indicator displayed next to the active column name
- Clicking the same column toggles asc/desc; clicking a new column resets to asc
- Only one field sorted at a time
- String fields use `localeCompare`; dates compare timestamps; X-Ray Exposures compares numerically

## Test plan
- [x] All 86 tests pass (8 new sorting tests added to RollsView.spec.ts)
- [x] Tests cover: default sort, field switching, direction toggle, numeric sort, date sort, header background class, direction indicator

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)