### PR TITLE
feat(#34): roll usage lifecycle — Load, Finished, History

### DIFF
--- a/frollz-api/.eslintrc.js
+++ b/frollz-api/.eslintrc.js
@@ -1,0 +1,25 @@
+module.exports = {
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: 'tsconfig.json',
+    tsconfigRootDir: __dirname,
+    sourceType: 'module',
+  },
+  plugins: ['@typescript-eslint/eslint-plugin'],
+  extends: [
+    'plugin:@typescript-eslint/recommended',
+    'plugin:prettier/recommended',
+  ],
+  root: true,
+  env: {
+    node: true,
+    jest: true,
+  },
+  ignorePatterns: ['.eslintrc.js'],
+  rules: {
+    '@typescript-eslint/interface-name-prefix': 'off',
+    '@typescript-eslint/explicit-function-return-type': 'off',
+    '@typescript-eslint/explicit-module-boundary-types': 'off',
+    '@typescript-eslint/no-explicit-any': 'off',
+  },
+};

--- a/frollz-api/package-lock.json
+++ b/frollz-api/package-lock.json
@@ -75,6 +75,23 @@
         }
       }
     },
+    "node_modules/@angular-devkit/core/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/@angular-devkit/core/node_modules/ajv-formats": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
@@ -220,6 +237,23 @@
         "@types/node": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@angular-devkit/schematics-cli/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/@angular-devkit/schematics-cli/node_modules/ajv-formats": {
@@ -873,6 +907,30 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@eslint/js": {
       "version": "8.57.1",
@@ -1548,53 +1606,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@jest/console/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@jest/console/node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/console/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/@jest/core": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
@@ -1656,33 +1667,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/@jest/core/node_modules/@jest/transform": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
-      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.11.6",
-        "@jest/types": "^29.6.3",
-        "@jridgewell/trace-mapping": "^0.3.18",
-        "babel-plugin-istanbul": "^6.1.1",
-        "chalk": "^4.0.0",
-        "convert-source-map": "^2.0.0",
-        "fast-json-stable-stringify": "^2.1.0",
-        "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.7.0",
-        "jest-regex-util": "^29.6.3",
-        "jest-util": "^29.7.0",
-        "micromatch": "^4.0.4",
-        "pirates": "^4.0.4",
-        "slash": "^3.0.0",
-        "write-file-atomic": "^4.0.2"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/@jest/core/node_modules/@jest/types": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
@@ -1708,82 +1692,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@jest/core/node_modules/babel-plugin-istanbul": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
-      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@istanbuljs/load-nyc-config": "^1.0.0",
-        "@istanbuljs/schema": "^0.1.2",
-        "istanbul-lib-instrument": "^5.0.4",
-        "test-exclude": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@jest/core/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@jest/core/node_modules/istanbul-lib-instrument": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
-      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@babel/core": "^7.12.3",
-        "@babel/parser": "^7.14.7",
-        "@istanbuljs/schema": "^0.1.2",
-        "istanbul-lib-coverage": "^3.2.0",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@jest/core/node_modules/jest-haste-map": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
-      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/graceful-fs": "^4.1.3",
-        "@types/node": "*",
-        "anymatch": "^3.0.3",
-        "fb-watchman": "^2.0.0",
-        "graceful-fs": "^4.2.9",
-        "jest-regex-util": "^29.6.3",
-        "jest-util": "^29.7.0",
-        "jest-worker": "^29.7.0",
-        "micromatch": "^4.0.4",
-        "walker": "^1.0.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "^2.3.2"
-      }
-    },
     "node_modules/@jest/core/node_modules/jest-regex-util": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
@@ -1792,100 +1700,6 @@
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/core/node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/core/node_modules/jest-worker": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
-      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "jest-util": "^29.7.0",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^8.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/core/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/@jest/core/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@jest/core/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/@jest/core/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/@jest/core/node_modules/write-file-atomic": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
-      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.7"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/@jest/environment": {
@@ -2025,53 +1839,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@jest/fake-timers/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@jest/fake-timers/node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/fake-timers/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/@jest/globals": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
@@ -2199,33 +1966,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/@jest/reporters/node_modules/@jest/transform": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
-      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.11.6",
-        "@jest/types": "^29.6.3",
-        "@jridgewell/trace-mapping": "^0.3.18",
-        "babel-plugin-istanbul": "^6.1.1",
-        "chalk": "^4.0.0",
-        "convert-source-map": "^2.0.0",
-        "fast-json-stable-stringify": "^2.1.0",
-        "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.7.0",
-        "jest-regex-util": "^29.6.3",
-        "jest-util": "^29.7.0",
-        "micromatch": "^4.0.4",
-        "pirates": "^4.0.4",
-        "slash": "^3.0.0",
-        "write-file-atomic": "^4.0.2"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/@jest/reporters/node_modules/@jest/types": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
@@ -2250,186 +1990,6 @@
       "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@jest/reporters/node_modules/babel-plugin-istanbul": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
-      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@istanbuljs/load-nyc-config": "^1.0.0",
-        "@istanbuljs/schema": "^0.1.2",
-        "istanbul-lib-instrument": "^5.0.4",
-        "test-exclude": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@jest/reporters/node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
-      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@babel/core": "^7.12.3",
-        "@babel/parser": "^7.14.7",
-        "@istanbuljs/schema": "^0.1.2",
-        "istanbul-lib-coverage": "^3.2.0",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@jest/reporters/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@jest/reporters/node_modules/jest-haste-map": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
-      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/graceful-fs": "^4.1.3",
-        "@types/node": "*",
-        "anymatch": "^3.0.3",
-        "fb-watchman": "^2.0.0",
-        "graceful-fs": "^4.2.9",
-        "jest-regex-util": "^29.6.3",
-        "jest-util": "^29.7.0",
-        "jest-worker": "^29.7.0",
-        "micromatch": "^4.0.4",
-        "walker": "^1.0.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "^2.3.2"
-      }
-    },
-    "node_modules/@jest/reporters/node_modules/jest-regex-util": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
-      "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/reporters/node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/reporters/node_modules/jest-worker": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
-      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "jest-util": "^29.7.0",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^8.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/reporters/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/@jest/reporters/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/@jest/reporters/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/@jest/reporters/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/@jest/reporters/node_modules/write-file-atomic": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
-      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.7"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
     },
     "node_modules/@jest/schemas": {
       "version": "30.0.5",
@@ -2531,7 +2091,34 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/@jest/test-sequencer/node_modules/@jest/schemas": {
+    "node_modules/@jest/transform": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "babel-plugin-istanbul": "^6.1.1",
+        "chalk": "^4.0.0",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pirates": "^4.0.4",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^4.0.2"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/transform/node_modules/@jest/schemas": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
       "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
@@ -2544,7 +2131,7 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/@jest/test-sequencer/node_modules/@jest/types": {
+    "node_modules/@jest/transform/node_modules/@jest/types": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
       "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
@@ -2562,56 +2149,14 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/@jest/test-sequencer/node_modules/@sinclair/typebox": {
+    "node_modules/@jest/transform/node_modules/@sinclair/typebox": {
       "version": "0.27.10",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
       "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@jest/test-sequencer/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@jest/test-sequencer/node_modules/jest-haste-map": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
-      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/graceful-fs": "^4.1.3",
-        "@types/node": "*",
-        "anymatch": "^3.0.3",
-        "fb-watchman": "^2.0.0",
-        "graceful-fs": "^4.2.9",
-        "jest-regex-util": "^29.6.3",
-        "jest-util": "^29.7.0",
-        "jest-worker": "^29.7.0",
-        "micromatch": "^4.0.4",
-        "walker": "^1.0.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "^2.3.2"
-      }
-    },
-    "node_modules/@jest/test-sequencer/node_modules/jest-regex-util": {
+    "node_modules/@jest/transform/node_modules/jest-regex-util": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
       "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
@@ -2619,97 +2164,6 @@
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/test-sequencer/node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/test-sequencer/node_modules/jest-worker": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
-      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "jest-util": "^29.7.0",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^8.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@jest/test-sequencer/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/@jest/test-sequencer/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/@jest/transform": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.3.0.tgz",
-      "integrity": "sha512-TLKY33fSLVd/lKB2YI1pH69ijyUblO/BQvCj566YvnwuzoTNr648iE0j22vRvVNk2HsPwByPxATg3MleS3gf5A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/core": "^7.27.4",
-        "@jest/types": "30.3.0",
-        "@jridgewell/trace-mapping": "^0.3.25",
-        "babel-plugin-istanbul": "^7.0.1",
-        "chalk": "^4.1.2",
-        "convert-source-map": "^2.0.0",
-        "fast-json-stable-stringify": "^2.1.0",
-        "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.3.0",
-        "jest-regex-util": "30.0.1",
-        "jest-util": "30.3.0",
-        "pirates": "^4.0.7",
-        "slash": "^3.0.0",
-        "write-file-atomic": "^5.0.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/types": {
@@ -2899,6 +2353,23 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0",
         "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
         "yarn": ">= 1.13.0"
+      }
+    },
+    "node_modules/@nestjs/cli/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/@nestjs/cli/node_modules/ajv-formats": {
@@ -3144,6 +2615,24 @@
         "class-validator": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/common/node_modules/file-type": {
+      "version": "21.3.2",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.2.tgz",
+      "integrity": "sha512-DLkUvGwep3poOV2wpzbHCOnSKGk1LzyXTv+aHFgN2VFl96wnp8YA9YjO2qPzg5PuL8q/SW9Pdi6WTkYOIh995w==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
     "node_modules/@nestjs/config": {
@@ -4254,6 +3743,18 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -4548,64 +4049,85 @@
       "license": "MIT"
     },
     "node_modules/babel-jest": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-30.3.0.tgz",
-      "integrity": "sha512-gRpauEU2KRrCox5Z296aeVHR4jQ98BCnu0IO332D/xpHNOsIH/bgSRk9k6GbKIbBw8vFeN6ctuu6tV8WOyVfYQ==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+      "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "@jest/transform": "30.3.0",
-        "@types/babel__core": "^7.20.5",
-        "babel-plugin-istanbul": "^7.0.1",
-        "babel-preset-jest": "30.3.0",
-        "chalk": "^4.1.2",
-        "graceful-fs": "^4.2.11",
+        "@jest/transform": "^29.7.0",
+        "@types/babel__core": "^7.1.14",
+        "babel-plugin-istanbul": "^6.1.1",
+        "babel-preset-jest": "^29.6.3",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
         "slash": "^3.0.0"
       },
       "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.11.0 || ^8.0.0-0"
+        "@babel/core": "^7.8.0"
       }
     },
     "node_modules/babel-plugin-istanbul": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.1.tgz",
-      "integrity": "sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "optional": true,
-      "peer": true,
-      "workspaces": [
-        "test/babel-8"
-      ],
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@istanbuljs/load-nyc-config": "^1.0.0",
-        "@istanbuljs/schema": "^0.1.3",
-        "istanbul-lib-instrument": "^6.0.2",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-instrument": "^5.0.4",
         "test-exclude": "^6.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-istanbul/node_modules/istanbul-lib-instrument": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.12.3",
+        "@babel/parser": "^7.14.7",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-istanbul/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/babel-plugin-jest-hoist": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-30.3.0.tgz",
-      "integrity": "sha512-+TRkByhsws6sfPjVaitzadk1I0F5sPvOVUH5tyTSzhePpsGIVrdeunHSw/C36QeocS95OOk8lunc4rlu5Anwsg==",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+      "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "@types/babel__core": "^7.20.5"
+        "@babel/template": "^7.3.3",
+        "@babel/types": "^7.3.3",
+        "@types/babel__core": "^7.1.14",
+        "@types/babel__traverse": "^7.0.6"
       },
       "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/babel-preset-current-node-syntax": {
@@ -4636,29 +4158,26 @@
       }
     },
     "node_modules/babel-preset-jest": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.3.0.tgz",
-      "integrity": "sha512-6ZcUbWHC+dMz2vfzdNwi87Z1gQsLNK2uLuK1Q89R11xdvejcivlYYwDlEv0FHX3VwEXpbBQ9uufB/MUNpZGfhQ==",
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+      "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "babel-plugin-jest-hoist": "30.3.0",
-        "babel-preset-current-node-syntax": "^1.2.0"
+        "babel-plugin-jest-hoist": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0"
       },
       "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       },
       "peerDependencies": {
-        "@babel/core": "^7.11.0 || ^8.0.0-beta.1"
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4983,9 +4502,9 @@
       }
     },
     "node_modules/ci-info": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
-      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
       "dev": true,
       "funding": [
         {
@@ -4994,8 +4513,6 @@
         }
       ],
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -5393,53 +4910,6 @@
       "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/create-jest/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/create-jest/node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/create-jest/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -5942,6 +5412,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/eslint/node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -5954,6 +5441,13 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/eslint/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/espree": {
       "version": "9.6.1",
@@ -6042,11 +5536,19 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.x"
@@ -6107,91 +5609,6 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/expect/node_modules/@jest/schemas": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/expect/node_modules/@jest/types": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/expect/node_modules/@sinclair/typebox": {
-      "version": "0.27.10",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/expect/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/expect/node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/expect/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/express": {
@@ -6362,24 +5779,6 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
-      }
-    },
-    "node_modules/file-type": {
-      "version": "21.3.3",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.3.tgz",
-      "integrity": "sha512-pNwbwz8c3aZ+GvbJnIsCnDjKvgCZLHxkFWLEFxU3RMa+Ey++ZSEfisvsWQMcdys6PpxQjWUOIDi1fifXsW3YRg==",
-      "license": "MIT",
-      "dependencies": {
-        "@tokenizer/inflate": "^0.4.1",
-        "strtok3": "^10.3.4",
-        "token-types": "^6.1.1",
-        "uint8array-extras": "^1.4.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
     "node_modules/fill-range": {
@@ -7342,91 +6741,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-changed-files/node_modules/@jest/schemas": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-changed-files/node_modules/@jest/types": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-changed-files/node_modules/@sinclair/typebox": {
-      "version": "0.27.10",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/jest-changed-files/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-changed-files/node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-changed-files/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/jest-circus": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
@@ -7496,53 +6810,6 @@
       "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/jest-circus/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-circus/node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-circus/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
     },
     "node_modules/jest-cli": {
       "version": "29.7.0",
@@ -7616,53 +6883,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/jest-cli/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-cli/node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-cli/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/jest-config": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
@@ -7722,33 +6942,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-config/node_modules/@jest/transform": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
-      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.11.6",
-        "@jest/types": "^29.6.3",
-        "@jridgewell/trace-mapping": "^0.3.18",
-        "babel-plugin-istanbul": "^6.1.1",
-        "chalk": "^4.0.0",
-        "convert-source-map": "^2.0.0",
-        "fast-json-stable-stringify": "^2.1.0",
-        "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.7.0",
-        "jest-regex-util": "^29.6.3",
-        "jest-util": "^29.7.0",
-        "micromatch": "^4.0.4",
-        "pirates": "^4.0.4",
-        "slash": "^3.0.0",
-        "write-file-atomic": "^4.0.2"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/jest-config/node_modules/@jest/types": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
@@ -7774,137 +6967,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/jest-config/node_modules/babel-jest": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
-      "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/transform": "^29.7.0",
-        "@types/babel__core": "^7.1.14",
-        "babel-plugin-istanbul": "^6.1.1",
-        "babel-preset-jest": "^29.6.3",
-        "chalk": "^4.0.0",
-        "graceful-fs": "^4.2.9",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.8.0"
-      }
-    },
-    "node_modules/jest-config/node_modules/babel-plugin-istanbul": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
-      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@istanbuljs/load-nyc-config": "^1.0.0",
-        "@istanbuljs/schema": "^0.1.2",
-        "istanbul-lib-instrument": "^5.0.4",
-        "test-exclude": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-config/node_modules/babel-plugin-jest-hoist": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
-      "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/template": "^7.3.3",
-        "@babel/types": "^7.3.3",
-        "@types/babel__core": "^7.1.14",
-        "@types/babel__traverse": "^7.0.6"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-config/node_modules/babel-preset-jest": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
-      "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "babel-plugin-jest-hoist": "^29.6.3",
-        "babel-preset-current-node-syntax": "^1.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/jest-config/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-config/node_modules/istanbul-lib-instrument": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
-      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@babel/core": "^7.12.3",
-        "@babel/parser": "^7.14.7",
-        "@istanbuljs/schema": "^0.1.2",
-        "istanbul-lib-coverage": "^3.2.0",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-config/node_modules/jest-haste-map": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
-      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/graceful-fs": "^4.1.3",
-        "@types/node": "*",
-        "anymatch": "^3.0.3",
-        "fb-watchman": "^2.0.0",
-        "graceful-fs": "^4.2.9",
-        "jest-regex-util": "^29.6.3",
-        "jest-util": "^29.7.0",
-        "jest-worker": "^29.7.0",
-        "micromatch": "^4.0.4",
-        "walker": "^1.0.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "^2.3.2"
-      }
-    },
     "node_modules/jest-config/node_modules/jest-regex-util": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
@@ -7913,100 +6975,6 @@
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-config/node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-config/node_modules/jest-worker": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
-      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "jest-util": "^29.7.0",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^8.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-config/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/jest-config/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/jest-config/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/jest-config/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/jest-config/node_modules/write-file-atomic": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
-      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.7"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/jest-diff": {
@@ -8093,53 +7061,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/jest-each/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-each/node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-each/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/jest-environment-node": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
@@ -8196,53 +7117,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/jest-environment-node/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-environment-node/node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-environment-node/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/jest-get-type": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
@@ -8254,45 +7128,77 @@
       }
     },
     "node_modules/jest-haste-map": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.3.0.tgz",
-      "integrity": "sha512-mMi2oqG4KRU0R9QEtscl87JzMXfUhbKaFqOxmjb2CKcbHcUGFrJCBWHmnTiUqi6JcnzoBlO4rWfpdl2k/RfLCA==",
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
-        "@jest/types": "30.3.0",
+        "@jest/types": "^29.6.3",
+        "@types/graceful-fs": "^4.1.3",
         "@types/node": "*",
-        "anymatch": "^3.1.3",
-        "fb-watchman": "^2.0.2",
-        "graceful-fs": "^4.2.11",
-        "jest-regex-util": "30.0.1",
-        "jest-util": "30.3.0",
-        "jest-worker": "30.3.0",
-        "picomatch": "^4.0.3",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "micromatch": "^4.0.4",
         "walker": "^1.0.8"
       },
       "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       },
       "optionalDependencies": {
-        "fsevents": "^2.3.3"
+        "fsevents": "^2.3.2"
       }
     },
-    "node_modules/jest-haste-map/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+    "node_modules/jest-haste-map/node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=12"
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/@jest/types": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-haste-map/node_modules/@sinclair/typebox": {
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-haste-map/node_modules/jest-regex-util": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+      "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-leak-detector": {
@@ -8437,53 +7343,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/jest-mock/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-mock/node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-mock/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/jest-pnp-resolver": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
@@ -8559,159 +7418,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-resolve/node_modules/@jest/schemas": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-resolve/node_modules/@jest/types": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-resolve/node_modules/@sinclair/typebox": {
-      "version": "0.27.10",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/jest-resolve/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-resolve/node_modules/jest-haste-map": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
-      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/graceful-fs": "^4.1.3",
-        "@types/node": "*",
-        "anymatch": "^3.0.3",
-        "fb-watchman": "^2.0.0",
-        "graceful-fs": "^4.2.9",
-        "jest-regex-util": "^29.6.3",
-        "jest-util": "^29.7.0",
-        "jest-worker": "^29.7.0",
-        "micromatch": "^4.0.4",
-        "walker": "^1.0.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "^2.3.2"
-      }
-    },
-    "node_modules/jest-resolve/node_modules/jest-regex-util": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
-      "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-resolve/node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-resolve/node_modules/jest-worker": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
-      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "jest-util": "^29.7.0",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^8.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-resolve/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/jest-resolve/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
     "node_modules/jest-runner": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
@@ -8758,33 +7464,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-runner/node_modules/@jest/transform": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
-      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.11.6",
-        "@jest/types": "^29.6.3",
-        "@jridgewell/trace-mapping": "^0.3.18",
-        "babel-plugin-istanbul": "^6.1.1",
-        "chalk": "^4.0.0",
-        "convert-source-map": "^2.0.0",
-        "fast-json-stable-stringify": "^2.1.0",
-        "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.7.0",
-        "jest-regex-util": "^29.6.3",
-        "jest-util": "^29.7.0",
-        "micromatch": "^4.0.4",
-        "pirates": "^4.0.4",
-        "slash": "^3.0.0",
-        "write-file-atomic": "^4.0.2"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/jest-runner/node_modules/@jest/types": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
@@ -8810,156 +7489,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/jest-runner/node_modules/babel-plugin-istanbul": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
-      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@istanbuljs/load-nyc-config": "^1.0.0",
-        "@istanbuljs/schema": "^0.1.2",
-        "istanbul-lib-instrument": "^5.0.4",
-        "test-exclude": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-runner/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-runner/node_modules/istanbul-lib-instrument": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
-      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@babel/core": "^7.12.3",
-        "@babel/parser": "^7.14.7",
-        "@istanbuljs/schema": "^0.1.2",
-        "istanbul-lib-coverage": "^3.2.0",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-runner/node_modules/jest-haste-map": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
-      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/graceful-fs": "^4.1.3",
-        "@types/node": "*",
-        "anymatch": "^3.0.3",
-        "fb-watchman": "^2.0.0",
-        "graceful-fs": "^4.2.9",
-        "jest-regex-util": "^29.6.3",
-        "jest-util": "^29.7.0",
-        "jest-worker": "^29.7.0",
-        "micromatch": "^4.0.4",
-        "walker": "^1.0.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "^2.3.2"
-      }
-    },
-    "node_modules/jest-runner/node_modules/jest-regex-util": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
-      "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-runner/node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-runner/node_modules/jest-worker": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
-      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "jest-util": "^29.7.0",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^8.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-runner/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/jest-runner/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/jest-runner/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/jest-runner/node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -8979,36 +7508,6 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/jest-runner/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/jest-runner/node_modules/write-file-atomic": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
-      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.7"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/jest-runtime": {
@@ -9058,33 +7557,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-runtime/node_modules/@jest/transform": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
-      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.11.6",
-        "@jest/types": "^29.6.3",
-        "@jridgewell/trace-mapping": "^0.3.18",
-        "babel-plugin-istanbul": "^6.1.1",
-        "chalk": "^4.0.0",
-        "convert-source-map": "^2.0.0",
-        "fast-json-stable-stringify": "^2.1.0",
-        "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.7.0",
-        "jest-regex-util": "^29.6.3",
-        "jest-util": "^29.7.0",
-        "micromatch": "^4.0.4",
-        "pirates": "^4.0.4",
-        "slash": "^3.0.0",
-        "write-file-atomic": "^4.0.2"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/jest-runtime/node_modules/@jest/types": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
@@ -9110,82 +7582,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/jest-runtime/node_modules/babel-plugin-istanbul": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
-      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@istanbuljs/load-nyc-config": "^1.0.0",
-        "@istanbuljs/schema": "^0.1.2",
-        "istanbul-lib-instrument": "^5.0.4",
-        "test-exclude": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-runtime/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-runtime/node_modules/istanbul-lib-instrument": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
-      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@babel/core": "^7.12.3",
-        "@babel/parser": "^7.14.7",
-        "@istanbuljs/schema": "^0.1.2",
-        "istanbul-lib-coverage": "^3.2.0",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-runtime/node_modules/jest-haste-map": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
-      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/graceful-fs": "^4.1.3",
-        "@types/node": "*",
-        "anymatch": "^3.0.3",
-        "fb-watchman": "^2.0.0",
-        "graceful-fs": "^4.2.9",
-        "jest-regex-util": "^29.6.3",
-        "jest-util": "^29.7.0",
-        "jest-worker": "^29.7.0",
-        "micromatch": "^4.0.4",
-        "walker": "^1.0.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "^2.3.2"
-      }
-    },
     "node_modules/jest-runtime/node_modules/jest-regex-util": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
@@ -9194,100 +7590,6 @@
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-runtime/node_modules/jest-util": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-runtime/node_modules/jest-worker": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
-      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "jest-util": "^29.7.0",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^8.0.0"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-runtime/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/jest-runtime/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/jest-runtime/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/jest-runtime/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/jest-runtime/node_modules/write-file-atomic": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
-      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.7"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/jest-snapshot": {
@@ -9335,33 +7637,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-snapshot/node_modules/@jest/transform": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
-      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.11.6",
-        "@jest/types": "^29.6.3",
-        "@jridgewell/trace-mapping": "^0.3.18",
-        "babel-plugin-istanbul": "^6.1.1",
-        "chalk": "^4.0.0",
-        "convert-source-map": "^2.0.0",
-        "fast-json-stable-stringify": "^2.1.0",
-        "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.7.0",
-        "jest-regex-util": "^29.6.3",
-        "jest-util": "^29.7.0",
-        "micromatch": "^4.0.4",
-        "pirates": "^4.0.4",
-        "slash": "^3.0.0",
-        "write-file-atomic": "^4.0.2"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
     "node_modules/jest-snapshot/node_modules/@jest/types": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
@@ -9387,103 +7662,7 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/jest-snapshot/node_modules/babel-plugin-istanbul": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
-      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@istanbuljs/load-nyc-config": "^1.0.0",
-        "@istanbuljs/schema": "^0.1.2",
-        "istanbul-lib-instrument": "^5.0.4",
-        "test-exclude": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-snapshot/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-snapshot/node_modules/istanbul-lib-instrument": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
-      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@babel/core": "^7.12.3",
-        "@babel/parser": "^7.14.7",
-        "@istanbuljs/schema": "^0.1.2",
-        "istanbul-lib-coverage": "^3.2.0",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-snapshot/node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/jest-snapshot/node_modules/jest-haste-map": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
-      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^29.6.3",
-        "@types/graceful-fs": "^4.1.3",
-        "@types/node": "*",
-        "anymatch": "^3.0.3",
-        "fb-watchman": "^2.0.0",
-        "graceful-fs": "^4.2.9",
-        "jest-regex-util": "^29.6.3",
-        "jest-util": "^29.7.0",
-        "jest-worker": "^29.7.0",
-        "micromatch": "^4.0.4",
-        "walker": "^1.0.8"
-      },
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "^2.3.2"
-      }
-    },
-    "node_modules/jest-snapshot/node_modules/jest-regex-util": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
-      "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-snapshot/node_modules/jest-util": {
+    "node_modules/jest-util": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
       "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
@@ -9501,23 +7680,45 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-snapshot/node_modules/jest-worker": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
-      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+    "node_modules/jest-util/node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/node": "*",
-        "jest-util": "^29.7.0",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^8.0.0"
+        "@sinclair/typebox": "^0.27.8"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-snapshot/node_modules/picomatch": {
+    "node_modules/jest-util/node_modules/@jest/types": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-util/node_modules/@sinclair/typebox": {
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-util/node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
@@ -9525,78 +7726,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/jest-snapshot/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/jest-snapshot/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
-    "node_modules/jest-snapshot/node_modules/write-file-atomic": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
-      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.7"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/jest-util": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
-      "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jest/types": "30.3.0",
-        "@types/node": "*",
-        "chalk": "^4.1.2",
-        "ci-info": "^4.2.0",
-        "graceful-fs": "^4.2.11",
-        "picomatch": "^4.0.3"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-util/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -9729,70 +7858,20 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/jest-watcher/node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-watcher/node_modules/jest-util": {
+    "node_modules/jest-worker": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-      "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/types": "^29.6.3",
         "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
+        "jest-util": "^29.7.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-      }
-    },
-    "node_modules/jest-watcher/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/jest-worker": {
-      "version": "30.3.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.3.0.tgz",
-      "integrity": "sha512-DrCKkaQwHexjRUFTmPzs7sHQe0TSj9nvDALKGdwmK5mW9v7j90BudWirKAJHt3QQ9Dhrg1F7DogPzhChppkJpQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/node": "*",
-        "@ungap/structured-clone": "^1.3.0",
-        "jest-util": "30.3.0",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^8.1.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-worker/node_modules/supports-color": {
@@ -9801,8 +7880,6 @@
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -10260,6 +8337,57 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/mime-kind/node_modules/file-type": {
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-web-to-node-stream": "^3.0.0",
+        "strtok3": "^6.2.4",
+        "token-types": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
+    "node_modules/mime-kind/node_modules/strtok3": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
+      "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/mime-kind/node_modules/token-types": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
+      "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/mime-types": {
@@ -10768,6 +8896,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/peek-readable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
+      "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -11000,6 +9141,16 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pure-rand": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
@@ -11096,6 +9247,62 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/readable-web-to-node-stream": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.4.tgz",
+      "integrity": "sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^4.7.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/readable-web-to-node-stream/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/readable-web-to-node-stream/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/reflect-metadata": {
@@ -11352,6 +9559,23 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/schema-utils/node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/schema-utils/node_modules/ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
@@ -11361,6 +9585,13 @@
       "peerDependencies": {
         "ajv": "^6.9.1"
       }
+    },
+    "node_modules/schema-utils/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.7.4",
@@ -12485,6 +10716,16 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -12769,20 +11010,25 @@
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
-      "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
       "dev": true,
       "license": "ISC",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "imurmurhash": "^0.1.4",
-        "signal-exit": "^4.0.1"
+        "signal-exit": "^3.0.7"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
+    },
+    "node_modules/write-file-atomic/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/x3-linkedlist": {
       "version": "1.2.0",

--- a/frollz-api/package.json
+++ b/frollz-api/package.json
@@ -61,8 +61,9 @@
   "overrides": {
     "multer": ">=2.1.1",
     "minimatch": ">=9.0.7",
-    "file-type": ">=21.3.2",
-    "ajv": ">=8.18.0"
+    "babel-jest": "^29.7.0",
+    "@jest/transform": "^29.7.0",
+    "jest-util": "^29.7.0"
   },
   "jest": {
     "moduleFileExtensions": [

--- a/frollz-api/src/app.module.ts
+++ b/frollz-api/src/app.module.ts
@@ -1,12 +1,12 @@
-import { Module } from '@nestjs/common';
-import { ConfigModule } from '@nestjs/config';
-import { DatabaseModule } from './database/database.module';
-import { FilmFormatModule } from './film-format/film-format.module';
-import { StockModule } from './stock/stock.module';
-import { RollModule } from './roll/roll.module';
-import { RollStateModule } from './roll-state/roll-state.module';
-import { TagModule } from './tag/tag.module';
-import { StockTagModule } from './stock-tag/stock-tag.module';
+import { Module } from "@nestjs/common";
+import { ConfigModule } from "@nestjs/config";
+import { DatabaseModule } from "./database/database.module";
+import { FilmFormatModule } from "./film-format/film-format.module";
+import { StockModule } from "./stock/stock.module";
+import { RollModule } from "./roll/roll.module";
+import { RollStateModule } from "./roll-state/roll-state.module";
+import { TagModule } from "./tag/tag.module";
+import { StockTagModule } from "./stock-tag/stock-tag.module";
 
 @Module({
   imports: [

--- a/frollz-api/src/database/database.module.ts
+++ b/frollz-api/src/database/database.module.ts
@@ -1,24 +1,36 @@
-import { Module, Global } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
-import { Database } from 'arangojs';
-import { DatabaseService } from './database.service';
+import { Module, Global } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { Database } from "arangojs";
+import { DatabaseService } from "./database.service";
 
 @Global()
 @Module({
   providers: [
     {
-      provide: 'ARANGO_DB',
+      provide: "ARANGO_DB",
       useFactory: async (configService: ConfigService) => {
-        const connectWithRetry = async (maxRetries = 5, delay = 2000): Promise<Database> => {
+        const connectWithRetry = async (
+          maxRetries = 5,
+          delay = 2000,
+        ): Promise<Database> => {
           for (let attempt = 1; attempt <= maxRetries; attempt++) {
             try {
-              const url = configService.get('ARANGODB_URL', 'http://localhost:8529');
-              const databaseName = configService.get('ARANGODB_DATABASE', 'frollz');
-              const username = configService.get('ARANGODB_USERNAME', 'root');
-              const password = configService.get('ARANGODB_PASSWORD', 'rootpassword');
+              const url = configService.get(
+                "ARANGODB_URL",
+                "http://localhost:8529",
+              );
+              const databaseName = configService.get(
+                "ARANGODB_DATABASE",
+                "frollz",
+              );
+              const username = configService.get("ARANGODB_USERNAME", "root");
+              const password = configService.get(
+                "ARANGODB_PASSWORD",
+                "rootpassword",
+              );
 
               // Connect to _system first — the target database may not exist yet
-              const systemDb = new Database({ url, databaseName: '_system' });
+              const systemDb = new Database({ url, databaseName: "_system" });
               await systemDb.login(username, password);
 
               const existing = await systemDb.listDatabases();
@@ -28,17 +40,22 @@ import { DatabaseService } from './database.service';
               }
 
               const db = systemDb.database(databaseName);
-              console.log('Successfully connected to ArangoDB');
+              console.log("Successfully connected to ArangoDB");
               return db;
             } catch (error) {
-              console.log(`ArangoDB connection attempt ${attempt}/${maxRetries} failed:`, error.message);
-              
+              console.log(
+                `ArangoDB connection attempt ${attempt}/${maxRetries} failed:`,
+                error.message,
+              );
+
               if (attempt === maxRetries) {
-                throw new Error(`Failed to connect to ArangoDB after ${maxRetries} attempts: ${error.message}`);
+                throw new Error(
+                  `Failed to connect to ArangoDB after ${maxRetries} attempts: ${error.message}`,
+                );
               }
-              
+
               // Wait before retrying
-              await new Promise(resolve => setTimeout(resolve, delay));
+              await new Promise((resolve) => setTimeout(resolve, delay));
             }
           }
         };
@@ -49,6 +66,6 @@ import { DatabaseService } from './database.service';
     },
     DatabaseService,
   ],
-  exports: ['ARANGO_DB', DatabaseService],
+  exports: ["ARANGO_DB", DatabaseService],
 })
 export class DatabaseModule {}

--- a/frollz-api/src/database/database.service.spec.ts
+++ b/frollz-api/src/database/database.service.spec.ts
@@ -1,7 +1,7 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import * as fs from 'fs';
-import * as path from 'path';
-import { DatabaseService } from './database.service';
+import { Test, TestingModule } from "@nestjs/testing";
+import * as fs from "fs";
+import * as path from "path";
+import { DatabaseService } from "./database.service";
 
 // Helper to build a minimal mock ArangoDB collection
 const makeCollection = (overrides: Record<string, jest.Mock> = {}) => ({
@@ -18,7 +18,7 @@ const makeCollection = (overrides: Record<string, jest.Mock> = {}) => ({
   ...overrides,
 });
 
-describe('DatabaseService — loadSeedData', () => {
+describe("DatabaseService — loadSeedData", () => {
   let service: DatabaseService;
   let mockDb: { collection: jest.Mock; query: jest.Mock };
   let collectionMocks: Record<string, ReturnType<typeof makeCollection>>;
@@ -26,8 +26,6 @@ describe('DatabaseService — loadSeedData', () => {
   // Spies on fs so the real filesystem is not touched
   let readdirSyncSpy: jest.SpyInstance;
   let readFileSyncSpy: jest.SpyInstance;
-  let existsSyncSpy: jest.SpyInstance;
-  let pathJoinSpy: jest.SpyInstance;
 
   beforeEach(async () => {
     collectionMocks = {};
@@ -39,24 +37,21 @@ describe('DatabaseService — loadSeedData', () => {
         }
         return collectionMocks[name];
       }),
-      query: jest.fn(),
+      query: jest.fn().mockResolvedValue({ all: jest.fn().mockResolvedValue([]) }),
     };
 
     // Stub path.join to return a predictable value so existsSync calls are controllable
-    pathJoinSpy = jest.spyOn(path, 'join').mockImplementation((...parts) => parts.join('/'));
+    jest.spyOn(path, "join").mockImplementation((...parts) => parts.join("/"));
 
     // No schema files by default
-    existsSyncSpy = jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+    jest.spyOn(fs, "existsSync").mockReturnValue(false);
 
     // Default: empty seed directory
-    readdirSyncSpy = jest.spyOn(fs, 'readdirSync').mockReturnValue([] as any);
-    readFileSyncSpy = jest.spyOn(fs, 'readFileSync').mockReturnValue('[]');
+    readdirSyncSpy = jest.spyOn(fs, "readdirSync").mockReturnValue([] as any);
+    readFileSyncSpy = jest.spyOn(fs, "readFileSync").mockReturnValue("[]");
 
     const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        DatabaseService,
-        { provide: 'ARANGO_DB', useValue: mockDb },
-      ],
+      providers: [DatabaseService, { provide: "ARANGO_DB", useValue: mockDb }],
     }).compile();
 
     service = module.get<DatabaseService>(DatabaseService);
@@ -64,135 +59,162 @@ describe('DatabaseService — loadSeedData', () => {
 
   afterEach(() => jest.restoreAllMocks());
 
-  describe('file discovery and ordering', () => {
-    it('should process seed files in lexicographic (numeric prefix) order', async () => {
-      readdirSyncSpy.mockReturnValue(['0002-stocks.json', '0001-film-formats.json'] as any);
-      readFileSyncSpy.mockReturnValue('[]');
+  describe("file discovery and ordering", () => {
+    it("should process seed files in lexicographic (numeric prefix) order", async () => {
+      readdirSyncSpy.mockReturnValue([
+        "0002-stocks.json",
+        "0001-film-formats.json",
+      ] as any);
+      readFileSyncSpy.mockReturnValue("[]");
 
       await (service as any).loadSeedData();
 
       // The film-formats collection (0001) should have been touched before stocks (0002)
       const callOrder = mockDb.collection.mock.calls.map(([name]) => name);
-      const formatsIdx = callOrder.indexOf('film_formats_default');
-      const stocksIdx = callOrder.indexOf('stocks_default');
+      const formatsIdx = callOrder.indexOf("film_formats_default");
+      const stocksIdx = callOrder.indexOf("stocks_default");
       expect(formatsIdx).toBeLessThan(stocksIdx);
     });
 
-    it('should ignore files that do not match the 4-digit prefix pattern', async () => {
-      readdirSyncSpy.mockReturnValue(['README.md', 'stocks.json', '0001-film-formats.json'] as any);
-      readFileSyncSpy.mockReturnValue('[]');
+    it("should ignore files that do not match the 4-digit prefix pattern", async () => {
+      readdirSyncSpy.mockReturnValue([
+        "README.md",
+        "stocks.json",
+        "0001-film-formats.json",
+      ] as any);
+      readFileSyncSpy.mockReturnValue("[]");
 
       await (service as any).loadSeedData();
 
       // Only the correctly-prefixed file should trigger a collection lookup
-      const touchedCollections = mockDb.collection.mock.calls.map(([name]) => name);
-      expect(touchedCollections).toContain('film_formats_default');
-      expect(touchedCollections).not.toContain('stocks_default'); // stocks.json (no prefix) skipped
+      const touchedCollections = mockDb.collection.mock.calls.map(
+        ([name]) => name,
+      );
+      expect(touchedCollections).toContain("film_formats_default");
+      expect(touchedCollections).not.toContain("stocks_default"); // stocks.json (no prefix) skipped
     });
 
-    it('should warn and skip files with no collection mapping', async () => {
-      readdirSyncSpy.mockReturnValue(['0001-unknown-type.json'] as any);
-      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    it("should warn and skip files with no collection mapping", async () => {
+      readdirSyncSpy.mockReturnValue(["0001-unknown-type.json"] as any);
+      const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
 
       await (service as any).loadSeedData();
 
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('0001-unknown-type.json'));
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("0001-unknown-type.json"),
+      );
     });
   });
 
-  describe('skipping already-populated collections', () => {
-    it('should skip a collection that already has documents', async () => {
-      readdirSyncSpy.mockReturnValue(['0003-tags.json'] as any);
-      collectionMocks['tags_default'] = makeCollection({
+  describe("skipping already-populated collections", () => {
+    it("should skip a collection that already has documents", async () => {
+      readdirSyncSpy.mockReturnValue(["0003-tags.json"] as any);
+      collectionMocks["tags_default"] = makeCollection({
         count: jest.fn().mockResolvedValue({ count: 5 }),
       });
 
       await (service as any).loadSeedData();
 
-      expect(collectionMocks['tags_default'].saveAll).not.toHaveBeenCalled();
+      expect(collectionMocks["tags_default"].saveAll).not.toHaveBeenCalled();
     });
 
-    it('should load into a collection that is empty', async () => {
-      readdirSyncSpy.mockReturnValue(['0003-tags.json'] as any);
+    it("should load into a collection that is empty", async () => {
+      readdirSyncSpy.mockReturnValue(["0003-tags.json"] as any);
       readFileSyncSpy.mockReturnValue(
-        JSON.stringify([{ _key: 'color', value: 'color', color: '#F97316' }]),
+        JSON.stringify([{ _key: "color", value: "color", color: "#F97316" }]),
       );
 
       await (service as any).loadSeedData();
 
-      expect(collectionMocks['tags_default'].saveAll).toHaveBeenCalled();
+      expect(collectionMocks["tags_default"].saveAll).toHaveBeenCalled();
     });
   });
 
-  describe('createdAt stamping', () => {
-    it('should stamp createdAt on documents that do not have one', async () => {
-      readdirSyncSpy.mockReturnValue(['0003-tags.json'] as any);
+  describe("createdAt stamping", () => {
+    it("should stamp createdAt on documents that do not have one", async () => {
+      readdirSyncSpy.mockReturnValue(["0003-tags.json"] as any);
       readFileSyncSpy.mockReturnValue(
-        JSON.stringify([{ _key: 'color', value: 'color', color: '#F97316' }]),
+        JSON.stringify([{ _key: "color", value: "color", color: "#F97316" }]),
       );
 
       await (service as any).loadSeedData();
 
-      const savedDocs: Record<string, unknown>[] = collectionMocks['tags_default'].saveAll.mock.calls[0][0];
-      expect(savedDocs[0]).toHaveProperty('createdAt');
-      expect(typeof savedDocs[0].createdAt).toBe('string');
+      const savedDocs: Record<string, unknown>[] =
+        collectionMocks["tags_default"].saveAll.mock.calls[0][0];
+      expect(savedDocs[0]).toHaveProperty("createdAt");
+      expect(typeof savedDocs[0].createdAt).toBe("string");
     });
 
-    it('should preserve an existing createdAt value', async () => {
-      readdirSyncSpy.mockReturnValue(['0003-tags.json'] as any);
+    it("should preserve an existing createdAt value", async () => {
+      readdirSyncSpy.mockReturnValue(["0003-tags.json"] as any);
       readFileSyncSpy.mockReturnValue(
-        JSON.stringify([{ _key: 'color', value: 'color', color: '#F97316', createdAt: '2024-01-01T00:00:00.000Z' }]),
+        JSON.stringify([
+          {
+            _key: "color",
+            value: "color",
+            color: "#F97316",
+            createdAt: "2024-01-01T00:00:00.000Z",
+          },
+        ]),
       );
 
       await (service as any).loadSeedData();
 
-      const savedDocs: Record<string, unknown>[] = collectionMocks['tags_default'].saveAll.mock.calls[0][0];
-      expect(savedDocs[0].createdAt).toBe('2024-01-01T00:00:00.000Z');
+      const savedDocs: Record<string, unknown>[] =
+        collectionMocks["tags_default"].saveAll.mock.calls[0][0];
+      expect(savedDocs[0].createdAt).toBe("2024-01-01T00:00:00.000Z");
     });
 
-    it('should NOT add updatedAt to seed documents', async () => {
-      readdirSyncSpy.mockReturnValue(['0003-tags.json'] as any);
+    it("should NOT add updatedAt to seed documents", async () => {
+      readdirSyncSpy.mockReturnValue(["0003-tags.json"] as any);
       readFileSyncSpy.mockReturnValue(
-        JSON.stringify([{ _key: 'color', value: 'color', color: '#F97316' }]),
+        JSON.stringify([{ _key: "color", value: "color", color: "#F97316" }]),
       );
 
       await (service as any).loadSeedData();
 
-      const savedDocs: Record<string, unknown>[] = collectionMocks['tags_default'].saveAll.mock.calls[0][0];
-      expect(savedDocs[0]).not.toHaveProperty('updatedAt');
+      const savedDocs: Record<string, unknown>[] =
+        collectionMocks["tags_default"].saveAll.mock.calls[0][0];
+      expect(savedDocs[0]).not.toHaveProperty("updatedAt");
     });
   });
 
-  describe('foreign-key reference validation', () => {
-    it('should validate tagKey references in stock_tags_default', async () => {
-      readdirSyncSpy.mockReturnValue(['0004-stock-tags.json'] as any);
+  describe("foreign-key reference validation", () => {
+    it("should validate tagKey references in stock_tags_default", async () => {
+      readdirSyncSpy.mockReturnValue(["0004-stock-tags.json"] as any);
       readFileSyncSpy.mockReturnValue(
-        JSON.stringify([{ stockKey: 'kodak-portra-400-35mm', tagKey: 'color' }]),
+        JSON.stringify([
+          { stockKey: "kodak-portra-400-35mm", tagKey: "color" },
+        ]),
       );
-      collectionMocks['tags_default'] = makeCollection({
+      collectionMocks["tags_default"] = makeCollection({
         documentExists: jest.fn().mockResolvedValue(true),
       });
-      collectionMocks['stocks_default'] = makeCollection({
+      collectionMocks["stocks_default"] = makeCollection({
         documentExists: jest.fn().mockResolvedValue(true),
       });
 
       await (service as any).loadSeedData();
 
-      expect(collectionMocks['tags_default'].documentExists).toHaveBeenCalledWith('color');
-      expect(collectionMocks['stocks_default'].documentExists).toHaveBeenCalledWith(
-        'kodak-portra-400-35mm',
-      );
+      expect(
+        collectionMocks["tags_default"].documentExists,
+      ).toHaveBeenCalledWith("color");
+      expect(
+        collectionMocks["stocks_default"].documentExists,
+      ).toHaveBeenCalledWith("kodak-portra-400-35mm");
     });
 
-    it('should throw when a tagKey reference is not found', async () => {
-      readdirSyncSpy.mockReturnValue(['0004-stock-tags.json'] as any);
+    it("should throw when a tagKey reference is not found", async () => {
+      readdirSyncSpy.mockReturnValue(["0004-stock-tags.json"] as any);
       readFileSyncSpy.mockReturnValue(
-        JSON.stringify([{ stockKey: 'kodak-portra-400-35mm', tagKey: 'missing-tag' }]),
+        JSON.stringify([
+          { stockKey: "kodak-portra-400-35mm", tagKey: "missing-tag" },
+        ]),
       );
-      collectionMocks['tags_default'] = makeCollection({
+      collectionMocks["tags_default"] = makeCollection({
         documentExists: jest.fn().mockResolvedValue(false),
       });
-      collectionMocks['stocks_default'] = makeCollection({
+      collectionMocks["stocks_default"] = makeCollection({
         documentExists: jest.fn().mockResolvedValue(true),
       });
 
@@ -201,15 +223,15 @@ describe('DatabaseService — loadSeedData', () => {
       );
     });
 
-    it('should throw when a stockKey reference is not found', async () => {
-      readdirSyncSpy.mockReturnValue(['0004-stock-tags.json'] as any);
+    it("should throw when a stockKey reference is not found", async () => {
+      readdirSyncSpy.mockReturnValue(["0004-stock-tags.json"] as any);
       readFileSyncSpy.mockReturnValue(
-        JSON.stringify([{ stockKey: 'missing-stock', tagKey: 'color' }]),
+        JSON.stringify([{ stockKey: "missing-stock", tagKey: "color" }]),
       );
-      collectionMocks['tags_default'] = makeCollection({
+      collectionMocks["tags_default"] = makeCollection({
         documentExists: jest.fn().mockResolvedValue(true),
       });
-      collectionMocks['stocks_default'] = makeCollection({
+      collectionMocks["stocks_default"] = makeCollection({
         documentExists: jest.fn().mockResolvedValue(false),
       });
 
@@ -218,22 +240,22 @@ describe('DatabaseService — loadSeedData', () => {
       );
     });
 
-    it('should skip reference validation for optional fields that are absent', async () => {
+    it("should skip reference validation for optional fields that are absent", async () => {
       // baseStockKey is optional — if absent, no lookup should occur
-      readdirSyncSpy.mockReturnValue(['0002-stocks.json'] as any);
+      readdirSyncSpy.mockReturnValue(["0002-stocks.json"] as any);
       readFileSyncSpy.mockReturnValue(
         JSON.stringify([
           {
-            _key: 'kodak-portra-400-35mm',
-            brand: 'Portra 400',
-            manufacturer: 'Kodak',
-            formatKey: '35mm',
-            process: 'C-41',
+            _key: "kodak-portra-400-35mm",
+            brand: "Portra 400",
+            manufacturer: "Kodak",
+            formatKey: "35mm",
+            process: "C-41",
             speed: 400,
           },
         ]),
       );
-      collectionMocks['film_formats_default'] = makeCollection({
+      collectionMocks["film_formats_default"] = makeCollection({
         documentExists: jest.fn().mockResolvedValue(true),
       });
 
@@ -241,7 +263,7 @@ describe('DatabaseService — loadSeedData', () => {
 
       // baseStockKey is absent so stocks_default.documentExists should NOT be called for it
       // (stocks_default is the ref collection for baseStockKey)
-      const stocksDefaultMock = collectionMocks['stocks_default'];
+      const stocksDefaultMock = collectionMocks["stocks_default"];
       if (stocksDefaultMock) {
         expect(stocksDefaultMock.documentExists).not.toHaveBeenCalled();
       }
@@ -249,7 +271,7 @@ describe('DatabaseService — loadSeedData', () => {
   });
 });
 
-describe('DatabaseService — getCollection / query', () => {
+describe("DatabaseService — getCollection / query", () => {
   let service: DatabaseService;
   let mockDb: { collection: jest.Mock; query: jest.Mock };
 
@@ -259,15 +281,12 @@ describe('DatabaseService — getCollection / query', () => {
       query: jest.fn().mockResolvedValue({ all: jest.fn() }),
     };
 
-    jest.spyOn(fs, 'existsSync').mockReturnValue(false);
-    jest.spyOn(fs, 'readdirSync').mockReturnValue([] as any);
-    jest.spyOn(path, 'join').mockImplementation((...parts) => parts.join('/'));
+    jest.spyOn(fs, "existsSync").mockReturnValue(false);
+    jest.spyOn(fs, "readdirSync").mockReturnValue([] as any);
+    jest.spyOn(path, "join").mockImplementation((...parts) => parts.join("/"));
 
     const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        DatabaseService,
-        { provide: 'ARANGO_DB', useValue: mockDb },
-      ],
+      providers: [DatabaseService, { provide: "ARANGO_DB", useValue: mockDb }],
     }).compile();
 
     service = module.get<DatabaseService>(DatabaseService);
@@ -275,13 +294,15 @@ describe('DatabaseService — getCollection / query', () => {
 
   afterEach(() => jest.restoreAllMocks());
 
-  it('getCollection should return the collection from the db', () => {
-    service.getCollection('tags');
-    expect(mockDb.collection).toHaveBeenCalledWith('tags');
+  it("getCollection should return the collection from the db", () => {
+    service.getCollection("tags");
+    expect(mockDb.collection).toHaveBeenCalledWith("tags");
   });
 
-  it('query should delegate to the db with aql and bindVars', async () => {
-    await service.query('FOR t IN tags RETURN t', { key: 'color' });
-    expect(mockDb.query).toHaveBeenCalledWith('FOR t IN tags RETURN t', { key: 'color' });
+  it("query should delegate to the db with aql and bindVars", async () => {
+    await service.query("FOR t IN tags RETURN t", { key: "color" });
+    expect(mockDb.query).toHaveBeenCalledWith("FOR t IN tags RETURN t", {
+      key: "color",
+    });
   });
 });

--- a/frollz-api/src/database/database.service.ts
+++ b/frollz-api/src/database/database.service.ts
@@ -1,12 +1,12 @@
-import { Injectable, Inject, OnModuleInit } from '@nestjs/common';
-import { Database } from 'arangojs';
-import { SchemaOptions } from 'arangojs/collection';
-import * as fs from 'fs';
-import * as path from 'path';
+import { Injectable, Inject, OnModuleInit } from "@nestjs/common";
+import { Database } from "arangojs";
+import { SchemaOptions } from "arangojs/collection";
+import * as fs from "fs";
+import * as path from "path";
 
 @Injectable()
 export class DatabaseService implements OnModuleInit {
-  constructor(@Inject('ARANGO_DB') private readonly db: Database) {}
+  constructor(@Inject("ARANGO_DB") private readonly db: Database) {}
 
   async onModuleInit() {
     await this.initializeCollections();
@@ -17,22 +17,27 @@ export class DatabaseService implements OnModuleInit {
 
   private loadSchema(collectionName: string): SchemaOptions | undefined {
     // Strip _default suffix so both film_formats and film_formats_default share the same schema
-    const baseName = collectionName.replace(/_default$/, '');
-    const schemaPath = path.join(process.cwd(), 'db-init', 'schemas', `${baseName}.schema.json`);
+    const baseName = collectionName.replace(/_default$/, "");
+    const schemaPath = path.join(
+      process.cwd(),
+      "db-init",
+      "schemas",
+      `${baseName}.schema.json`,
+    );
     if (fs.existsSync(schemaPath)) {
-      return JSON.parse(fs.readFileSync(schemaPath, 'utf8')) as SchemaOptions;
+      return JSON.parse(fs.readFileSync(schemaPath, "utf8")) as SchemaOptions;
     }
     return undefined;
   }
 
   private async initializeCollections() {
     const collections = [
-      'film_formats',
-      'stocks',
-      'rolls',
-      'roll_states',
-      'tags',
-      'stock_tags',
+      "film_formats",
+      "stocks",
+      "rolls",
+      "roll_states",
+      "tags",
+      "stock_tags",
     ];
 
     for (const collectionName of collections) {
@@ -43,10 +48,14 @@ export class DatabaseService implements OnModuleInit {
 
         if (!exists) {
           await collection.create(schema ? { schema } : undefined);
-          console.log(`Created collection: ${collectionName}${schema ? ' (with schema)' : ''}`);
+          console.log(
+            `Created collection: ${collectionName}${schema ? " (with schema)" : ""}`,
+          );
         } else if (schema) {
           await collection.properties({ schema });
-          console.log(`Applied schema to existing collection: ${collectionName}`);
+          console.log(
+            `Applied schema to existing collection: ${collectionName}`,
+          );
         }
       } catch (error) {
         console.error(`Error creating collection ${collectionName}:`, error);
@@ -56,10 +65,10 @@ export class DatabaseService implements OnModuleInit {
 
   private async initializeDefaultCollections() {
     const defaultCollections = [
-      'film_formats_default',
-      'stocks_default',
-      'tags_default',
-      'stock_tags_default',
+      "film_formats_default",
+      "stocks_default",
+      "tags_default",
+      "stock_tags_default",
     ];
 
     for (const collectionName of defaultCollections) {
@@ -70,51 +79,64 @@ export class DatabaseService implements OnModuleInit {
 
         if (!exists) {
           await collection.create(schema ? { schema } : undefined);
-          console.log(`Created default collection: ${collectionName}${schema ? ' (with schema)' : ''}`);
+          console.log(
+            `Created default collection: ${collectionName}${schema ? " (with schema)" : ""}`,
+          );
         } else if (schema) {
           await collection.properties({ schema });
-          console.log(`Applied schema to existing default collection: ${collectionName}`);
+          console.log(
+            `Applied schema to existing default collection: ${collectionName}`,
+          );
         }
       } catch (error) {
-        console.error(`Error creating default collection ${collectionName}:`, error);
+        console.error(
+          `Error creating default collection ${collectionName}:`,
+          error,
+        );
       }
     }
   }
 
   // Maps the base filename (after stripping the numeric prefix) to its target _default collection.
   private readonly seedCollectionMap: Record<string, string> = {
-    'film-formats': 'film_formats_default',
-    'stocks': 'stocks_default',
-    'tags': 'tags_default',
-    'stock-tags': 'stock_tags_default',
+    "film-formats": "film_formats_default",
+    stocks: "stocks_default",
+    tags: "tags_default",
+    "stock-tags": "stock_tags_default",
   };
 
   // For each collection, declares which fields are foreign-key references and which
   // collection they must resolve against before insertion.
-  private readonly seedReferenceMap: Record<string, { field: string; collection: string }[]> = {
+  private readonly seedReferenceMap: Record<
+    string,
+    { field: string; collection: string }[]
+  > = {
     stocks_default: [
-      { field: 'formatKey', collection: 'film_formats_default' },
-      { field: 'baseStockKey', collection: 'stocks_default' },
+      { field: "formatKey", collection: "film_formats_default" },
+      { field: "baseStockKey", collection: "stocks_default" },
     ],
     stock_tags_default: [
-      { field: 'tagKey', collection: 'tags_default' },
-      { field: 'stockKey', collection: 'stocks_default' },
+      { field: "tagKey", collection: "tags_default" },
+      { field: "stockKey", collection: "stocks_default" },
     ],
   };
 
   private async loadSeedData() {
-    const defaultDir = path.join(process.cwd(), 'db-init', 'default');
+    const defaultDir = path.join(process.cwd(), "db-init", "default");
 
-    const files = fs.readdirSync(defaultDir)
+    const files = fs
+      .readdirSync(defaultDir)
       .filter((f: string) => /^\d{4}-.+\.json$/.test(f))
       .sort(); // lexicographic sort respects the 4-digit prefix ordering
 
     for (const filename of files) {
-      const baseName = filename.replace(/^\d{4}-/, '').replace(/\.json$/, '');
+      const baseName = filename.replace(/^\d{4}-/, "").replace(/\.json$/, "");
       const collectionName = this.seedCollectionMap[baseName];
 
       if (!collectionName) {
-        console.warn(`No collection mapping for seed file: ${filename} — skipping`);
+        console.warn(
+          `No collection mapping for seed file: ${filename} — skipping`,
+        );
         continue;
       }
 
@@ -125,7 +147,9 @@ export class DatabaseService implements OnModuleInit {
 
         const filePath = path.join(defaultDir, filename);
         const now = new Date().toISOString();
-        const raw: Record<string, unknown>[] = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+        const raw: Record<string, unknown>[] = JSON.parse(
+          fs.readFileSync(filePath, "utf8"),
+        );
 
         // Validate all foreign-key references before inserting anything
         const refs = this.seedReferenceMap[collectionName] ?? [];
@@ -144,13 +168,15 @@ export class DatabaseService implements OnModuleInit {
           }
         }
 
-        const data = raw.map(doc => ({
+        const data = raw.map((doc) => ({
           ...doc,
           createdAt: doc.createdAt ?? now,
         }));
 
         await collection.saveAll(data);
-        console.log(`Loaded ${data.length} records into ${collectionName} from ${filename}`);
+        console.log(
+          `Loaded ${data.length} records into ${collectionName} from ${filename}`,
+        );
       } catch (error) {
         console.error(`Error loading seed data from ${filename}:`, error);
         throw error; // re-throw so the app fails fast on bad seed data
@@ -160,30 +186,36 @@ export class DatabaseService implements OnModuleInit {
 
   private async populateMainCollections() {
     const collectionMappings = [
-      { main: 'film_formats', default: 'film_formats_default' },
-      { main: 'stocks', default: 'stocks_default' },
-      { main: 'tags', default: 'tags_default' },
-      { main: 'stock_tags', default: 'stock_tags_default' },
+      { main: "film_formats", default: "film_formats_default" },
+      { main: "stocks", default: "stocks_default" },
+      { main: "tags", default: "tags_default" },
+      { main: "stock_tags", default: "stock_tags_default" },
     ];
 
     for (const mapping of collectionMappings) {
       try {
         const mainCollection = this.db.collection(mapping.main);
-        const defaultCollection = this.db.collection(mapping.default);
-        
+
         const mainCount = await mainCollection.count();
-        
+
         if (mainCount.count === 0) {
-          const cursor = await this.db.query(`FOR doc IN ${mapping.default} RETURN doc`);
+          const cursor = await this.db.query(
+            `FOR doc IN ${mapping.default} RETURN doc`,
+          );
           const documents = await cursor.all();
-          
+
           if (documents.length > 0) {
             await mainCollection.saveAll(documents);
-            console.log(`Populated ${mapping.main} with ${documents.length} records from ${mapping.default}`);
+            console.log(
+              `Populated ${mapping.main} with ${documents.length} records from ${mapping.default}`,
+            );
           }
         }
       } catch (error) {
-        console.error(`Error populating main collection ${mapping.main}:`, error);
+        console.error(
+          `Error populating main collection ${mapping.main}:`,
+          error,
+        );
       }
     }
   }

--- a/frollz-api/src/film-format/dto/create-film-format.dto.ts
+++ b/frollz-api/src/film-format/dto/create-film-format.dto.ts
@@ -1,6 +1,6 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsEnum } from 'class-validator';
-import { FormFactor, Format } from '../entities/film-format.entity';
+import { ApiProperty } from "@nestjs/swagger";
+import { IsEnum } from "class-validator";
+import { FormFactor, Format } from "../entities/film-format.entity";
 
 export class CreateFilmFormatDto {
   @ApiProperty({ enum: FormFactor })

--- a/frollz-api/src/film-format/dto/update-film-format.dto.ts
+++ b/frollz-api/src/film-format/dto/update-film-format.dto.ts
@@ -1,4 +1,4 @@
-import { PartialType } from '@nestjs/swagger';
-import { CreateFilmFormatDto } from './create-film-format.dto';
+import { PartialType } from "@nestjs/swagger";
+import { CreateFilmFormatDto } from "./create-film-format.dto";
 
 export class UpdateFilmFormatDto extends PartialType(CreateFilmFormatDto) {}

--- a/frollz-api/src/film-format/entities/film-format.entity.ts
+++ b/frollz-api/src/film-format/entities/film-format.entity.ts
@@ -1,27 +1,27 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty } from "@nestjs/swagger";
 
 export enum FormFactor {
-  ROLL = 'Roll',
-  SHEET = 'Sheet',
-  INSTANT = 'Instant',
-  BULK_100FT = '100ft Bulk',
-  BULK_400FT = '400ft Bulk',
+  ROLL = "Roll",
+  SHEET = "Sheet",
+  INSTANT = "Instant",
+  BULK_100FT = "100ft Bulk",
+  BULK_400FT = "400ft Bulk",
 }
 
 export enum Format {
-  MM35 = '35mm',
-  MM110 = '110',
-  MINI = 'Mini',
-  WIDE = 'Wide',
-  SQUARE = 'Square',
-  MM120 = '120',
-  MM220 = '220',
-  FOURX5 = '4x5',
-  EIGHTX10 = '8x10',
-  I_TYPE = 'I-Type',
-  SIX_HUNDRED = '600',
-  SX_70 = 'SX-70',
-  GO = 'GO',
+  MM35 = "35mm",
+  MM110 = "110",
+  MINI = "Mini",
+  WIDE = "Wide",
+  SQUARE = "Square",
+  MM120 = "120",
+  MM220 = "220",
+  FOURX5 = "4x5",
+  EIGHTX10 = "8x10",
+  I_TYPE = "I-Type",
+  SIX_HUNDRED = "600",
+  SX_70 = "SX-70",
+  GO = "GO",
 }
 
 export class FilmFormat {

--- a/frollz-api/src/film-format/film-format.controller.ts
+++ b/frollz-api/src/film-format/film-format.controller.ts
@@ -1,62 +1,95 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete, NotFoundException } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
-import { FilmFormatService } from './film-format.service';
-import { CreateFilmFormatDto } from './dto/create-film-format.dto';
-import { UpdateFilmFormatDto } from './dto/update-film-format.dto';
-import { FilmFormat } from './entities/film-format.entity';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  NotFoundException,
+} from "@nestjs/common";
+import { ApiTags, ApiOperation, ApiResponse } from "@nestjs/swagger";
+import { FilmFormatService } from "./film-format.service";
+import { CreateFilmFormatDto } from "./dto/create-film-format.dto";
+import { UpdateFilmFormatDto } from "./dto/update-film-format.dto";
+import { FilmFormat } from "./entities/film-format.entity";
 
-@ApiTags('film-formats')
-@Controller('film-formats')
+@ApiTags("film-formats")
+@Controller("film-formats")
 export class FilmFormatController {
   constructor(private readonly filmFormatService: FilmFormatService) {}
 
   @Post()
-  @ApiOperation({ summary: 'Create a new film format' })
-  @ApiResponse({ status: 201, description: 'Film format created successfully', type: FilmFormat })
-  create(@Body() createFilmFormatDto: CreateFilmFormatDto): Promise<FilmFormat> {
+  @ApiOperation({ summary: "Create a new film format" })
+  @ApiResponse({
+    status: 201,
+    description: "Film format created successfully",
+    type: FilmFormat,
+  })
+  create(
+    @Body() createFilmFormatDto: CreateFilmFormatDto,
+  ): Promise<FilmFormat> {
     return this.filmFormatService.create(createFilmFormatDto);
   }
 
   @Get()
-  @ApiOperation({ summary: 'Get all film formats' })
-  @ApiResponse({ status: 200, description: 'Film formats retrieved successfully', type: [FilmFormat] })
+  @ApiOperation({ summary: "Get all film formats" })
+  @ApiResponse({
+    status: 200,
+    description: "Film formats retrieved successfully",
+    type: [FilmFormat],
+  })
   findAll(): Promise<FilmFormat[]> {
     return this.filmFormatService.findAll();
   }
 
-  @Get(':key')
-  @ApiOperation({ summary: 'Get a film format by key' })
-  @ApiResponse({ status: 200, description: 'Film format retrieved successfully', type: FilmFormat })
-  @ApiResponse({ status: 404, description: 'Film format not found' })
-  async findOne(@Param('key') key: string): Promise<FilmFormat> {
+  @Get(":key")
+  @ApiOperation({ summary: "Get a film format by key" })
+  @ApiResponse({
+    status: 200,
+    description: "Film format retrieved successfully",
+    type: FilmFormat,
+  })
+  @ApiResponse({ status: 404, description: "Film format not found" })
+  async findOne(@Param("key") key: string): Promise<FilmFormat> {
     const filmFormat = await this.filmFormatService.findOne(key);
     if (!filmFormat) {
-      throw new NotFoundException('Film format not found');
+      throw new NotFoundException("Film format not found");
     }
     return filmFormat;
   }
 
-  @Patch(':key')
-  @ApiOperation({ summary: 'Update a film format' })
-  @ApiResponse({ status: 200, description: 'Film format updated successfully', type: FilmFormat })
-  @ApiResponse({ status: 404, description: 'Film format not found' })
-  async update(@Param('key') key: string, @Body() updateFilmFormatDto: UpdateFilmFormatDto): Promise<FilmFormat> {
-    const filmFormat = await this.filmFormatService.update(key, updateFilmFormatDto);
+  @Patch(":key")
+  @ApiOperation({ summary: "Update a film format" })
+  @ApiResponse({
+    status: 200,
+    description: "Film format updated successfully",
+    type: FilmFormat,
+  })
+  @ApiResponse({ status: 404, description: "Film format not found" })
+  async update(
+    @Param("key") key: string,
+    @Body() updateFilmFormatDto: UpdateFilmFormatDto,
+  ): Promise<FilmFormat> {
+    const filmFormat = await this.filmFormatService.update(
+      key,
+      updateFilmFormatDto,
+    );
     if (!filmFormat) {
-      throw new NotFoundException('Film format not found');
+      throw new NotFoundException("Film format not found");
     }
     return filmFormat;
   }
 
-  @Delete(':key')
-  @ApiOperation({ summary: 'Delete a film format' })
-  @ApiResponse({ status: 200, description: 'Film format deleted successfully' })
-  @ApiResponse({ status: 404, description: 'Film format not found' })
-  async remove(@Param('key') key: string): Promise<{ message: string }> {
+  @Delete(":key")
+  @ApiOperation({ summary: "Delete a film format" })
+  @ApiResponse({ status: 200, description: "Film format deleted successfully" })
+  @ApiResponse({ status: 404, description: "Film format not found" })
+  async remove(@Param("key") key: string): Promise<{ message: string }> {
     const deleted = await this.filmFormatService.remove(key);
     if (!deleted) {
-      throw new NotFoundException('Film format not found');
+      throw new NotFoundException("Film format not found");
     }
-    return { message: 'Film format deleted successfully' };
+    return { message: "Film format deleted successfully" };
   }
 }

--- a/frollz-api/src/film-format/film-format.module.ts
+++ b/frollz-api/src/film-format/film-format.module.ts
@@ -1,6 +1,6 @@
-import { Module } from '@nestjs/common';
-import { FilmFormatService } from './film-format.service';
-import { FilmFormatController } from './film-format.controller';
+import { Module } from "@nestjs/common";
+import { FilmFormatService } from "./film-format.service";
+import { FilmFormatController } from "./film-format.controller";
 
 @Module({
   controllers: [FilmFormatController],

--- a/frollz-api/src/film-format/film-format.service.ts
+++ b/frollz-api/src/film-format/film-format.service.ts
@@ -1,16 +1,16 @@
-import { Injectable } from '@nestjs/common';
-import { DatabaseService } from '../database/database.service';
-import { CreateFilmFormatDto } from './dto/create-film-format.dto';
-import { UpdateFilmFormatDto } from './dto/update-film-format.dto';
-import { FilmFormat } from './entities/film-format.entity';
+import { Injectable } from "@nestjs/common";
+import { DatabaseService } from "../database/database.service";
+import { CreateFilmFormatDto } from "./dto/create-film-format.dto";
+import { UpdateFilmFormatDto } from "./dto/update-film-format.dto";
+import { FilmFormat } from "./entities/film-format.entity";
 
 @Injectable()
 export class FilmFormatService {
   constructor(private readonly databaseService: DatabaseService) {}
 
   async create(createFilmFormatDto: CreateFilmFormatDto): Promise<FilmFormat> {
-    const collection = this.databaseService.getCollection('film_formats');
-    
+    const collection = this.databaseService.getCollection("film_formats");
+
     const filmFormat = {
       ...createFilmFormatDto,
       createdAt: new Date(),
@@ -26,24 +26,30 @@ export class FilmFormatService {
       FOR format IN film_formats
       RETURN format
     `);
-    
+
     return await cursor.all();
   }
 
   async findOne(key: string): Promise<FilmFormat | null> {
-    const cursor = await this.databaseService.query(`
+    const cursor = await this.databaseService.query(
+      `
       FOR format IN film_formats
       FILTER format._key == @key
       RETURN format
-    `, { key });
+    `,
+      { key },
+    );
 
     const results = await cursor.all();
     return results.length > 0 ? results[0] : null;
   }
 
-  async update(key: string, updateFilmFormatDto: UpdateFilmFormatDto): Promise<FilmFormat | null> {
-    const collection = this.databaseService.getCollection('film_formats');
-    
+  async update(
+    key: string,
+    updateFilmFormatDto: UpdateFilmFormatDto,
+  ): Promise<FilmFormat | null> {
+    const collection = this.databaseService.getCollection("film_formats");
+
     const updateData = {
       ...updateFilmFormatDto,
       updatedAt: new Date(),
@@ -52,18 +58,18 @@ export class FilmFormatService {
     try {
       await collection.update(key, updateData);
       return await this.findOne(key);
-    } catch (error) {
+    } catch {
       return null;
     }
   }
 
   async remove(key: string): Promise<boolean> {
-    const collection = this.databaseService.getCollection('film_formats');
-    
+    const collection = this.databaseService.getCollection("film_formats");
+
     try {
       await collection.remove(key);
       return true;
-    } catch (error) {
+    } catch {
       return false;
     }
   }

--- a/frollz-api/src/main.ts
+++ b/frollz-api/src/main.ts
@@ -1,35 +1,37 @@
-import { NestFactory } from '@nestjs/core';
-import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
-import { ValidationPipe } from '@nestjs/common';
-import { AppModule } from './app.module';
+import { NestFactory } from "@nestjs/core";
+import { SwaggerModule, DocumentBuilder } from "@nestjs/swagger";
+import { ValidationPipe } from "@nestjs/common";
+import { AppModule } from "./app.module";
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
   // Enable CORS
   app.enableCors({
-    origin: process.env.CORS_ORIGIN || ['http://localhost:5173'],
+    origin: process.env.CORS_ORIGIN || ["http://localhost:5173"],
     credentials: true,
   });
 
   // Global validation pipe
-  app.useGlobalPipes(new ValidationPipe({
-    transform: true,
-    whitelist: true,
-    forbidNonWhitelisted: true,
-  }));
+  app.useGlobalPipes(
+    new ValidationPipe({
+      transform: true,
+      whitelist: true,
+      forbidNonWhitelisted: true,
+    }),
+  );
 
   // API prefix
-  app.setGlobalPrefix('api');
+  app.setGlobalPrefix("api");
 
   // Swagger documentation
   const config = new DocumentBuilder()
-    .setTitle('Frollz API')
-    .setDescription('Film roll tracking system API')
-    .setVersion('1.0')
+    .setTitle("Frollz API")
+    .setDescription("Film roll tracking system API")
+    .setVersion("1.0")
     .build();
   const document = SwaggerModule.createDocument(app, config);
-  SwaggerModule.setup('api/docs', app, document);
+  SwaggerModule.setup("api/docs", app, document);
 
   const port = process.env.PORT || 3000;
   await app.listen(port);

--- a/frollz-api/src/roll-state/dto/create-roll-state.dto.ts
+++ b/frollz-api/src/roll-state/dto/create-roll-state.dto.ts
@@ -1,7 +1,7 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsEnum, IsString, IsOptional, IsDate } from 'class-validator';
-import { Type } from 'class-transformer';
-import { RollState } from '../../roll/entities/roll.entity';
+import { ApiProperty } from "@nestjs/swagger";
+import { IsEnum, IsString, IsOptional, IsDate } from "class-validator";
+import { Type } from "class-transformer";
+import { RollState } from "../../roll/entities/roll.entity";
 
 export class CreateRollStateDto {
   @ApiProperty()

--- a/frollz-api/src/roll-state/entities/roll-state.entity.ts
+++ b/frollz-api/src/roll-state/entities/roll-state.entity.ts
@@ -1,5 +1,5 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { RollState } from '../../roll/entities/roll.entity';
+import { ApiProperty } from "@nestjs/swagger";
+import { RollState } from "../../roll/entities/roll.entity";
 
 export class RollStateHistory {
   @ApiProperty()

--- a/frollz-api/src/roll-state/roll-state.controller.ts
+++ b/frollz-api/src/roll-state/roll-state.controller.ts
@@ -1,18 +1,28 @@
-import { Controller, Get, Query } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiQuery } from '@nestjs/swagger';
-import { RollStateService } from './roll-state.service';
-import { RollStateHistory } from './entities/roll-state.entity';
+import { Controller, Get, Query } from "@nestjs/common";
+import { ApiTags, ApiOperation, ApiResponse, ApiQuery } from "@nestjs/swagger";
+import { RollStateService } from "./roll-state.service";
+import { RollStateHistory } from "./entities/roll-state.entity";
 
-@ApiTags('roll-states')
-@Controller('roll-states')
+@ApiTags("roll-states")
+@Controller("roll-states")
 export class RollStateController {
   constructor(private readonly rollStateService: RollStateService) {}
 
   @Get()
-  @ApiOperation({ summary: 'Get state history for a roll' })
-  @ApiQuery({ name: 'rollKey', required: true, description: 'The _key of the roll' })
-  @ApiResponse({ status: 200, description: 'State history retrieved', type: [RollStateHistory] })
-  findByRollKey(@Query('rollKey') rollKey: string): Promise<RollStateHistory[]> {
+  @ApiOperation({ summary: "Get state history for a roll" })
+  @ApiQuery({
+    name: "rollKey",
+    required: true,
+    description: "The _key of the roll",
+  })
+  @ApiResponse({
+    status: 200,
+    description: "State history retrieved",
+    type: [RollStateHistory],
+  })
+  findByRollKey(
+    @Query("rollKey") rollKey: string,
+  ): Promise<RollStateHistory[]> {
     return this.rollStateService.findByRollKey(rollKey);
   }
 }

--- a/frollz-api/src/roll-state/roll-state.module.ts
+++ b/frollz-api/src/roll-state/roll-state.module.ts
@@ -1,6 +1,6 @@
-import { Module } from '@nestjs/common';
-import { RollStateService } from './roll-state.service';
-import { RollStateController } from './roll-state.controller';
+import { Module } from "@nestjs/common";
+import { RollStateService } from "./roll-state.service";
+import { RollStateController } from "./roll-state.controller";
 
 @Module({
   controllers: [RollStateController],

--- a/frollz-api/src/roll-state/roll-state.service.ts
+++ b/frollz-api/src/roll-state/roll-state.service.ts
@@ -1,17 +1,17 @@
-import { Injectable } from '@nestjs/common';
-import { DatabaseService } from '../database/database.service';
-import { CreateRollStateDto } from './dto/create-roll-state.dto';
-import { RollStateHistory } from './entities/roll-state.entity';
+import { Injectable } from "@nestjs/common";
+import { DatabaseService } from "../database/database.service";
+import { CreateRollStateDto } from "./dto/create-roll-state.dto";
+import { RollStateHistory } from "./entities/roll-state.entity";
 
 @Injectable()
 export class RollStateService {
   constructor(private readonly databaseService: DatabaseService) {}
 
   async create(dto: CreateRollStateDto): Promise<RollStateHistory> {
-    const collection = this.databaseService.getCollection('roll_states');
+    const collection = this.databaseService.getCollection("roll_states");
     const now = new Date();
 
-    const record: Omit<RollStateHistory, '_key'> = {
+    const record: Omit<RollStateHistory, "_key"> = {
       stateId: crypto.randomUUID(),
       rollId: dto.rollKey,
       state: dto.state,

--- a/frollz-api/src/roll/dto/create-roll.dto.ts
+++ b/frollz-api/src/roll/dto/create-roll.dto.ts
@@ -1,7 +1,14 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsEnum, IsString, IsDate, IsNumber, IsOptional, IsUrl } from 'class-validator';
-import { Type } from 'class-transformer';
-import { RollState, ObtainmentMethod } from '../entities/roll.entity';
+import { ApiProperty } from "@nestjs/swagger";
+import {
+  IsEnum,
+  IsString,
+  IsDate,
+  IsNumber,
+  IsOptional,
+  IsUrl,
+} from "class-validator";
+import { Type } from "class-transformer";
+import { RollState, ObtainmentMethod } from "../entities/roll.entity";
 
 export class CreateRollDto {
   @ApiProperty({ required: false })
@@ -22,7 +29,7 @@ export class CreateRollDto {
   @IsUrl()
   imagesUrl?: string;
 
-  @ApiProperty({ required: false, default: 'current date' })
+  @ApiProperty({ required: false, default: "current date" })
   @IsOptional()
   @IsDate()
   @Type(() => Date)

--- a/frollz-api/src/roll/dto/transition-roll.dto.ts
+++ b/frollz-api/src/roll/dto/transition-roll.dto.ts
@@ -1,6 +1,6 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsEnum, IsOptional, IsString } from 'class-validator';
-import { RollState } from '../entities/roll.entity';
+import { ApiProperty } from "@nestjs/swagger";
+import { IsEnum, IsOptional, IsString } from "class-validator";
+import { RollState } from "../entities/roll.entity";
 
 export class TransitionRollDto {
   @ApiProperty({ enum: RollState })

--- a/frollz-api/src/roll/dto/update-roll.dto.ts
+++ b/frollz-api/src/roll/dto/update-roll.dto.ts
@@ -1,4 +1,4 @@
-import { PartialType } from '@nestjs/swagger';
-import { CreateRollDto } from './create-roll.dto';
+import { PartialType } from "@nestjs/swagger";
+import { CreateRollDto } from "./create-roll.dto";
 
 export class UpdateRollDto extends PartialType(CreateRollDto) {}

--- a/frollz-api/src/roll/entities/roll.entity.ts
+++ b/frollz-api/src/roll/entities/roll.entity.ts
@@ -1,18 +1,18 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty } from "@nestjs/swagger";
 
 export enum RollState {
-  ADDED = 'Added',
-  FROZEN = 'Frozen',
-  REFRIGERATED = 'Refrigerated',
-  SHELFED = 'Shelved',
-  LOADED = 'Loaded',
-  FINISHED = 'Finished',
-  DEVELOPED = 'Developed',
+  ADDED = "Added",
+  FROZEN = "Frozen",
+  REFRIGERATED = "Refrigerated",
+  SHELFED = "Shelved",
+  LOADED = "Loaded",
+  FINISHED = "Finished",
+  DEVELOPED = "Developed",
 }
 
 export enum ObtainmentMethod {
-  GIFT = 'Gift',
-  PURCHASE = 'Purchase',
+  GIFT = "Gift",
+  PURCHASE = "Purchase",
 }
 
 export class Roll {

--- a/frollz-api/src/roll/roll.controller.ts
+++ b/frollz-api/src/roll/roll.controller.ts
@@ -1,91 +1,125 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete, NotFoundException, BadRequestException } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
-import { RollService } from './roll.service';
-import { CreateRollDto } from './dto/create-roll.dto';
-import { UpdateRollDto } from './dto/update-roll.dto';
-import { TransitionRollDto } from './dto/transition-roll.dto';
-import { Roll } from './entities/roll.entity';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  NotFoundException,
+  BadRequestException,
+} from "@nestjs/common";
+import { ApiTags, ApiOperation, ApiResponse } from "@nestjs/swagger";
+import { RollService } from "./roll.service";
+import { CreateRollDto } from "./dto/create-roll.dto";
+import { UpdateRollDto } from "./dto/update-roll.dto";
+import { TransitionRollDto } from "./dto/transition-roll.dto";
+import { Roll } from "./entities/roll.entity";
 
-@ApiTags('rolls')
-@Controller('rolls')
+@ApiTags("rolls")
+@Controller("rolls")
 export class RollController {
   constructor(private readonly rollService: RollService) {}
 
   @Post()
-  @ApiOperation({ summary: 'Create a new roll' })
-  @ApiResponse({ status: 201, description: 'Roll created successfully', type: Roll })
+  @ApiOperation({ summary: "Create a new roll" })
+  @ApiResponse({
+    status: 201,
+    description: "Roll created successfully",
+    type: Roll,
+  })
   create(@Body() createRollDto: CreateRollDto): Promise<Roll> {
     return this.rollService.create(createRollDto);
   }
 
-  @Get('next-id')
-  @ApiOperation({ summary: 'Get the next roll ID' })
-  @ApiResponse({ status: 200, description: 'Next roll ID' })
+  @Get("next-id")
+  @ApiOperation({ summary: "Get the next roll ID" })
+  @ApiResponse({ status: 200, description: "Next roll ID" })
   getNextId(): Promise<string> {
     return this.rollService.getNextId();
   }
 
   @Get()
-  @ApiOperation({ summary: 'Get all rolls' })
-  @ApiResponse({ status: 200, description: 'Rolls retrieved successfully', type: [Roll] })
+  @ApiOperation({ summary: "Get all rolls" })
+  @ApiResponse({
+    status: 200,
+    description: "Rolls retrieved successfully",
+    type: [Roll],
+  })
   findAll(): Promise<Roll[]> {
     return this.rollService.findAll();
   }
 
-  @Get(':key')
-  @ApiOperation({ summary: 'Get a roll by key' })
-  @ApiResponse({ status: 200, description: 'Roll retrieved successfully', type: Roll })
-  @ApiResponse({ status: 404, description: 'Roll not found' })
-  async findOne(@Param('key') key: string): Promise<Roll> {
+  @Get(":key")
+  @ApiOperation({ summary: "Get a roll by key" })
+  @ApiResponse({
+    status: 200,
+    description: "Roll retrieved successfully",
+    type: Roll,
+  })
+  @ApiResponse({ status: 404, description: "Roll not found" })
+  async findOne(@Param("key") key: string): Promise<Roll> {
     const roll = await this.rollService.findOne(key);
     if (!roll) {
-      throw new NotFoundException('Roll not found');
+      throw new NotFoundException("Roll not found");
     }
     return roll;
   }
 
-  @Patch(':key')
-  @ApiOperation({ summary: 'Update a roll' })
-  @ApiResponse({ status: 200, description: 'Roll updated successfully', type: Roll })
-  @ApiResponse({ status: 404, description: 'Roll not found' })
-  async update(@Param('key') key: string, @Body() updateRollDto: UpdateRollDto): Promise<Roll> {
+  @Patch(":key")
+  @ApiOperation({ summary: "Update a roll" })
+  @ApiResponse({
+    status: 200,
+    description: "Roll updated successfully",
+    type: Roll,
+  })
+  @ApiResponse({ status: 404, description: "Roll not found" })
+  async update(
+    @Param("key") key: string,
+    @Body() updateRollDto: UpdateRollDto,
+  ): Promise<Roll> {
     const roll = await this.rollService.update(key, updateRollDto);
     if (!roll) {
-      throw new NotFoundException('Roll not found');
+      throw new NotFoundException("Roll not found");
     }
     return roll;
   }
 
-  @Delete(':key')
-  @ApiOperation({ summary: 'Delete a roll' })
-  @ApiResponse({ status: 200, description: 'Roll deleted successfully' })
-  @ApiResponse({ status: 404, description: 'Roll not found' })
-  async remove(@Param('key') key: string): Promise<{ message: string }> {
+  @Delete(":key")
+  @ApiOperation({ summary: "Delete a roll" })
+  @ApiResponse({ status: 200, description: "Roll deleted successfully" })
+  @ApiResponse({ status: 404, description: "Roll not found" })
+  async remove(@Param("key") key: string): Promise<{ message: string }> {
     const deleted = await this.rollService.remove(key);
     if (!deleted) {
-      throw new NotFoundException('Roll not found');
+      throw new NotFoundException("Roll not found");
     }
-    return { message: 'Roll deleted successfully' };
+    return { message: "Roll deleted successfully" };
   }
 
-  @Post(':key/transition')
-  @ApiOperation({ summary: 'Transition a roll to a new storage state' })
-  @ApiResponse({ status: 200, description: 'Roll transitioned successfully', type: Roll })
-  @ApiResponse({ status: 400, description: 'Invalid state transition' })
-  @ApiResponse({ status: 404, description: 'Roll not found' })
+  @Post(":key/transition")
+  @ApiOperation({ summary: "Transition a roll to a new storage state" })
+  @ApiResponse({
+    status: 200,
+    description: "Roll transitioned successfully",
+    type: Roll,
+  })
+  @ApiResponse({ status: 400, description: "Invalid state transition" })
+  @ApiResponse({ status: 404, description: "Roll not found" })
   async transition(
-    @Param('key') key: string,
+    @Param("key") key: string,
     @Body() transitionRollDto: TransitionRollDto,
   ): Promise<Roll> {
     try {
       const roll = await this.rollService.transition(key, transitionRollDto);
       if (!roll) {
-        throw new NotFoundException('Roll not found');
+        throw new NotFoundException("Roll not found");
       }
       return roll;
     } catch (e) {
-      if (e instanceof NotFoundException || e instanceof BadRequestException) throw e;
-      throw new NotFoundException('Roll not found');
+      if (e instanceof NotFoundException || e instanceof BadRequestException)
+        throw e;
+      throw new NotFoundException("Roll not found");
     }
   }
 }

--- a/frollz-api/src/roll/roll.module.ts
+++ b/frollz-api/src/roll/roll.module.ts
@@ -1,7 +1,7 @@
-import { Module } from '@nestjs/common';
-import { RollService } from './roll.service';
-import { RollController } from './roll.controller';
-import { RollStateModule } from '../roll-state/roll-state.module';
+import { Module } from "@nestjs/common";
+import { RollService } from "./roll.service";
+import { RollController } from "./roll.controller";
+import { RollStateModule } from "../roll-state/roll-state.module";
 
 @Module({
   imports: [RollStateModule],

--- a/frollz-api/src/roll/roll.service.ts
+++ b/frollz-api/src/roll/roll.service.ts
@@ -1,15 +1,25 @@
-import { Injectable, BadRequestException } from '@nestjs/common';
-import { DatabaseService } from '../database/database.service';
-import { CreateRollDto } from './dto/create-roll.dto';
-import { UpdateRollDto } from './dto/update-roll.dto';
-import { TransitionRollDto } from './dto/transition-roll.dto';
-import { Roll, RollState } from './entities/roll.entity';
-import { RollStateService } from '../roll-state/roll-state.service';
+import { Injectable, BadRequestException } from "@nestjs/common";
+import { DatabaseService } from "../database/database.service";
+import { CreateRollDto } from "./dto/create-roll.dto";
+import { UpdateRollDto } from "./dto/update-roll.dto";
+import { TransitionRollDto } from "./dto/transition-roll.dto";
+import { Roll, RollState } from "./entities/roll.entity";
+import { RollStateService } from "../roll-state/roll-state.service";
 
-const STORAGE_TRANSITIONS: Partial<Record<RollState, RollState[]>> = {
-  [RollState.ADDED]: [RollState.FROZEN, RollState.REFRIGERATED, RollState.SHELFED],
-  [RollState.FROZEN]: [RollState.REFRIGERATED, RollState.SHELFED, RollState.ADDED],
+const VALID_TRANSITIONS: Partial<Record<RollState, RollState[]>> = {
+  [RollState.ADDED]: [
+    RollState.FROZEN,
+    RollState.REFRIGERATED,
+    RollState.SHELFED,
+  ],
+  [RollState.FROZEN]: [
+    RollState.REFRIGERATED,
+    RollState.SHELFED,
+    RollState.ADDED,
+  ],
   [RollState.REFRIGERATED]: [RollState.SHELFED, RollState.ADDED],
+  [RollState.SHELFED]: [RollState.LOADED],
+  [RollState.LOADED]: [RollState.FINISHED, RollState.SHELFED],
 };
 
 @Injectable()
@@ -20,7 +30,7 @@ export class RollService {
   ) {}
 
   async create(createRollDto: CreateRollDto): Promise<Roll> {
-    const collection = this.databaseService.getCollection('rolls');
+    const collection = this.databaseService.getCollection("rolls");
 
     const dateObtained = createRollDto.dateObtained ?? new Date();
 
@@ -31,9 +41,10 @@ export class RollService {
         { key: createRollDto.stockKey },
       );
       const stocks = await stockCursor.all();
-      const stockName = stocks.length > 0
-        ? (stocks[0].brand as string).toLowerCase().replace(/\s+/g, '-')
-        : 'unknown';
+      const stockName =
+        stocks.length > 0
+          ? (stocks[0].brand as string).toLowerCase().replace(/\s+/g, "-")
+          : "unknown";
       const datePart = dateObtained.toISOString().slice(0, 10);
       rollId = `roll-${stockName}-${datePart}`;
     }
@@ -56,7 +67,7 @@ export class RollService {
     `);
     const results = await cursor.all();
     const count = results[0] as number;
-    return String(count + 1).padStart(5, '0');
+    return String(count + 1).padStart(5, "0");
   }
 
   async findAll(): Promise<Roll[]> {
@@ -64,24 +75,30 @@ export class RollService {
       FOR roll IN rolls
       RETURN roll
     `);
-    
+
     return await cursor.all();
   }
 
   async findOne(key: string): Promise<Roll | null> {
-    const cursor = await this.databaseService.query(`
+    const cursor = await this.databaseService.query(
+      `
       FOR roll IN rolls
       FILTER roll._key == @key
       RETURN roll
-    `, { key });
+    `,
+      { key },
+    );
 
     const results = await cursor.all();
     return results.length > 0 ? results[0] : null;
   }
 
-  async update(key: string, updateRollDto: UpdateRollDto): Promise<Roll | null> {
-    const collection = this.databaseService.getCollection('rolls');
-    
+  async update(
+    key: string,
+    updateRollDto: UpdateRollDto,
+  ): Promise<Roll | null> {
+    const collection = this.databaseService.getCollection("rolls");
+
     const updateData = {
       ...updateRollDto,
       updatedAt: new Date(),
@@ -90,18 +107,18 @@ export class RollService {
     try {
       await collection.update(key, updateData);
       return await this.findOne(key);
-    } catch (error) {
+    } catch {
       return null;
     }
   }
 
   async remove(key: string): Promise<boolean> {
-    const collection = this.databaseService.getCollection('rolls');
+    const collection = this.databaseService.getCollection("rolls");
 
     try {
       await collection.remove(key);
       return true;
-    } catch (error) {
+    } catch {
       return false;
     }
   }
@@ -110,7 +127,7 @@ export class RollService {
     const roll = await this.findOne(key);
     if (!roll) return null;
 
-    const allowed = STORAGE_TRANSITIONS[roll.state];
+    const allowed = VALID_TRANSITIONS[roll.state];
     if (!allowed || !allowed.includes(dto.targetState)) {
       throw new BadRequestException(
         `Cannot transition from ${roll.state} to ${dto.targetState}`,

--- a/frollz-api/src/stock-tag/dto/create-stock-tag.dto.ts
+++ b/frollz-api/src/stock-tag/dto/create-stock-tag.dto.ts
@@ -1,5 +1,5 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsString, MinLength } from 'class-validator';
+import { ApiProperty } from "@nestjs/swagger";
+import { IsString, MinLength } from "class-validator";
 
 export class CreateStockTagDto {
   @ApiProperty()

--- a/frollz-api/src/stock-tag/entities/stock-tag.entity.ts
+++ b/frollz-api/src/stock-tag/entities/stock-tag.entity.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty } from "@nestjs/swagger";
 
 export class StockTag {
   @ApiProperty()

--- a/frollz-api/src/stock-tag/stock-tag.controller.spec.ts
+++ b/frollz-api/src/stock-tag/stock-tag.controller.spec.ts
@@ -1,16 +1,16 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { NotFoundException } from '@nestjs/common';
-import { StockTagController } from './stock-tag.controller';
-import { StockTagService } from './stock-tag.service';
+import { Test, TestingModule } from "@nestjs/testing";
+import { NotFoundException } from "@nestjs/common";
+import { StockTagController } from "./stock-tag.controller";
+import { StockTagService } from "./stock-tag.service";
 
-describe('StockTagController', () => {
+describe("StockTagController", () => {
   let controller: StockTagController;
   let service: jest.Mocked<StockTagService>;
 
   const mockStockTag = {
-    _key: 'abc123',
-    stockKey: 'kodak-portra-400-35mm',
-    tagKey: 'color',
+    _key: "abc123",
+    stockKey: "kodak-portra-400-35mm",
+    tagKey: "color",
   };
 
   beforeEach(async () => {
@@ -37,47 +37,50 @@ describe('StockTagController', () => {
 
   afterEach(() => jest.clearAllMocks());
 
-  describe('create', () => {
-    it('should return the created stock-tag association', async () => {
+  describe("create", () => {
+    it("should return the created stock-tag association", async () => {
       service.create.mockResolvedValue(mockStockTag);
 
       const result = await controller.create({
-        stockKey: 'kodak-portra-400-35mm',
-        tagKey: 'color',
+        stockKey: "kodak-portra-400-35mm",
+        tagKey: "color",
       });
 
       expect(service.create).toHaveBeenCalledWith({
-        stockKey: 'kodak-portra-400-35mm',
-        tagKey: 'color',
+        stockKey: "kodak-portra-400-35mm",
+        tagKey: "color",
       });
       expect(result).toEqual(mockStockTag);
     });
   });
 
-  describe('findAll', () => {
-    it('should call findByStock when stockKey query param is provided', async () => {
+  describe("findAll", () => {
+    it("should call findByStock when stockKey query param is provided", async () => {
       service.findByStock.mockResolvedValue([mockStockTag]);
 
-      const result = await controller.findAll('kodak-portra-400-35mm', undefined);
+      const result = await controller.findAll(
+        "kodak-portra-400-35mm",
+        undefined,
+      );
 
-      expect(service.findByStock).toHaveBeenCalledWith('kodak-portra-400-35mm');
+      expect(service.findByStock).toHaveBeenCalledWith("kodak-portra-400-35mm");
       expect(service.findByTag).not.toHaveBeenCalled();
       expect(service.findAll).not.toHaveBeenCalled();
       expect(result).toEqual([mockStockTag]);
     });
 
-    it('should call findByTag when tagKey query param is provided', async () => {
+    it("should call findByTag when tagKey query param is provided", async () => {
       service.findByTag.mockResolvedValue([mockStockTag]);
 
-      const result = await controller.findAll(undefined, 'color');
+      const result = await controller.findAll(undefined, "color");
 
-      expect(service.findByTag).toHaveBeenCalledWith('color');
+      expect(service.findByTag).toHaveBeenCalledWith("color");
       expect(service.findByStock).not.toHaveBeenCalled();
       expect(service.findAll).not.toHaveBeenCalled();
       expect(result).toEqual([mockStockTag]);
     });
 
-    it('should call findAll when no filter params are provided', async () => {
+    it("should call findAll when no filter params are provided", async () => {
       service.findAll.mockResolvedValue([mockStockTag]);
 
       const result = await controller.findAll(undefined, undefined);
@@ -88,45 +91,49 @@ describe('StockTagController', () => {
       expect(result).toEqual([mockStockTag]);
     });
 
-    it('should prefer stockKey over tagKey when both are provided', async () => {
+    it("should prefer stockKey over tagKey when both are provided", async () => {
       service.findByStock.mockResolvedValue([mockStockTag]);
 
-      await controller.findAll('kodak-portra-400-35mm', 'color');
+      await controller.findAll("kodak-portra-400-35mm", "color");
 
       expect(service.findByStock).toHaveBeenCalled();
       expect(service.findByTag).not.toHaveBeenCalled();
     });
   });
 
-  describe('findOne', () => {
-    it('should return the stock-tag when found', async () => {
+  describe("findOne", () => {
+    it("should return the stock-tag when found", async () => {
       service.findOne.mockResolvedValue(mockStockTag);
 
-      const result = await controller.findOne('abc123');
+      const result = await controller.findOne("abc123");
 
       expect(result).toEqual(mockStockTag);
     });
 
-    it('should throw NotFoundException when not found', async () => {
+    it("should throw NotFoundException when not found", async () => {
       service.findOne.mockResolvedValue(null);
 
-      await expect(controller.findOne('nonexistent')).rejects.toThrow(NotFoundException);
+      await expect(controller.findOne("nonexistent")).rejects.toThrow(
+        NotFoundException,
+      );
     });
   });
 
-  describe('remove', () => {
-    it('should return a success message when deleted', async () => {
+  describe("remove", () => {
+    it("should return a success message when deleted", async () => {
       service.remove.mockResolvedValue(true);
 
-      const result = await controller.remove('abc123');
+      const result = await controller.remove("abc123");
 
-      expect(result).toEqual({ message: 'StockTag deleted successfully' });
+      expect(result).toEqual({ message: "StockTag deleted successfully" });
     });
 
-    it('should throw NotFoundException when not found', async () => {
+    it("should throw NotFoundException when not found", async () => {
       service.remove.mockResolvedValue(false);
 
-      await expect(controller.remove('nonexistent')).rejects.toThrow(NotFoundException);
+      await expect(controller.remove("nonexistent")).rejects.toThrow(
+        NotFoundException,
+      );
     });
   });
 });

--- a/frollz-api/src/stock-tag/stock-tag.controller.ts
+++ b/frollz-api/src/stock-tag/stock-tag.controller.ts
@@ -1,56 +1,79 @@
-import { Controller, Get, Post, Body, Param, Delete, NotFoundException, Query } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiQuery } from '@nestjs/swagger';
-import { StockTagService } from './stock-tag.service';
-import { CreateStockTagDto } from './dto/create-stock-tag.dto';
-import { StockTag } from './entities/stock-tag.entity';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Param,
+  Delete,
+  NotFoundException,
+  Query,
+} from "@nestjs/common";
+import { ApiTags, ApiOperation, ApiResponse, ApiQuery } from "@nestjs/swagger";
+import { StockTagService } from "./stock-tag.service";
+import { CreateStockTagDto } from "./dto/create-stock-tag.dto";
+import { StockTag } from "./entities/stock-tag.entity";
 
-@ApiTags('stock-tags')
-@Controller('stock-tags')
+@ApiTags("stock-tags")
+@Controller("stock-tags")
 export class StockTagController {
   constructor(private readonly stockTagService: StockTagService) {}
 
   @Post()
-  @ApiOperation({ summary: 'Associate a tag with a stock' })
-  @ApiResponse({ status: 201, description: 'StockTag created successfully', type: StockTag })
+  @ApiOperation({ summary: "Associate a tag with a stock" })
+  @ApiResponse({
+    status: 201,
+    description: "StockTag created successfully",
+    type: StockTag,
+  })
   create(@Body() createStockTagDto: CreateStockTagDto): Promise<StockTag> {
     return this.stockTagService.create(createStockTagDto);
   }
 
   @Get()
-  @ApiOperation({ summary: 'Get all stock-tag associations, optionally filtered' })
-  @ApiResponse({ status: 200, description: 'StockTags retrieved successfully', type: [StockTag] })
-  @ApiQuery({ name: 'stockKey', required: false })
-  @ApiQuery({ name: 'tagKey', required: false })
+  @ApiOperation({
+    summary: "Get all stock-tag associations, optionally filtered",
+  })
+  @ApiResponse({
+    status: 200,
+    description: "StockTags retrieved successfully",
+    type: [StockTag],
+  })
+  @ApiQuery({ name: "stockKey", required: false })
+  @ApiQuery({ name: "tagKey", required: false })
   findAll(
-    @Query('stockKey') stockKey?: string,
-    @Query('tagKey') tagKey?: string,
+    @Query("stockKey") stockKey?: string,
+    @Query("tagKey") tagKey?: string,
   ): Promise<StockTag[]> {
     if (stockKey) return this.stockTagService.findByStock(stockKey);
     if (tagKey) return this.stockTagService.findByTag(tagKey);
     return this.stockTagService.findAll();
   }
 
-  @Get(':key')
-  @ApiOperation({ summary: 'Get a stock-tag association by key' })
-  @ApiResponse({ status: 200, description: 'StockTag retrieved successfully', type: StockTag })
-  @ApiResponse({ status: 404, description: 'StockTag not found' })
-  async findOne(@Param('key') key: string): Promise<StockTag> {
+  @Get(":key")
+  @ApiOperation({ summary: "Get a stock-tag association by key" })
+  @ApiResponse({
+    status: 200,
+    description: "StockTag retrieved successfully",
+    type: StockTag,
+  })
+  @ApiResponse({ status: 404, description: "StockTag not found" })
+  async findOne(@Param("key") key: string): Promise<StockTag> {
     const stockTag = await this.stockTagService.findOne(key);
     if (!stockTag) {
-      throw new NotFoundException('StockTag not found');
+      throw new NotFoundException("StockTag not found");
     }
     return stockTag;
   }
 
-  @Delete(':key')
-  @ApiOperation({ summary: 'Remove a stock-tag association' })
-  @ApiResponse({ status: 200, description: 'StockTag deleted successfully' })
-  @ApiResponse({ status: 404, description: 'StockTag not found' })
-  async remove(@Param('key') key: string): Promise<{ message: string }> {
+  @Delete(":key")
+  @ApiOperation({ summary: "Remove a stock-tag association" })
+  @ApiResponse({ status: 200, description: "StockTag deleted successfully" })
+  @ApiResponse({ status: 404, description: "StockTag not found" })
+  async remove(@Param("key") key: string): Promise<{ message: string }> {
     const deleted = await this.stockTagService.remove(key);
     if (!deleted) {
-      throw new NotFoundException('StockTag not found');
+      throw new NotFoundException("StockTag not found");
     }
-    return { message: 'StockTag deleted successfully' };
+    return { message: "StockTag deleted successfully" };
   }
 }

--- a/frollz-api/src/stock-tag/stock-tag.module.ts
+++ b/frollz-api/src/stock-tag/stock-tag.module.ts
@@ -1,6 +1,6 @@
-import { Module } from '@nestjs/common';
-import { StockTagService } from './stock-tag.service';
-import { StockTagController } from './stock-tag.controller';
+import { Module } from "@nestjs/common";
+import { StockTagService } from "./stock-tag.service";
+import { StockTagController } from "./stock-tag.controller";
 
 @Module({
   controllers: [StockTagController],

--- a/frollz-api/src/stock-tag/stock-tag.service.spec.ts
+++ b/frollz-api/src/stock-tag/stock-tag.service.spec.ts
@@ -1,8 +1,8 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { StockTagService } from './stock-tag.service';
-import { DatabaseService } from '../database/database.service';
+import { Test, TestingModule } from "@nestjs/testing";
+import { StockTagService } from "./stock-tag.service";
+import { DatabaseService } from "../database/database.service";
 
-describe('StockTagService', () => {
+describe("StockTagService", () => {
   let service: StockTagService;
   let databaseService: { getCollection: jest.Mock; query: jest.Mock };
 
@@ -33,40 +33,45 @@ describe('StockTagService', () => {
 
   afterEach(() => jest.clearAllMocks());
 
-  describe('create', () => {
-    it('should save a stock-tag with createdAt and return it with _key', async () => {
-      mockCollection.save.mockResolvedValue({ _key: 'abc123' });
+  describe("create", () => {
+    it("should save a stock-tag with createdAt and return it with _key", async () => {
+      mockCollection.save.mockResolvedValue({ _key: "abc123" });
 
       const result = await service.create({
-        stockKey: 'kodak-portra-400-35mm',
-        tagKey: 'color',
+        stockKey: "kodak-portra-400-35mm",
+        tagKey: "color",
       });
 
       expect(mockCollection.save).toHaveBeenCalledWith(
         expect.objectContaining({
-          stockKey: 'kodak-portra-400-35mm',
-          tagKey: 'color',
+          stockKey: "kodak-portra-400-35mm",
+          tagKey: "color",
           createdAt: expect.any(Date),
         }),
       );
-      expect(result._key).toBe('abc123');
-      expect(result.stockKey).toBe('kodak-portra-400-35mm');
-      expect(result.tagKey).toBe('color');
+      expect(result._key).toBe("abc123");
+      expect(result.stockKey).toBe("kodak-portra-400-35mm");
+      expect(result.tagKey).toBe("color");
     });
 
-    it('should not include updatedAt in the saved document', async () => {
-      mockCollection.save.mockResolvedValue({ _key: 'abc123' });
+    it("should not include updatedAt in the saved document", async () => {
+      mockCollection.save.mockResolvedValue({ _key: "abc123" });
 
-      await service.create({ stockKey: 'kodak-portra-400-35mm', tagKey: 'color' });
+      await service.create({
+        stockKey: "kodak-portra-400-35mm",
+        tagKey: "color",
+      });
 
       const savedDoc = mockCollection.save.mock.calls[0][0];
-      expect(savedDoc).not.toHaveProperty('updatedAt');
+      expect(savedDoc).not.toHaveProperty("updatedAt");
     });
   });
 
-  describe('findAll', () => {
-    it('should return all stock-tag associations', async () => {
-      const stockTags = [{ _key: 'abc', stockKey: 'kodak-portra-400-35mm', tagKey: 'color' }];
+  describe("findAll", () => {
+    it("should return all stock-tag associations", async () => {
+      const stockTags = [
+        { _key: "abc", stockKey: "kodak-portra-400-35mm", tagKey: "color" },
+      ];
       mockCursor.all.mockResolvedValue(stockTags);
 
       const result = await service.findAll();
@@ -75,76 +80,84 @@ describe('StockTagService', () => {
     });
   });
 
-  describe('findByStock', () => {
-    it('should query filtered by stockKey', async () => {
+  describe("findByStock", () => {
+    it("should query filtered by stockKey", async () => {
       mockCursor.all.mockResolvedValue([]);
 
-      await service.findByStock('kodak-portra-400-35mm');
+      await service.findByStock("kodak-portra-400-35mm");
 
       expect(databaseService.query).toHaveBeenCalledWith(
-        expect.stringContaining('st.stockKey == @stockKey'),
-        { stockKey: 'kodak-portra-400-35mm' },
+        expect.stringContaining("st.stockKey == @stockKey"),
+        { stockKey: "kodak-portra-400-35mm" },
       );
     });
 
-    it('should return the filtered results', async () => {
-      const stockTags = [{ _key: 'abc', stockKey: 'kodak-portra-400-35mm', tagKey: 'color' }];
+    it("should return the filtered results", async () => {
+      const stockTags = [
+        { _key: "abc", stockKey: "kodak-portra-400-35mm", tagKey: "color" },
+      ];
       mockCursor.all.mockResolvedValue(stockTags);
 
-      const result = await service.findByStock('kodak-portra-400-35mm');
+      const result = await service.findByStock("kodak-portra-400-35mm");
 
       expect(result).toEqual(stockTags);
     });
   });
 
-  describe('findByTag', () => {
-    it('should query filtered by tagKey', async () => {
+  describe("findByTag", () => {
+    it("should query filtered by tagKey", async () => {
       mockCursor.all.mockResolvedValue([]);
 
-      await service.findByTag('color');
+      await service.findByTag("color");
 
       expect(databaseService.query).toHaveBeenCalledWith(
-        expect.stringContaining('st.tagKey == @tagKey'),
-        { tagKey: 'color' },
+        expect.stringContaining("st.tagKey == @tagKey"),
+        { tagKey: "color" },
       );
     });
 
-    it('should return the filtered results', async () => {
-      const stockTags = [{ _key: 'abc', stockKey: 'kodak-portra-400-35mm', tagKey: 'color' }];
+    it("should return the filtered results", async () => {
+      const stockTags = [
+        { _key: "abc", stockKey: "kodak-portra-400-35mm", tagKey: "color" },
+      ];
       mockCursor.all.mockResolvedValue(stockTags);
 
-      const result = await service.findByTag('color');
+      const result = await service.findByTag("color");
 
       expect(result).toEqual(stockTags);
     });
   });
 
-  describe('findOne', () => {
-    it('should return the stock-tag when found', async () => {
-      const st = { _key: 'abc', stockKey: 'kodak-portra-400-35mm', tagKey: 'color' };
+  describe("findOne", () => {
+    it("should return the stock-tag when found", async () => {
+      const st = {
+        _key: "abc",
+        stockKey: "kodak-portra-400-35mm",
+        tagKey: "color",
+      };
       mockCursor.all.mockResolvedValue([st]);
 
-      expect(await service.findOne('abc')).toEqual(st);
+      expect(await service.findOne("abc")).toEqual(st);
     });
 
-    it('should return null when not found', async () => {
+    it("should return null when not found", async () => {
       mockCursor.all.mockResolvedValue([]);
 
-      expect(await service.findOne('nonexistent')).toBeNull();
+      expect(await service.findOne("nonexistent")).toBeNull();
     });
   });
 
-  describe('remove', () => {
-    it('should return true on successful removal', async () => {
+  describe("remove", () => {
+    it("should return true on successful removal", async () => {
       mockCollection.remove.mockResolvedValue({});
 
-      expect(await service.remove('abc')).toBe(true);
+      expect(await service.remove("abc")).toBe(true);
     });
 
-    it('should return false when removal throws', async () => {
-      mockCollection.remove.mockRejectedValue(new Error('document not found'));
+    it("should return false when removal throws", async () => {
+      mockCollection.remove.mockRejectedValue(new Error("document not found"));
 
-      expect(await service.remove('nonexistent')).toBe(false);
+      expect(await service.remove("nonexistent")).toBe(false);
     });
   });
 });

--- a/frollz-api/src/stock-tag/stock-tag.service.ts
+++ b/frollz-api/src/stock-tag/stock-tag.service.ts
@@ -1,14 +1,14 @@
-import { Injectable } from '@nestjs/common';
-import { DatabaseService } from '../database/database.service';
-import { CreateStockTagDto } from './dto/create-stock-tag.dto';
-import { StockTag } from './entities/stock-tag.entity';
+import { Injectable } from "@nestjs/common";
+import { DatabaseService } from "../database/database.service";
+import { CreateStockTagDto } from "./dto/create-stock-tag.dto";
+import { StockTag } from "./entities/stock-tag.entity";
 
 @Injectable()
 export class StockTagService {
   constructor(private readonly databaseService: DatabaseService) {}
 
   async create(createStockTagDto: CreateStockTagDto): Promise<StockTag> {
-    const collection = this.databaseService.getCollection('stock_tags');
+    const collection = this.databaseService.getCollection("stock_tags");
 
     const stockTag = {
       ...createStockTagDto,
@@ -28,41 +28,50 @@ export class StockTagService {
   }
 
   async findByStock(stockKey: string): Promise<StockTag[]> {
-    const cursor = await this.databaseService.query(`
+    const cursor = await this.databaseService.query(
+      `
       FOR st IN stock_tags
       FILTER st.stockKey == @stockKey
       RETURN st
-    `, { stockKey });
+    `,
+      { stockKey },
+    );
     return await cursor.all();
   }
 
   async findByTag(tagKey: string): Promise<StockTag[]> {
-    const cursor = await this.databaseService.query(`
+    const cursor = await this.databaseService.query(
+      `
       FOR st IN stock_tags
       FILTER st.tagKey == @tagKey
       RETURN st
-    `, { tagKey });
+    `,
+      { tagKey },
+    );
     return await cursor.all();
   }
 
   async findOne(key: string): Promise<StockTag | null> {
-    const cursor = await this.databaseService.query(`
+    const cursor = await this.databaseService.query(
+      `
       FOR st IN stock_tags
       FILTER st._key == @key
       RETURN st
-    `, { key });
+    `,
+      { key },
+    );
 
     const results = await cursor.all();
     return results.length > 0 ? results[0] : null;
   }
 
   async remove(key: string): Promise<boolean> {
-    const collection = this.databaseService.getCollection('stock_tags');
+    const collection = this.databaseService.getCollection("stock_tags");
 
     try {
       await collection.remove(key);
       return true;
-    } catch (error) {
+    } catch {
       return false;
     }
   }

--- a/frollz-api/src/stock/dto/create-stock-multiple-formats.dto.ts
+++ b/frollz-api/src/stock/dto/create-stock-multiple-formats.dto.ts
@@ -1,11 +1,22 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsEnum, IsString, IsNumber, IsOptional, IsUrl, IsArray, ArrayMinSize } from 'class-validator';
-import { Process } from '../entities/stock.entity';
+import { ApiProperty } from "@nestjs/swagger";
+import {
+  IsEnum,
+  IsString,
+  IsNumber,
+  IsOptional,
+  IsUrl,
+  IsArray,
+  ArrayMinSize,
+} from "class-validator";
+import { Process } from "../entities/stock.entity";
 
 export class CreateStockMultipleFormatsDto {
-  @ApiProperty({ type: [String], description: 'Array of format keys to create stocks for' })
+  @ApiProperty({
+    type: [String],
+    description: "Array of format keys to create stocks for",
+  })
   @IsArray()
-  @ArrayMinSize(1, { message: 'At least one format must be selected' })
+  @ArrayMinSize(1, { message: "At least one format must be selected" })
   @IsString({ each: true })
   formatKeys: string[];
 

--- a/frollz-api/src/stock/dto/create-stock.dto.ts
+++ b/frollz-api/src/stock/dto/create-stock.dto.ts
@@ -1,6 +1,6 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsEnum, IsString, IsNumber, IsOptional, IsUrl } from 'class-validator';
-import { Process } from '../entities/stock.entity';
+import { ApiProperty } from "@nestjs/swagger";
+import { IsEnum, IsString, IsNumber, IsOptional, IsUrl } from "class-validator";
+import { Process } from "../entities/stock.entity";
 
 export class CreateStockDto {
   @ApiProperty()

--- a/frollz-api/src/stock/dto/update-stock.dto.ts
+++ b/frollz-api/src/stock/dto/update-stock.dto.ts
@@ -1,4 +1,4 @@
-import { PartialType } from '@nestjs/swagger';
-import { CreateStockDto } from './create-stock.dto';
+import { PartialType } from "@nestjs/swagger";
+import { CreateStockDto } from "./create-stock.dto";
 
 export class UpdateStockDto extends PartialType(CreateStockDto) {}

--- a/frollz-api/src/stock/entities/stock.entity.ts
+++ b/frollz-api/src/stock/entities/stock.entity.ts
@@ -1,10 +1,10 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty } from "@nestjs/swagger";
 
 export enum Process {
-  ECN_2 = 'ECN-2',
-  E_6 = 'E-6',
-  C_41 = 'C-41',
-  BLACK_WHITE = 'Black & White',
+  ECN_2 = "ECN-2",
+  E_6 = "E-6",
+  C_41 = "C-41",
+  BLACK_WHITE = "Black & White",
 }
 
 export class Stock {

--- a/frollz-api/src/stock/stock.controller.spec.ts
+++ b/frollz-api/src/stock/stock.controller.spec.ts
@@ -1,20 +1,20 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { NotFoundException } from '@nestjs/common';
-import { StockController } from './stock.controller';
-import { StockService } from './stock.service';
-import { Process } from './entities/stock.entity';
+import { Test, TestingModule } from "@nestjs/testing";
+import { NotFoundException } from "@nestjs/common";
+import { StockController } from "./stock.controller";
+import { StockService } from "./stock.service";
+import { Process } from "./entities/stock.entity";
 
-describe('StockController', () => {
+describe("StockController", () => {
   let controller: StockController;
   let service: jest.Mocked<StockService>;
 
   const mockStock = {
-    _key: 'kodak-portra-400-35mm',
-    brand: 'Portra 400',
-    manufacturer: 'Kodak',
-    formatKey: '35mm',
-    format: '35mm',
-    process: 'C-41' as any,
+    _key: "kodak-portra-400-35mm",
+    brand: "Portra 400",
+    manufacturer: "Kodak",
+    formatKey: "35mm",
+    format: "35mm",
+    process: "C-41" as any,
     speed: 400,
   };
 
@@ -45,19 +45,19 @@ describe('StockController', () => {
 
   afterEach(() => jest.clearAllMocks());
 
-  describe('createMultipleFormats', () => {
+  describe("createMultipleFormats", () => {
     const dto = {
-      formatKeys: ['35mm', '120'],
+      formatKeys: ["35mm", "120"],
       process: Process.C_41,
-      manufacturer: 'Kodak',
-      brand: 'Portra 400',
+      manufacturer: "Kodak",
+      brand: "Portra 400",
       speed: 400,
     };
 
-    it('should delegate to the service and return its result', async () => {
+    it("should delegate to the service and return its result", async () => {
       const createdStocks = [
-        { ...mockStock, _key: 'kodak-portra-400-400-35mm' },
-        { ...mockStock, _key: 'kodak-portra-400-400-120', formatKey: '120' },
+        { ...mockStock, _key: "kodak-portra-400-400-35mm" },
+        { ...mockStock, _key: "kodak-portra-400-400-120", formatKey: "120" },
       ];
       service.createMultipleFormats.mockResolvedValue(createdStocks);
 
@@ -68,116 +68,120 @@ describe('StockController', () => {
     });
   });
 
-  describe('getBrands', () => {
-    it('should return brands from the service', async () => {
-      service.getBrands.mockResolvedValue(['Portra 400', 'Portra 800']);
+  describe("getBrands", () => {
+    it("should return brands from the service", async () => {
+      service.getBrands.mockResolvedValue(["Portra 400", "Portra 800"]);
 
-      const result = await controller.getBrands('por');
+      const result = await controller.getBrands("por");
 
-      expect(service.getBrands).toHaveBeenCalledWith('por');
-      expect(result).toEqual(['Portra 400', 'Portra 800']);
+      expect(service.getBrands).toHaveBeenCalledWith("por");
+      expect(result).toEqual(["Portra 400", "Portra 800"]);
     });
 
-    it('should pass empty string when q is undefined', async () => {
+    it("should pass empty string when q is undefined", async () => {
       service.getBrands.mockResolvedValue([]);
 
       await controller.getBrands(undefined as any);
 
-      expect(service.getBrands).toHaveBeenCalledWith('');
+      expect(service.getBrands).toHaveBeenCalledWith("");
     });
 
-    it('should return an empty array when no brands match', async () => {
+    it("should return an empty array when no brands match", async () => {
       service.getBrands.mockResolvedValue([]);
 
-      const result = await controller.getBrands('zzz');
+      const result = await controller.getBrands("zzz");
 
       expect(result).toEqual([]);
     });
   });
 
-  describe('getManufacturers', () => {
-    it('should return manufacturers from the service', async () => {
-      service.getManufacturers.mockResolvedValue(['Kodak', 'Konica']);
+  describe("getManufacturers", () => {
+    it("should return manufacturers from the service", async () => {
+      service.getManufacturers.mockResolvedValue(["Kodak", "Konica"]);
 
-      const result = await controller.getManufacturers('ko');
+      const result = await controller.getManufacturers("ko");
 
-      expect(service.getManufacturers).toHaveBeenCalledWith('ko');
-      expect(result).toEqual(['Kodak', 'Konica']);
+      expect(service.getManufacturers).toHaveBeenCalledWith("ko");
+      expect(result).toEqual(["Kodak", "Konica"]);
     });
 
-    it('should pass empty string when q is undefined', async () => {
+    it("should pass empty string when q is undefined", async () => {
       service.getManufacturers.mockResolvedValue([]);
 
       await controller.getManufacturers(undefined as any);
 
-      expect(service.getManufacturers).toHaveBeenCalledWith('');
+      expect(service.getManufacturers).toHaveBeenCalledWith("");
     });
 
-    it('should return an empty array when no manufacturers match', async () => {
+    it("should return an empty array when no manufacturers match", async () => {
       service.getManufacturers.mockResolvedValue([]);
 
-      const result = await controller.getManufacturers('zzz');
+      const result = await controller.getManufacturers("zzz");
 
       expect(result).toEqual([]);
     });
   });
 
-  describe('getSpeeds', () => {
-    it('should return speeds from the service', async () => {
+  describe("getSpeeds", () => {
+    it("should return speeds from the service", async () => {
       service.getSpeeds.mockResolvedValue([400, 800]);
 
-      const result = await controller.getSpeeds('4');
+      const result = await controller.getSpeeds("4");
 
-      expect(service.getSpeeds).toHaveBeenCalledWith('4');
+      expect(service.getSpeeds).toHaveBeenCalledWith("4");
       expect(result).toEqual([400, 800]);
     });
 
-    it('should pass empty string when q is undefined', async () => {
+    it("should pass empty string when q is undefined", async () => {
       service.getSpeeds.mockResolvedValue([]);
 
       await controller.getSpeeds(undefined as any);
 
-      expect(service.getSpeeds).toHaveBeenCalledWith('');
+      expect(service.getSpeeds).toHaveBeenCalledWith("");
     });
 
-    it('should return an empty array when no speeds match', async () => {
+    it("should return an empty array when no speeds match", async () => {
       service.getSpeeds.mockResolvedValue([]);
 
-      const result = await controller.getSpeeds('999');
+      const result = await controller.getSpeeds("999");
 
       expect(result).toEqual([]);
     });
   });
 
-  describe('findOne', () => {
-    it('should return the stock when found', async () => {
+  describe("findOne", () => {
+    it("should return the stock when found", async () => {
       service.findOne.mockResolvedValue(mockStock);
 
-      const result = await controller.findOne('kodak-portra-400-35mm');
+      const result = await controller.findOne("kodak-portra-400-35mm");
 
       expect(result).toEqual(mockStock);
     });
 
-    it('should throw NotFoundException when stock does not exist', async () => {
+    it("should throw NotFoundException when stock does not exist", async () => {
       service.findOne.mockResolvedValue(null);
 
-      await expect(controller.findOne('nonexistent')).rejects.toThrow(NotFoundException);
+      await expect(controller.findOne("nonexistent")).rejects.toThrow(
+        NotFoundException,
+      );
     });
   });
 
-  describe('remove', () => {
-    it('should return a success message when deleted', async () => {
+  describe("remove", () => {
+    it("should return a success message when deleted", async () => {
       service.remove.mockResolvedValue(true);
 
-      const result = await controller.remove('kodak-portra-400-35mm');
+      const result = await controller.remove("kodak-portra-400-35mm");
 
-      expect(result).toEqual({ message: 'Stock deleted successfully' });
+      expect(result).toEqual({ message: "Stock deleted successfully" });
     });
 
-    it('should throw NotFoundException when stock does not exist', async () => {
+    it("should throw NotFoundException when stock does not exist", async () => {
       service.remove.mockResolvedValue(false);
 
-      await expect(controller.remove('nonexistent')).rejects.toThrow(NotFoundException);
+      await expect(controller.remove("nonexistent")).rejects.toThrow(
+        NotFoundException,
+      );
     });
   });
 });

--- a/frollz-api/src/stock/stock.controller.ts
+++ b/frollz-api/src/stock/stock.controller.ts
@@ -1,91 +1,138 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete, NotFoundException, Query } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
-import { StockService } from './stock.service';
-import { CreateStockDto } from './dto/create-stock.dto';
-import { CreateStockMultipleFormatsDto } from './dto/create-stock-multiple-formats.dto';
-import { UpdateStockDto } from './dto/update-stock.dto';
-import { Stock } from './entities/stock.entity';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  NotFoundException,
+  Query,
+} from "@nestjs/common";
+import { ApiTags, ApiOperation, ApiResponse } from "@nestjs/swagger";
+import { StockService } from "./stock.service";
+import { CreateStockDto } from "./dto/create-stock.dto";
+import { CreateStockMultipleFormatsDto } from "./dto/create-stock-multiple-formats.dto";
+import { UpdateStockDto } from "./dto/update-stock.dto";
+import { Stock } from "./entities/stock.entity";
 
-@ApiTags('stocks')
-@Controller('stocks')
+@ApiTags("stocks")
+@Controller("stocks")
 export class StockController {
   constructor(private readonly stockService: StockService) {}
 
   @Post()
-  @ApiOperation({ summary: 'Create a new stock' })
-  @ApiResponse({ status: 201, description: 'Stock created successfully', type: Stock })
+  @ApiOperation({ summary: "Create a new stock" })
+  @ApiResponse({
+    status: 201,
+    description: "Stock created successfully",
+    type: Stock,
+  })
   create(@Body() createStockDto: CreateStockDto): Promise<Stock> {
     return this.stockService.create(createStockDto);
   }
 
-  @Post('bulk')
-  @ApiOperation({ summary: 'Create stocks for multiple formats at once' })
-  @ApiResponse({ status: 201, description: 'Stocks created successfully', type: [Stock] })
-  createMultipleFormats(@Body() dto: CreateStockMultipleFormatsDto): Promise<Stock[]> {
+  @Post("bulk")
+  @ApiOperation({ summary: "Create stocks for multiple formats at once" })
+  @ApiResponse({
+    status: 201,
+    description: "Stocks created successfully",
+    type: [Stock],
+  })
+  createMultipleFormats(
+    @Body() dto: CreateStockMultipleFormatsDto,
+  ): Promise<Stock[]> {
     return this.stockService.createMultipleFormats(dto);
   }
 
   @Get()
-  @ApiOperation({ summary: 'Get all stocks' })
-  @ApiResponse({ status: 200, description: 'Stocks retrieved successfully', type: [Stock] })
+  @ApiOperation({ summary: "Get all stocks" })
+  @ApiResponse({
+    status: 200,
+    description: "Stocks retrieved successfully",
+    type: [Stock],
+  })
   findAll(): Promise<Stock[]> {
     return this.stockService.findAll();
   }
 
-  @Get('brands')
-  @ApiOperation({ summary: 'Get distinct brand names matching a query' })
-  @ApiResponse({ status: 200, description: 'Matching brand names', type: [String] })
-  getBrands(@Query('q') q: string): Promise<string[]> {
-    return this.stockService.getBrands(q ?? '');
+  @Get("brands")
+  @ApiOperation({ summary: "Get distinct brand names matching a query" })
+  @ApiResponse({
+    status: 200,
+    description: "Matching brand names",
+    type: [String],
+  })
+  getBrands(@Query("q") q: string): Promise<string[]> {
+    return this.stockService.getBrands(q ?? "");
   }
 
-  @Get('manufacturers')
-  @ApiOperation({ summary: 'Get distinct manufacturer names matching a query' })
-  @ApiResponse({ status: 200, description: 'Matching manufacturer names', type: [String] })
-  getManufacturers(@Query('q') q: string): Promise<string[]> {
-    return this.stockService.getManufacturers(q ?? '');
+  @Get("manufacturers")
+  @ApiOperation({ summary: "Get distinct manufacturer names matching a query" })
+  @ApiResponse({
+    status: 200,
+    description: "Matching manufacturer names",
+    type: [String],
+  })
+  getManufacturers(@Query("q") q: string): Promise<string[]> {
+    return this.stockService.getManufacturers(q ?? "");
   }
 
-  @Get('speeds')
-  @ApiOperation({ summary: 'Get distinct speed values matching a query' })
-  @ApiResponse({ status: 200, description: 'Matching speed values', type: [Number] })
-  getSpeeds(@Query('q') q: string): Promise<number[]> {
-    return this.stockService.getSpeeds(q ?? '');
+  @Get("speeds")
+  @ApiOperation({ summary: "Get distinct speed values matching a query" })
+  @ApiResponse({
+    status: 200,
+    description: "Matching speed values",
+    type: [Number],
+  })
+  getSpeeds(@Query("q") q: string): Promise<number[]> {
+    return this.stockService.getSpeeds(q ?? "");
   }
 
-  @Get(':key')
-  @ApiOperation({ summary: 'Get a stock by key' })
-  @ApiResponse({ status: 200, description: 'Stock retrieved successfully', type: Stock })
-  @ApiResponse({ status: 404, description: 'Stock not found' })
-  async findOne(@Param('key') key: string): Promise<Stock> {
+  @Get(":key")
+  @ApiOperation({ summary: "Get a stock by key" })
+  @ApiResponse({
+    status: 200,
+    description: "Stock retrieved successfully",
+    type: Stock,
+  })
+  @ApiResponse({ status: 404, description: "Stock not found" })
+  async findOne(@Param("key") key: string): Promise<Stock> {
     const stock = await this.stockService.findOne(key);
     if (!stock) {
-      throw new NotFoundException('Stock not found');
+      throw new NotFoundException("Stock not found");
     }
     return stock;
   }
 
-  @Patch(':key')
-  @ApiOperation({ summary: 'Update a stock' })
-  @ApiResponse({ status: 200, description: 'Stock updated successfully', type: Stock })
-  @ApiResponse({ status: 404, description: 'Stock not found' })
-  async update(@Param('key') key: string, @Body() updateStockDto: UpdateStockDto): Promise<Stock> {
+  @Patch(":key")
+  @ApiOperation({ summary: "Update a stock" })
+  @ApiResponse({
+    status: 200,
+    description: "Stock updated successfully",
+    type: Stock,
+  })
+  @ApiResponse({ status: 404, description: "Stock not found" })
+  async update(
+    @Param("key") key: string,
+    @Body() updateStockDto: UpdateStockDto,
+  ): Promise<Stock> {
     const stock = await this.stockService.update(key, updateStockDto);
     if (!stock) {
-      throw new NotFoundException('Stock not found');
+      throw new NotFoundException("Stock not found");
     }
     return stock;
   }
 
-  @Delete(':key')
-  @ApiOperation({ summary: 'Delete a stock' })
-  @ApiResponse({ status: 200, description: 'Stock deleted successfully' })
-  @ApiResponse({ status: 404, description: 'Stock not found' })
-  async remove(@Param('key') key: string): Promise<{ message: string }> {
+  @Delete(":key")
+  @ApiOperation({ summary: "Delete a stock" })
+  @ApiResponse({ status: 200, description: "Stock deleted successfully" })
+  @ApiResponse({ status: 404, description: "Stock not found" })
+  async remove(@Param("key") key: string): Promise<{ message: string }> {
     const deleted = await this.stockService.remove(key);
     if (!deleted) {
-      throw new NotFoundException('Stock not found');
+      throw new NotFoundException("Stock not found");
     }
-    return { message: 'Stock deleted successfully' };
+    return { message: "Stock deleted successfully" };
   }
 }

--- a/frollz-api/src/stock/stock.module.ts
+++ b/frollz-api/src/stock/stock.module.ts
@@ -1,6 +1,6 @@
-import { Module } from '@nestjs/common';
-import { StockService } from './stock.service';
-import { StockController } from './stock.controller';
+import { Module } from "@nestjs/common";
+import { StockService } from "./stock.service";
+import { StockController } from "./stock.controller";
 
 @Module({
   controllers: [StockController],

--- a/frollz-api/src/stock/stock.service.spec.ts
+++ b/frollz-api/src/stock/stock.service.spec.ts
@@ -1,9 +1,9 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { StockService } from './stock.service';
-import { DatabaseService } from '../database/database.service';
-import { Process } from './entities/stock.entity';
+import { Test, TestingModule } from "@nestjs/testing";
+import { StockService } from "./stock.service";
+import { DatabaseService } from "../database/database.service";
+import { Process } from "./entities/stock.entity";
 
-describe('StockService', () => {
+describe("StockService", () => {
   let service: StockService;
   let databaseService: { getCollection: jest.Mock; query: jest.Mock };
 
@@ -35,119 +35,120 @@ describe('StockService', () => {
 
   afterEach(() => jest.clearAllMocks());
 
-  describe('getBrands', () => {
-    it('should query using CONTAINS on brand with the provided query', async () => {
+  describe("getBrands", () => {
+    it("should query using CONTAINS on brand with the provided query", async () => {
       mockCursor.all.mockResolvedValue([]);
 
-      await service.getBrands('por');
+      await service.getBrands("por");
 
       expect(databaseService.query).toHaveBeenCalledWith(
-        expect.stringContaining('CONTAINS'),
-        { query: 'por' },
+        expect.stringContaining("CONTAINS"),
+        { query: "por" },
       );
     });
 
-    it('should use DISTINCT to avoid duplicate brand names', async () => {
+    it("should use DISTINCT to avoid duplicate brand names", async () => {
       mockCursor.all.mockResolvedValue([]);
 
-      await service.getBrands('por');
+      await service.getBrands("por");
 
       expect(databaseService.query).toHaveBeenCalledWith(
-        expect.stringContaining('DISTINCT'),
+        expect.stringContaining("DISTINCT"),
         expect.anything(),
       );
     });
 
-    it('should return matching brand names from the cursor', async () => {
-      mockCursor.all.mockResolvedValue(['Portra 400', 'Portra 800']);
+    it("should return matching brand names from the cursor", async () => {
+      mockCursor.all.mockResolvedValue(["Portra 400", "Portra 800"]);
 
-      const result = await service.getBrands('por');
+      const result = await service.getBrands("por");
 
-      expect(result).toEqual(['Portra 400', 'Portra 800']);
+      expect(result).toEqual(["Portra 400", "Portra 800"]);
     });
 
-    it('should return an empty array when no brands match', async () => {
+    it("should return an empty array when no brands match", async () => {
       mockCursor.all.mockResolvedValue([]);
 
-      const result = await service.getBrands('zzz');
+      const result = await service.getBrands("zzz");
 
       expect(result).toEqual([]);
     });
 
-    it('should pass an empty string query when called with empty string', async () => {
+    it("should pass an empty string query when called with empty string", async () => {
       mockCursor.all.mockResolvedValue([]);
 
-      await service.getBrands('');
+      await service.getBrands("");
 
-      expect(databaseService.query).toHaveBeenCalledWith(
-        expect.any(String),
-        { query: '' },
-      );
+      expect(databaseService.query).toHaveBeenCalledWith(expect.any(String), {
+        query: "",
+      });
     });
   });
 
-  describe('getManufacturers', () => {
-    it('should query using CONTAINS on manufacturer with the provided query', async () => {
+  describe("getManufacturers", () => {
+    it("should query using CONTAINS on manufacturer with the provided query", async () => {
       mockCursor.all.mockResolvedValue([]);
 
-      await service.getManufacturers('kod');
+      await service.getManufacturers("kod");
 
       expect(databaseService.query).toHaveBeenCalledWith(
-        expect.stringContaining('CONTAINS'),
-        { query: 'kod' },
+        expect.stringContaining("CONTAINS"),
+        { query: "kod" },
       );
     });
 
-    it('should filter on the manufacturer field', async () => {
+    it("should filter on the manufacturer field", async () => {
       mockCursor.all.mockResolvedValue([]);
 
-      await service.getManufacturers('kod');
+      await service.getManufacturers("kod");
 
       expect(databaseService.query).toHaveBeenCalledWith(
-        expect.stringContaining('stock.manufacturer'),
+        expect.stringContaining("stock.manufacturer"),
         expect.anything(),
       );
     });
 
-    it('should use DISTINCT to avoid duplicate manufacturer names', async () => {
+    it("should use DISTINCT to avoid duplicate manufacturer names", async () => {
       mockCursor.all.mockResolvedValue([]);
 
-      await service.getManufacturers('kod');
+      await service.getManufacturers("kod");
 
       expect(databaseService.query).toHaveBeenCalledWith(
-        expect.stringContaining('DISTINCT'),
+        expect.stringContaining("DISTINCT"),
         expect.anything(),
       );
     });
 
-    it('should return matching manufacturer names from the cursor', async () => {
-      mockCursor.all.mockResolvedValue(['Kodak', 'Konica']);
+    it("should return matching manufacturer names from the cursor", async () => {
+      mockCursor.all.mockResolvedValue(["Kodak", "Konica"]);
 
-      const result = await service.getManufacturers('ko');
+      const result = await service.getManufacturers("ko");
 
-      expect(result).toEqual(['Kodak', 'Konica']);
+      expect(result).toEqual(["Kodak", "Konica"]);
     });
 
-    it('should return an empty array when no manufacturers match', async () => {
+    it("should return an empty array when no manufacturers match", async () => {
       mockCursor.all.mockResolvedValue([]);
 
-      const result = await service.getManufacturers('zzz');
+      const result = await service.getManufacturers("zzz");
 
       expect(result).toEqual([]);
     });
   });
 
-  describe('createMultipleFormats', () => {
+  describe("createMultipleFormats", () => {
     const dto = {
-      formatKeys: ['35mm', '120'],
+      formatKeys: ["35mm", "120"],
       process: Process.C_41,
-      manufacturer: 'Kodak',
-      brand: 'Portra 400',
+      manufacturer: "Kodak",
+      brand: "Portra 400",
       speed: 400,
     };
 
-    it('should save a stock for each formatKey', async () => {
-      mockCollection.save.mockImplementation((stock: any) => Promise.resolve({ _key: stock._key }));
+    it("should save a stock for each formatKey", async () => {
+      mockCollection.save.mockImplementation((stock: any) =>
+        Promise.resolve({ _key: stock._key }),
+      );
 
       const results = await service.createMultipleFormats(dto);
 
@@ -155,36 +156,48 @@ describe('StockService', () => {
       expect(results).toHaveLength(2);
     });
 
-    it('should generate _key as {manufacturer}-{brand}-{speed}-{formatKey}', async () => {
-      mockCollection.save.mockImplementation((stock: any) => Promise.resolve({ _key: stock._key }));
+    it("should generate _key as {manufacturer}-{brand}-{speed}-{formatKey}", async () => {
+      mockCollection.save.mockImplementation((stock: any) =>
+        Promise.resolve({ _key: stock._key }),
+      );
 
       const results = await service.createMultipleFormats(dto);
 
-      expect(results[0]._key).toBe('kodak-portra-400-400-35mm');
-      expect(results[1]._key).toBe('kodak-portra-400-400-120');
+      expect(results[0]._key).toBe("kodak-portra-400-400-35mm");
+      expect(results[1]._key).toBe("kodak-portra-400-400-120");
     });
 
-    it('should lowercase and dasherize manufacturer and brand in the key', async () => {
-      const dtoWithSpaces = { ...dto, manufacturer: 'Fuji Film', brand: 'Pro 400H' };
-      mockCollection.save.mockImplementation((stock: any) => Promise.resolve({ _key: stock._key }));
+    it("should lowercase and dasherize manufacturer and brand in the key", async () => {
+      const dtoWithSpaces = {
+        ...dto,
+        manufacturer: "Fuji Film",
+        brand: "Pro 400H",
+      };
+      mockCollection.save.mockImplementation((stock: any) =>
+        Promise.resolve({ _key: stock._key }),
+      );
 
       const results = await service.createMultipleFormats(dtoWithSpaces);
 
-      expect(results[0]._key).toBe('fuji-film-pro-400h-400-35mm');
+      expect(results[0]._key).toBe("fuji-film-pro-400h-400-35mm");
     });
 
-    it('should set formatKey on each created stock', async () => {
-      mockCollection.save.mockImplementation((stock: any) => Promise.resolve({ _key: stock._key }));
+    it("should set formatKey on each created stock", async () => {
+      mockCollection.save.mockImplementation((stock: any) =>
+        Promise.resolve({ _key: stock._key }),
+      );
 
       const results = await service.createMultipleFormats(dto);
 
-      expect(results[0].formatKey).toBe('35mm');
-      expect(results[1].formatKey).toBe('120');
+      expect(results[0].formatKey).toBe("35mm");
+      expect(results[1].formatKey).toBe("120");
     });
 
-    it('should create a single stock when only one formatKey is provided', async () => {
-      const singleFormat = { ...dto, formatKeys: ['35mm'] };
-      mockCollection.save.mockImplementation((stock: any) => Promise.resolve({ _key: stock._key }));
+    it("should create a single stock when only one formatKey is provided", async () => {
+      const singleFormat = { ...dto, formatKeys: ["35mm"] };
+      mockCollection.save.mockImplementation((stock: any) =>
+        Promise.resolve({ _key: stock._key }),
+      );
 
       const results = await service.createMultipleFormats(singleFormat);
 
@@ -193,52 +206,52 @@ describe('StockService', () => {
     });
   });
 
-  describe('getSpeeds', () => {
-    it('should query using CONTAINS on speed with the provided query', async () => {
+  describe("getSpeeds", () => {
+    it("should query using CONTAINS on speed with the provided query", async () => {
       mockCursor.all.mockResolvedValue([]);
 
-      await service.getSpeeds('40');
+      await service.getSpeeds("40");
 
       expect(databaseService.query).toHaveBeenCalledWith(
-        expect.stringContaining('CONTAINS'),
-        { query: '40' },
+        expect.stringContaining("CONTAINS"),
+        { query: "40" },
       );
     });
 
-    it('should convert speed to string for matching', async () => {
+    it("should convert speed to string for matching", async () => {
       mockCursor.all.mockResolvedValue([]);
 
-      await service.getSpeeds('40');
+      await service.getSpeeds("40");
 
       expect(databaseService.query).toHaveBeenCalledWith(
-        expect.stringContaining('TO_STRING'),
+        expect.stringContaining("TO_STRING"),
         expect.anything(),
       );
     });
 
-    it('should use DISTINCT to avoid duplicate speed values', async () => {
+    it("should use DISTINCT to avoid duplicate speed values", async () => {
       mockCursor.all.mockResolvedValue([]);
 
-      await service.getSpeeds('40');
+      await service.getSpeeds("40");
 
       expect(databaseService.query).toHaveBeenCalledWith(
-        expect.stringContaining('DISTINCT'),
+        expect.stringContaining("DISTINCT"),
         expect.anything(),
       );
     });
 
-    it('should return matching speeds from the cursor', async () => {
+    it("should return matching speeds from the cursor", async () => {
       mockCursor.all.mockResolvedValue([400, 800]);
 
-      const result = await service.getSpeeds('4');
+      const result = await service.getSpeeds("4");
 
       expect(result).toEqual([400, 800]);
     });
 
-    it('should return an empty array when no speeds match', async () => {
+    it("should return an empty array when no speeds match", async () => {
       mockCursor.all.mockResolvedValue([]);
 
-      const result = await service.getSpeeds('999');
+      const result = await service.getSpeeds("999");
 
       expect(result).toEqual([]);
     });

--- a/frollz-api/src/stock/stock.service.ts
+++ b/frollz-api/src/stock/stock.service.ts
@@ -1,16 +1,16 @@
-import { Injectable } from '@nestjs/common';
-import { DatabaseService } from '../database/database.service';
-import { CreateStockDto } from './dto/create-stock.dto';
-import { CreateStockMultipleFormatsDto } from './dto/create-stock-multiple-formats.dto';
-import { UpdateStockDto } from './dto/update-stock.dto';
-import { Stock } from './entities/stock.entity';
+import { Injectable } from "@nestjs/common";
+import { DatabaseService } from "../database/database.service";
+import { CreateStockDto } from "./dto/create-stock.dto";
+import { CreateStockMultipleFormatsDto } from "./dto/create-stock-multiple-formats.dto";
+import { UpdateStockDto } from "./dto/update-stock.dto";
+import { Stock } from "./entities/stock.entity";
 
 @Injectable()
 export class StockService {
   constructor(private readonly databaseService: DatabaseService) {}
 
   async create(createStockDto: CreateStockDto): Promise<Stock> {
-    const collection = this.databaseService.getCollection('stocks');
+    const collection = this.databaseService.getCollection("stocks");
 
     const stock = {
       ...createStockDto,
@@ -22,11 +22,13 @@ export class StockService {
     return { ...stock, _key: result._key };
   }
 
-  async createMultipleFormats(dto: CreateStockMultipleFormatsDto): Promise<Stock[]> {
-    const collection = this.databaseService.getCollection('stocks');
+  async createMultipleFormats(
+    dto: CreateStockMultipleFormatsDto,
+  ): Promise<Stock[]> {
+    const collection = this.databaseService.getCollection("stocks");
     const now = new Date();
 
-    const toSlug = (s: string) => s.toLowerCase().replace(/\s+/g, '-');
+    const toSlug = (s: string) => s.toLowerCase().replace(/\s+/g, "-");
 
     return Promise.all(
       dto.formatKeys.map(async (formatKey) => {
@@ -60,20 +62,26 @@ export class StockService {
   }
 
   async findOne(key: string): Promise<Stock | null> {
-    const cursor = await this.databaseService.query(`
+    const cursor = await this.databaseService.query(
+      `
       FOR stock IN stocks
       FILTER stock._key == @key
       LET fmt = FIRST(FOR f IN film_formats FILTER f._key == stock.formatKey RETURN f)
       RETURN MERGE(stock, { format: fmt ? fmt.format : stock.format })
-    `, { key });
+    `,
+      { key },
+    );
 
     const results = await cursor.all();
     return results.length > 0 ? results[0] : null;
   }
 
-  async update(key: string, updateStockDto: UpdateStockDto): Promise<Stock | null> {
-    const collection = this.databaseService.getCollection('stocks');
-    
+  async update(
+    key: string,
+    updateStockDto: UpdateStockDto,
+  ): Promise<Stock | null> {
+    const collection = this.databaseService.getCollection("stocks");
+
     const updateData = {
       ...updateStockDto,
       updatedAt: new Date(),
@@ -82,18 +90,18 @@ export class StockService {
     try {
       await collection.update(key, updateData);
       return await this.findOne(key);
-    } catch (error) {
+    } catch {
       return null;
     }
   }
 
   async remove(key: string): Promise<boolean> {
-    const collection = this.databaseService.getCollection('stocks');
+    const collection = this.databaseService.getCollection("stocks");
 
     try {
       await collection.remove(key);
       return true;
-    } catch (error) {
+    } catch {
       return false;
     }
   }

--- a/frollz-api/src/tag/dto/create-tag.dto.ts
+++ b/frollz-api/src/tag/dto/create-tag.dto.ts
@@ -1,5 +1,5 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsString, IsHexColor, MinLength } from 'class-validator';
+import { ApiProperty } from "@nestjs/swagger";
+import { IsString, IsHexColor, MinLength } from "class-validator";
 
 export class CreateTagDto {
   @ApiProperty()
@@ -7,7 +7,7 @@ export class CreateTagDto {
   @MinLength(1)
   value: string;
 
-  @ApiProperty({ description: 'Hex color code, e.g. #F97316' })
+  @ApiProperty({ description: "Hex color code, e.g. #F97316" })
   @IsHexColor()
   color: string;
 }

--- a/frollz-api/src/tag/dto/update-tag.dto.ts
+++ b/frollz-api/src/tag/dto/update-tag.dto.ts
@@ -1,4 +1,4 @@
-import { PartialType } from '@nestjs/swagger';
-import { CreateTagDto } from './create-tag.dto';
+import { PartialType } from "@nestjs/swagger";
+import { CreateTagDto } from "./create-tag.dto";
 
 export class UpdateTagDto extends PartialType(CreateTagDto) {}

--- a/frollz-api/src/tag/entities/tag.entity.ts
+++ b/frollz-api/src/tag/entities/tag.entity.ts
@@ -1,4 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty } from "@nestjs/swagger";
 
 export class Tag {
   @ApiProperty()

--- a/frollz-api/src/tag/tag.controller.spec.ts
+++ b/frollz-api/src/tag/tag.controller.spec.ts
@@ -1,13 +1,13 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { NotFoundException } from '@nestjs/common';
-import { TagController } from './tag.controller';
-import { TagService } from './tag.service';
+import { Test, TestingModule } from "@nestjs/testing";
+import { NotFoundException } from "@nestjs/common";
+import { TagController } from "./tag.controller";
+import { TagService } from "./tag.service";
 
-describe('TagController', () => {
+describe("TagController", () => {
   let controller: TagController;
   let service: jest.Mocked<TagService>;
 
-  const mockTag = { _key: 'color', value: 'color', color: '#F97316' };
+  const mockTag = { _key: "color", value: "color", color: "#F97316" };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -32,19 +32,25 @@ describe('TagController', () => {
 
   afterEach(() => jest.clearAllMocks());
 
-  describe('create', () => {
-    it('should return the created tag', async () => {
+  describe("create", () => {
+    it("should return the created tag", async () => {
       service.create.mockResolvedValue(mockTag);
 
-      const result = await controller.create({ value: 'color', color: '#F97316' });
+      const result = await controller.create({
+        value: "color",
+        color: "#F97316",
+      });
 
-      expect(service.create).toHaveBeenCalledWith({ value: 'color', color: '#F97316' });
+      expect(service.create).toHaveBeenCalledWith({
+        value: "color",
+        color: "#F97316",
+      });
       expect(result).toEqual(mockTag);
     });
   });
 
-  describe('findAll', () => {
-    it('should return all tags', async () => {
+  describe("findAll", () => {
+    it("should return all tags", async () => {
       service.findAll.mockResolvedValue([mockTag]);
 
       const result = await controller.findAll();
@@ -53,55 +59,61 @@ describe('TagController', () => {
     });
   });
 
-  describe('findOne', () => {
-    it('should return the tag when found', async () => {
+  describe("findOne", () => {
+    it("should return the tag when found", async () => {
       service.findOne.mockResolvedValue(mockTag);
 
-      const result = await controller.findOne('color');
+      const result = await controller.findOne("color");
 
       expect(result).toEqual(mockTag);
     });
 
-    it('should throw NotFoundException when not found', async () => {
+    it("should throw NotFoundException when not found", async () => {
       service.findOne.mockResolvedValue(null);
 
-      await expect(controller.findOne('nonexistent')).rejects.toThrow(NotFoundException);
-    });
-  });
-
-  describe('update', () => {
-    it('should return the updated tag', async () => {
-      const updated = { ...mockTag, color: '#FFFFFF' };
-      service.update.mockResolvedValue(updated);
-
-      const result = await controller.update('color', { color: '#FFFFFF' });
-
-      expect(service.update).toHaveBeenCalledWith('color', { color: '#FFFFFF' });
-      expect(result).toEqual(updated);
-    });
-
-    it('should throw NotFoundException when tag does not exist', async () => {
-      service.update.mockResolvedValue(null);
-
-      await expect(controller.update('nonexistent', { color: '#FFFFFF' })).rejects.toThrow(
+      await expect(controller.findOne("nonexistent")).rejects.toThrow(
         NotFoundException,
       );
     });
   });
 
-  describe('remove', () => {
-    it('should return a success message when deleted', async () => {
-      service.remove.mockResolvedValue(true);
+  describe("update", () => {
+    it("should return the updated tag", async () => {
+      const updated = { ...mockTag, color: "#FFFFFF" };
+      service.update.mockResolvedValue(updated);
 
-      const result = await controller.remove('color');
+      const result = await controller.update("color", { color: "#FFFFFF" });
 
-      expect(result).toEqual({ message: 'Tag deleted successfully' });
+      expect(service.update).toHaveBeenCalledWith("color", {
+        color: "#FFFFFF",
+      });
+      expect(result).toEqual(updated);
     });
 
-    it('should throw NotFoundException when tag does not exist', async () => {
+    it("should throw NotFoundException when tag does not exist", async () => {
+      service.update.mockResolvedValue(null);
+
+      await expect(
+        controller.update("nonexistent", { color: "#FFFFFF" }),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe("remove", () => {
+    it("should return a success message when deleted", async () => {
+      service.remove.mockResolvedValue(true);
+
+      const result = await controller.remove("color");
+
+      expect(result).toEqual({ message: "Tag deleted successfully" });
+    });
+
+    it("should throw NotFoundException when tag does not exist", async () => {
       service.remove.mockResolvedValue(false);
 
-      await expect(controller.remove('nonexistent')).rejects.toThrow(NotFoundException);
+      await expect(controller.remove("nonexistent")).rejects.toThrow(
+        NotFoundException,
+      );
     });
   });
 });

--- a/frollz-api/src/tag/tag.controller.ts
+++ b/frollz-api/src/tag/tag.controller.ts
@@ -1,62 +1,90 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete, NotFoundException } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
-import { TagService } from './tag.service';
-import { CreateTagDto } from './dto/create-tag.dto';
-import { UpdateTagDto } from './dto/update-tag.dto';
-import { Tag } from './entities/tag.entity';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  NotFoundException,
+} from "@nestjs/common";
+import { ApiTags, ApiOperation, ApiResponse } from "@nestjs/swagger";
+import { TagService } from "./tag.service";
+import { CreateTagDto } from "./dto/create-tag.dto";
+import { UpdateTagDto } from "./dto/update-tag.dto";
+import { Tag } from "./entities/tag.entity";
 
-@ApiTags('tags')
-@Controller('tags')
+@ApiTags("tags")
+@Controller("tags")
 export class TagController {
   constructor(private readonly tagService: TagService) {}
 
   @Post()
-  @ApiOperation({ summary: 'Create a new tag' })
-  @ApiResponse({ status: 201, description: 'Tag created successfully', type: Tag })
+  @ApiOperation({ summary: "Create a new tag" })
+  @ApiResponse({
+    status: 201,
+    description: "Tag created successfully",
+    type: Tag,
+  })
   create(@Body() createTagDto: CreateTagDto): Promise<Tag> {
     return this.tagService.create(createTagDto);
   }
 
   @Get()
-  @ApiOperation({ summary: 'Get all tags' })
-  @ApiResponse({ status: 200, description: 'Tags retrieved successfully', type: [Tag] })
+  @ApiOperation({ summary: "Get all tags" })
+  @ApiResponse({
+    status: 200,
+    description: "Tags retrieved successfully",
+    type: [Tag],
+  })
   findAll(): Promise<Tag[]> {
     return this.tagService.findAll();
   }
 
-  @Get(':key')
-  @ApiOperation({ summary: 'Get a tag by key' })
-  @ApiResponse({ status: 200, description: 'Tag retrieved successfully', type: Tag })
-  @ApiResponse({ status: 404, description: 'Tag not found' })
-  async findOne(@Param('key') key: string): Promise<Tag> {
+  @Get(":key")
+  @ApiOperation({ summary: "Get a tag by key" })
+  @ApiResponse({
+    status: 200,
+    description: "Tag retrieved successfully",
+    type: Tag,
+  })
+  @ApiResponse({ status: 404, description: "Tag not found" })
+  async findOne(@Param("key") key: string): Promise<Tag> {
     const tag = await this.tagService.findOne(key);
     if (!tag) {
-      throw new NotFoundException('Tag not found');
+      throw new NotFoundException("Tag not found");
     }
     return tag;
   }
 
-  @Patch(':key')
-  @ApiOperation({ summary: 'Update a tag' })
-  @ApiResponse({ status: 200, description: 'Tag updated successfully', type: Tag })
-  @ApiResponse({ status: 404, description: 'Tag not found' })
-  async update(@Param('key') key: string, @Body() updateTagDto: UpdateTagDto): Promise<Tag> {
+  @Patch(":key")
+  @ApiOperation({ summary: "Update a tag" })
+  @ApiResponse({
+    status: 200,
+    description: "Tag updated successfully",
+    type: Tag,
+  })
+  @ApiResponse({ status: 404, description: "Tag not found" })
+  async update(
+    @Param("key") key: string,
+    @Body() updateTagDto: UpdateTagDto,
+  ): Promise<Tag> {
     const tag = await this.tagService.update(key, updateTagDto);
     if (!tag) {
-      throw new NotFoundException('Tag not found');
+      throw new NotFoundException("Tag not found");
     }
     return tag;
   }
 
-  @Delete(':key')
-  @ApiOperation({ summary: 'Delete a tag' })
-  @ApiResponse({ status: 200, description: 'Tag deleted successfully' })
-  @ApiResponse({ status: 404, description: 'Tag not found' })
-  async remove(@Param('key') key: string): Promise<{ message: string }> {
+  @Delete(":key")
+  @ApiOperation({ summary: "Delete a tag" })
+  @ApiResponse({ status: 200, description: "Tag deleted successfully" })
+  @ApiResponse({ status: 404, description: "Tag not found" })
+  async remove(@Param("key") key: string): Promise<{ message: string }> {
     const deleted = await this.tagService.remove(key);
     if (!deleted) {
-      throw new NotFoundException('Tag not found');
+      throw new NotFoundException("Tag not found");
     }
-    return { message: 'Tag deleted successfully' };
+    return { message: "Tag deleted successfully" };
   }
 }

--- a/frollz-api/src/tag/tag.module.ts
+++ b/frollz-api/src/tag/tag.module.ts
@@ -1,6 +1,6 @@
-import { Module } from '@nestjs/common';
-import { TagService } from './tag.service';
-import { TagController } from './tag.controller';
+import { Module } from "@nestjs/common";
+import { TagService } from "./tag.service";
+import { TagController } from "./tag.controller";
 
 @Module({
   controllers: [TagController],

--- a/frollz-api/src/tag/tag.service.spec.ts
+++ b/frollz-api/src/tag/tag.service.spec.ts
@@ -1,8 +1,8 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { TagService } from './tag.service';
-import { DatabaseService } from '../database/database.service';
+import { Test, TestingModule } from "@nestjs/testing";
+import { TagService } from "./tag.service";
+import { DatabaseService } from "../database/database.service";
 
-describe('TagService', () => {
+describe("TagService", () => {
   let service: TagService;
   let databaseService: { getCollection: jest.Mock; query: jest.Mock };
 
@@ -34,39 +34,43 @@ describe('TagService', () => {
 
   afterEach(() => jest.clearAllMocks());
 
-  describe('create', () => {
-    it('should save a tag with createdAt and return it with _key', async () => {
-      mockCollection.save.mockResolvedValue({ _key: 'color' });
+  describe("create", () => {
+    it("should save a tag with createdAt and return it with _key", async () => {
+      mockCollection.save.mockResolvedValue({ _key: "color" });
 
-      const result = await service.create({ value: 'color', color: '#F97316' });
+      const result = await service.create({ value: "color", color: "#F97316" });
 
       expect(mockCollection.save).toHaveBeenCalledWith(
         expect.objectContaining({
-          value: 'color',
-          color: '#F97316',
+          value: "color",
+          color: "#F97316",
           createdAt: expect.any(Date),
         }),
       );
       expect(result).toEqual(
-        expect.objectContaining({ _key: 'color', value: 'color', color: '#F97316' }),
+        expect.objectContaining({
+          _key: "color",
+          value: "color",
+          color: "#F97316",
+        }),
       );
     });
 
-    it('should not include updatedAt in the saved document', async () => {
-      mockCollection.save.mockResolvedValue({ _key: 'portrait' });
+    it("should not include updatedAt in the saved document", async () => {
+      mockCollection.save.mockResolvedValue({ _key: "portrait" });
 
-      await service.create({ value: 'portrait', color: '#EC4899' });
+      await service.create({ value: "portrait", color: "#EC4899" });
 
       const savedDoc = mockCollection.save.mock.calls[0][0];
-      expect(savedDoc).not.toHaveProperty('updatedAt');
+      expect(savedDoc).not.toHaveProperty("updatedAt");
     });
   });
 
-  describe('findAll', () => {
-    it('should return all tags from the cursor', async () => {
+  describe("findAll", () => {
+    it("should return all tags from the cursor", async () => {
       const tags = [
-        { _key: 'color', value: 'color', color: '#F97316' },
-        { _key: 'portrait', value: 'portrait', color: '#EC4899' },
+        { _key: "color", value: "color", color: "#F97316" },
+        { _key: "portrait", value: "portrait", color: "#EC4899" },
       ];
       mockCursor.all.mockResolvedValue(tags);
 
@@ -75,79 +79,81 @@ describe('TagService', () => {
       expect(result).toEqual(tags);
     });
 
-    it('should query with SORT tag.value ASC', async () => {
+    it("should query with SORT tag.value ASC", async () => {
       mockCursor.all.mockResolvedValue([]);
 
       await service.findAll();
 
       expect(databaseService.query).toHaveBeenCalledWith(
-        expect.stringContaining('SORT tag.value ASC'),
+        expect.stringContaining("SORT tag.value ASC"),
       );
     });
   });
 
-  describe('findOne', () => {
-    it('should return the tag when found', async () => {
-      const tag = { _key: 'color', value: 'color', color: '#F97316' };
+  describe("findOne", () => {
+    it("should return the tag when found", async () => {
+      const tag = { _key: "color", value: "color", color: "#F97316" };
       mockCursor.all.mockResolvedValue([tag]);
 
-      const result = await service.findOne('color');
+      const result = await service.findOne("color");
 
       expect(result).toEqual(tag);
     });
 
-    it('should return null when not found', async () => {
+    it("should return null when not found", async () => {
       mockCursor.all.mockResolvedValue([]);
 
-      const result = await service.findOne('nonexistent');
+      const result = await service.findOne("nonexistent");
 
       expect(result).toBeNull();
     });
 
-    it('should filter by the provided key', async () => {
+    it("should filter by the provided key", async () => {
       mockCursor.all.mockResolvedValue([]);
 
-      await service.findOne('color');
+      await service.findOne("color");
 
       expect(databaseService.query).toHaveBeenCalledWith(
-        expect.stringContaining('tag._key == @key'),
-        { key: 'color' },
+        expect.stringContaining("tag._key == @key"),
+        { key: "color" },
       );
     });
   });
 
-  describe('update', () => {
-    it('should update and return the refreshed tag', async () => {
-      const updated = { _key: 'color', value: 'color', color: '#FFFFFF' };
+  describe("update", () => {
+    it("should update and return the refreshed tag", async () => {
+      const updated = { _key: "color", value: "color", color: "#FFFFFF" };
       mockCollection.update.mockResolvedValue({});
       mockCursor.all.mockResolvedValue([updated]);
 
-      const result = await service.update('color', { color: '#FFFFFF' });
+      const result = await service.update("color", { color: "#FFFFFF" });
 
-      expect(mockCollection.update).toHaveBeenCalledWith('color', { color: '#FFFFFF' });
+      expect(mockCollection.update).toHaveBeenCalledWith("color", {
+        color: "#FFFFFF",
+      });
       expect(result).toEqual(updated);
     });
 
-    it('should return null when update throws', async () => {
-      mockCollection.update.mockRejectedValue(new Error('document not found'));
+    it("should return null when update throws", async () => {
+      mockCollection.update.mockRejectedValue(new Error("document not found"));
 
-      const result = await service.update('nonexistent', { color: '#FFFFFF' });
+      const result = await service.update("nonexistent", { color: "#FFFFFF" });
 
       expect(result).toBeNull();
     });
   });
 
-  describe('remove', () => {
-    it('should return true on successful removal', async () => {
+  describe("remove", () => {
+    it("should return true on successful removal", async () => {
       mockCollection.remove.mockResolvedValue({});
 
-      expect(await service.remove('color')).toBe(true);
+      expect(await service.remove("color")).toBe(true);
     });
 
-    it('should return false when removal throws', async () => {
-      mockCollection.remove.mockRejectedValue(new Error('document not found'));
+    it("should return false when removal throws", async () => {
+      mockCollection.remove.mockRejectedValue(new Error("document not found"));
 
-      expect(await service.remove('nonexistent')).toBe(false);
+      expect(await service.remove("nonexistent")).toBe(false);
     });
   });
 });

--- a/frollz-api/src/tag/tag.service.ts
+++ b/frollz-api/src/tag/tag.service.ts
@@ -1,15 +1,15 @@
-import { Injectable } from '@nestjs/common';
-import { DatabaseService } from '../database/database.service';
-import { CreateTagDto } from './dto/create-tag.dto';
-import { UpdateTagDto } from './dto/update-tag.dto';
-import { Tag } from './entities/tag.entity';
+import { Injectable } from "@nestjs/common";
+import { DatabaseService } from "../database/database.service";
+import { CreateTagDto } from "./dto/create-tag.dto";
+import { UpdateTagDto } from "./dto/update-tag.dto";
+import { Tag } from "./entities/tag.entity";
 
 @Injectable()
 export class TagService {
   constructor(private readonly databaseService: DatabaseService) {}
 
   async create(createTagDto: CreateTagDto): Promise<Tag> {
-    const collection = this.databaseService.getCollection('tags');
+    const collection = this.databaseService.getCollection("tags");
 
     const tag = {
       ...createTagDto,
@@ -30,34 +30,37 @@ export class TagService {
   }
 
   async findOne(key: string): Promise<Tag | null> {
-    const cursor = await this.databaseService.query(`
+    const cursor = await this.databaseService.query(
+      `
       FOR tag IN tags
       FILTER tag._key == @key
       RETURN tag
-    `, { key });
+    `,
+      { key },
+    );
 
     const results = await cursor.all();
     return results.length > 0 ? results[0] : null;
   }
 
   async update(key: string, updateTagDto: UpdateTagDto): Promise<Tag | null> {
-    const collection = this.databaseService.getCollection('tags');
+    const collection = this.databaseService.getCollection("tags");
 
     try {
       await collection.update(key, updateTagDto);
       return await this.findOne(key);
-    } catch (error) {
+    } catch {
       return null;
     }
   }
 
   async remove(key: string): Promise<boolean> {
-    const collection = this.databaseService.getCollection('tags');
+    const collection = this.databaseService.getCollection("tags");
 
     try {
       await collection.remove(key);
       return true;
-    } catch (error) {
+    } catch {
       return false;
     }
   }

--- a/frollz-ui/.eslintrc.cjs
+++ b/frollz-ui/.eslintrc.cjs
@@ -1,0 +1,24 @@
+/* eslint-env node */
+require('@rushstack/eslint-patch/modern-module-resolution')
+
+module.exports = {
+  root: true,
+  extends: [
+    'plugin:vue/vue3-essential',
+    'eslint:recommended',
+    '@vue/eslint-config-typescript',
+    '@vue/eslint-config-prettier/skip-formatting',
+  ],
+  parserOptions: {
+    ecmaVersion: 'latest',
+  },
+  rules: {
+    'vue/multi-word-component-names': 'off',
+  },
+  overrides: [
+    {
+      files: ['*.cjs', '*.config.js'],
+      env: { node: true },
+    },
+  ],
+}

--- a/frollz-ui/package-lock.json
+++ b/frollz-ui/package-lock.json
@@ -22,10 +22,12 @@
         "@vitejs/plugin-vue": "^6.0.5",
         "@vue/eslint-config-prettier": "^10.0.0",
         "@vue/eslint-config-typescript": "^13.0.0",
+        "@vue/test-utils": "^2.4.6",
         "@vue/tsconfig": "^0.5.1",
         "autoprefixer": "^10.4.17",
         "eslint": "^8.56.0",
         "eslint-plugin-vue": "^9.20.1",
+        "jsdom": "^26.0.0",
         "npm-run-all2": "^6.1.1",
         "postcss": "^8.4.35",
         "prettier": "^3.2.5",
@@ -47,6 +49,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -93,6 +109,121 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@emnapi/core": {
@@ -254,6 +385,53 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -347,6 +525,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@one-ini/wasm": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
+      "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@oxc-project/runtime": {
       "version": "0.115.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.115.0.tgz",
@@ -365,6 +550,17 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@pkgr/core": {
@@ -1249,12 +1445,33 @@
       "integrity": "sha512-YXgQ7JjaO18NeK2K9VTbDHaFy62WrObMa6XERNfNOkAhD1F1oDSf3ZJ7K6GqabZ0BvSDHajp8qfS5Sa2I9n8uQ==",
       "license": "MIT"
     },
+    "node_modules/@vue/test-utils": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.4.6.tgz",
+      "integrity": "sha512-FMxEjOpYNYiFe0GkaHsnJPXFHxQ6m4t8vI/ElPGpMWxZKpmRvQ33OIrvRXemy6yha03RxhOlQuy+gZMC3CQSow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-beautify": "^1.14.9",
+        "vue-component-type-helpers": "^2.0.0"
+      }
+    },
     "node_modules/@vue/tsconfig": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/@vue/tsconfig/-/tsconfig-0.5.1.tgz",
       "integrity": "sha512-VcZK7MvpjuTPx2w6blwnwZAu5/LgBUtejFOi3pPGQFXQN5Ela03FUtd2Qtg4yWGGissVL0dr6Ro1LfOFh+PCuQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/abbrev": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/acorn": {
       "version": "8.16.0",
@@ -1277,6 +1494,16 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -1702,6 +1929,17 @@
         "node": ">= 6"
       }
     },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1737,11 +1975,39 @@
         "node": ">=4"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1760,6 +2026,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -1841,12 +2114,55 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/editorconfig": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.7.tgz",
+      "integrity": "sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@one-ini/wasm": "0.1.1",
+        "commander": "^10.0.0",
+        "minimatch": "^9.0.1",
+        "semver": "^7.5.3"
+      },
+      "bin": {
+        "editorconfig": "bin/editorconfig"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/editorconfig/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.313",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.313.tgz",
       "integrity": "sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/entities": {
       "version": "7.0.1",
@@ -2325,6 +2641,23 @@
         }
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
@@ -2563,6 +2896,60 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2619,6 +3006,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -2658,6 +3052,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -2691,12 +3095,35 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
     },
     "node_modules/jiti": {
       "version": "1.21.7",
@@ -2706,6 +3133,60 @@
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/js-beautify": {
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.15.4.tgz",
+      "integrity": "sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "config-chain": "^1.1.13",
+        "editorconfig": "^1.0.4",
+        "glob": "^10.4.2",
+        "js-cookie": "^3.0.5",
+        "nopt": "^7.2.1"
+      },
+      "bin": {
+        "css-beautify": "js/bin/css-beautify.js",
+        "html-beautify": "js/bin/html-beautify.js",
+        "js-beautify": "js/bin/js-beautify.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/js-beautify/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/js-yaml": {
@@ -2719,6 +3200,56 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/json-buffer": {
@@ -3087,6 +3618,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3175,6 +3713,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -3232,6 +3780,22 @@
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nopt": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
+      "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^2.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -3321,6 +3885,13 @@
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -3413,6 +3984,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3424,6 +4002,32 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/path-browserify": {
@@ -3469,6 +4073,23 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -3762,6 +4383,13 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -3929,6 +4557,13 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.9"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -3951,6 +4586,26 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/semver": {
@@ -4009,6 +4664,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -4042,7 +4710,91 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -4116,6 +4868,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/synckit": {
       "version": "0.11.12",
@@ -4276,6 +5035,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -4287,6 +5066,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ts-api-utils": {
@@ -4664,6 +5469,13 @@
         }
       }
     },
+    "node_modules/vue-component-type-helpers": {
+      "version": "2.2.12",
+      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-2.2.12.tgz",
+      "integrity": "sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/vue-demi": {
       "version": "0.14.10",
       "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
@@ -4747,6 +5559,77 @@
         "typescript": ">=5.0.0"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/w3c-xmlserializer/node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4790,12 +5673,135 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xml-name-validator": {
       "version": "4.0.0",
@@ -4806,6 +5812,13 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/frollz-ui/package.json
+++ b/frollz-ui/package.json
@@ -36,6 +36,8 @@
     "prettier": "^3.2.5",
     "tailwindcss": "^3.4.1",
     "typescript": "~5.3.0",
+    "@vue/test-utils": "^2.4.6",
+    "jsdom": "^26.0.0",
     "vite": "^8.0.0",
     "vitest": "^4.1.0",
     "vue-tsc": "^3.0.0"

--- a/frollz-ui/src/views/RollsView.vue
+++ b/frollz-ui/src/views/RollsView.vue
@@ -81,20 +81,14 @@
               >{{ roll.timesExposedToXrays }}</td>
               <td class="px-6 py-4 whitespace-nowrap text-right">
                 <div class="flex items-center justify-end gap-2">
-                  <!-- Storage transition buttons -->
+                  <!-- State transition buttons -->
                   <button
-                    v-for="targetState in getStorageTransitions(roll.state)"
+                    v-for="targetState in getValidTransitions(roll.state)"
                     :key="targetState"
                     @click="openTransitionModal(roll, targetState)"
                     class="px-3 py-1 text-xs font-medium border rounded hover:opacity-80"
                     :class="getTransitionButtonColor(targetState)"
                   >{{ targetState }}</button>
-                  <!-- Load button -->
-                  <button
-                    v-if="canLoad(roll.state)"
-                    @click="openLoadModal(roll)"
-                    class="px-3 py-1 text-xs font-medium text-yellow-700 border border-yellow-400 rounded hover:bg-yellow-50"
-                  >Load</button>
                   <!-- History button -->
                   <button
                     @click="openHistoryModal(roll)"
@@ -140,40 +134,6 @@
               :disabled="transitionSubmitting"
               class="px-4 py-2 bg-primary-600 text-white rounded-md text-sm hover:bg-primary-700 disabled:opacity-50"
             >{{ transitionSubmitting ? 'Saving...' : 'Save' }}</button>
-          </div>
-        </form>
-      </div>
-    </div>
-
-    <!-- Load Roll Modal -->
-    <div v-if="loadTarget" class="fixed inset-0 bg-gray-500 bg-opacity-75 flex items-center justify-center z-50">
-      <div class="bg-white rounded-lg shadow-xl p-6 w-full max-w-md">
-        <h2 class="text-xl font-bold text-gray-900 mb-4">Load Roll</h2>
-        <form @submit.prevent="handleLoad">
-          <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">
-              What will this roll be loaded into? <span class="text-red-500">*</span>
-            </label>
-            <input
-              v-model="loadedInto"
-              type="text"
-              required
-              placeholder="e.g. Nikon F3"
-              class="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
-            />
-          </div>
-          <div v-if="loadError" class="mt-3 text-sm text-red-600">{{ loadError }}</div>
-          <div class="flex justify-end gap-3 mt-6">
-            <button
-              type="button"
-              @click="closeLoadModal"
-              class="px-4 py-2 border border-gray-300 rounded-md text-sm text-gray-700 hover:bg-gray-50"
-            >Cancel</button>
-            <button
-              type="submit"
-              :disabled="loadSubmitting"
-              class="px-4 py-2 bg-yellow-600 text-white rounded-md text-sm hover:bg-yellow-700 disabled:opacity-50"
-            >{{ loadSubmitting ? 'Loading...' : 'Load' }}</button>
           </div>
         </form>
       </div>
@@ -415,15 +375,17 @@ const formatDateTime = (date: Date | string) => {
   return new Date(date as string).toLocaleString()
 }
 
-// Storage state machine transitions
-const STORAGE_TRANSITIONS: Partial<Record<RollState, RollState[]>> = {
+// Unified state machine transitions (storage + usage)
+const VALID_TRANSITIONS: Partial<Record<RollState, RollState[]>> = {
   [RollState.ADDED]: [RollState.FROZEN, RollState.REFRIGERATED, RollState.SHELFED],
   [RollState.FROZEN]: [RollState.REFRIGERATED, RollState.SHELFED, RollState.ADDED],
   [RollState.REFRIGERATED]: [RollState.SHELFED, RollState.ADDED],
+  [RollState.SHELFED]: [RollState.LOADED],
+  [RollState.LOADED]: [RollState.FINISHED, RollState.SHELFED],
 }
 
-const getStorageTransitions = (state: RollState): RollState[] => {
-  return STORAGE_TRANSITIONS[state] ?? []
+const getValidTransitions = (state: RollState): RollState[] => {
+  return VALID_TRANSITIONS[state] ?? []
 }
 
 const TRANSITION_BUTTON_COLORS: Partial<Record<RollState, string>> = {
@@ -431,6 +393,8 @@ const TRANSITION_BUTTON_COLORS: Partial<Record<RollState, string>> = {
   [RollState.FROZEN]: 'text-blue-700 border-blue-400 hover:bg-blue-50',
   [RollState.REFRIGERATED]: 'text-cyan-700 border-cyan-400 hover:bg-cyan-50',
   [RollState.SHELFED]: 'text-gray-600 border-gray-400 hover:bg-gray-50',
+  [RollState.LOADED]: 'text-yellow-700 border-yellow-400 hover:bg-yellow-50',
+  [RollState.FINISHED]: 'text-green-700 border-green-400 hover:bg-green-50',
 }
 
 const getTransitionButtonColor = (state: RollState): string => {
@@ -470,43 +434,6 @@ const handleTransition = async () => {
     transitionError.value = 'Failed to transition roll. Please try again.'
   } finally {
     transitionSubmitting.value = false
-  }
-}
-
-const LOADABLE_STATES = new Set([RollState.FROZEN, RollState.REFRIGERATED, RollState.SHELFED])
-
-const canLoad = (state: RollState) => LOADABLE_STATES.has(state)
-
-const loadTarget = ref<Roll | null>(null)
-const loadedInto = ref('')
-const loadSubmitting = ref(false)
-const loadError = ref('')
-
-const openLoadModal = (roll: Roll) => {
-  loadTarget.value = roll
-  loadedInto.value = ''
-  loadError.value = ''
-}
-
-const closeLoadModal = () => {
-  loadTarget.value = null
-}
-
-const handleLoad = async () => {
-  if (!loadTarget.value) return
-  loadSubmitting.value = true
-  loadError.value = ''
-  try {
-    await rollApi.update(loadTarget.value._key!, {
-      state: RollState.LOADED,
-      loadedInto: loadedInto.value,
-    })
-    closeLoadModal()
-    await loadRolls()
-  } catch {
-    loadError.value = 'Failed to load roll. Please try again.'
-  } finally {
-    loadSubmitting.value = false
   }
 }
 

--- a/frollz-ui/src/views/__tests__/RollsView.spec.ts
+++ b/frollz-ui/src/views/__tests__/RollsView.spec.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { createRouter, createMemoryHistory } from 'vue-router'
 import RollsView from '@/views/RollsView.vue'
-import { rollApi, stockApi } from '@/services/api-client'
+import { rollApi, rollStateApi, stockApi } from '@/services/api-client'
 import { RollState, ObtainmentMethod } from '@/types'
 
 vi.mock('@/services/api-client', () => ({
@@ -12,6 +12,10 @@ vi.mock('@/services/api-client', () => ({
     getNextId: vi.fn(),
     create: vi.fn(),
     update: vi.fn(),
+    transition: vi.fn(),
+  },
+  rollStateApi: {
+    getHistory: vi.fn(),
   },
   stockApi: {
     getAll: vi.fn(),
@@ -188,29 +192,39 @@ describe('RollsView', () => {
     })
   })
 
-  describe('canLoad', () => {
-    it.each([RollState.FROZEN, RollState.REFRIGERATED, RollState.SHELFED])(
-      'should show Load button for %s state',
+  describe('getValidTransitions', () => {
+    it('should show Loaded transition button for a Shelved roll', async () => {
+      vi.mocked(rollApi.getAll).mockResolvedValue({ data: [makeRoll('r1', RollState.SHELFED)] } as any)
+
+      const wrapper = mount(RollsView, { global: { plugins: [router] } })
+      await flushPromises()
+
+      const vm = wrapper.vm as any
+      expect(vm.getValidTransitions(RollState.SHELFED)).toContain(RollState.LOADED)
+      expect(wrapper.findAll('button').some(b => b.text() === RollState.LOADED)).toBe(true)
+    })
+
+    it('should show Finished and Shelved buttons for a Loaded roll', async () => {
+      vi.mocked(rollApi.getAll).mockResolvedValue({ data: [makeRoll('r1', RollState.LOADED)] } as any)
+
+      const wrapper = mount(RollsView, { global: { plugins: [router] } })
+      await flushPromises()
+
+      const buttonTexts = wrapper.findAll('button').map(b => b.text())
+      expect(buttonTexts).toContain(RollState.FINISHED)
+      expect(buttonTexts).toContain(RollState.SHELFED)
+    })
+
+    it.each([RollState.FINISHED, RollState.DEVELOPED])(
+      'should show no transition buttons for terminal state %s',
       async (state) => {
         vi.mocked(rollApi.getAll).mockResolvedValue({ data: [makeRoll('r1', state)] } as any)
 
         const wrapper = mount(RollsView, { global: { plugins: [router] } })
         await flushPromises()
 
-        expect(wrapper.text()).toContain('Load')
-      }
-    )
-
-    it.each([RollState.LOADED, RollState.FINISHED, RollState.DEVELOPED])(
-      'should not show Load button for %s state',
-      async (state) => {
-        vi.mocked(rollApi.getAll).mockResolvedValue({ data: [makeRoll('r1', state)] } as any)
-
-        const wrapper = mount(RollsView, { global: { plugins: [router] } })
-        await flushPromises()
-
-        const loadButtons = wrapper.findAll('button').filter(b => b.text() === 'Load')
-        expect(loadButtons).toHaveLength(0)
+        const vm = wrapper.vm as any
+        expect(vm.getValidTransitions(state)).toHaveLength(0)
       }
     )
   })
@@ -336,8 +350,8 @@ describe('RollsView', () => {
     })
   })
 
-  describe('load modal', () => {
-    it('should open load modal when Load button is clicked', async () => {
+  describe('transition modal', () => {
+    it('should open transition modal when a transition button is clicked', async () => {
       vi.mocked(rollApi.getAll).mockResolvedValue({
         data: [makeRoll('r1', RollState.SHELFED)],
       } as any)
@@ -346,59 +360,71 @@ describe('RollsView', () => {
       await flushPromises()
 
       const vm = wrapper.vm as any
-      vm.openLoadModal(makeRoll('r1', RollState.SHELFED))
+      vm.openTransitionModal(makeRoll('r1', RollState.SHELFED), RollState.LOADED)
       await wrapper.vm.$nextTick()
 
-      expect(vm.loadTarget).not.toBeNull()
-      expect(wrapper.text()).toContain('What will this roll be loaded into?')
+      expect(vm.transitionTarget).not.toBeNull()
+      expect(wrapper.text()).toContain('Transition Roll')
     })
 
-    it('should close load modal on cancel', async () => {
+    it('should close transition modal on cancel', async () => {
       const wrapper = mount(RollsView, { global: { plugins: [router] } })
       await flushPromises()
 
       const vm = wrapper.vm as any
-      vm.openLoadModal(makeRoll('r1', RollState.SHELFED))
-      vm.closeLoadModal()
+      vm.openTransitionModal(makeRoll('r1', RollState.SHELFED), RollState.LOADED)
+      vm.closeTransitionModal()
       await wrapper.vm.$nextTick()
 
-      expect(vm.loadTarget).toBeNull()
+      expect(vm.transitionTarget).toBeNull()
     })
 
-    it('should call rollApi.update with Loaded state and loadedInto on submit', async () => {
-      vi.mocked(rollApi.update).mockResolvedValue({ data: {} } as any)
+    it('should call rollApi.transition with the target state on submit', async () => {
+      vi.mocked(rollApi.transition).mockResolvedValue({ data: {} } as any)
 
       const wrapper = mount(RollsView, { global: { plugins: [router] } })
       await flushPromises()
 
       const vm = wrapper.vm as any
-      vm.openLoadModal(makeRoll('r1', RollState.SHELFED))
-      vm.loadedInto = 'Nikon F3'
+      vm.openTransitionModal(makeRoll('r1', RollState.SHELFED), RollState.LOADED)
+      vm.transitionNotes = 'Loading into Nikon F3'
 
-      await vm.handleLoad()
+      await vm.handleTransition()
       await flushPromises()
 
-      expect(rollApi.update).toHaveBeenCalledWith('r1', {
-        state: RollState.LOADED,
-        loadedInto: 'Nikon F3',
-      })
+      expect(rollApi.transition).toHaveBeenCalledWith('r1', RollState.LOADED, 'Loading into Nikon F3')
     })
 
-    it('should close modal and reload rolls after successful load', async () => {
-      vi.mocked(rollApi.update).mockResolvedValue({ data: {} } as any)
+    it('should close modal and reload rolls after successful transition', async () => {
+      vi.mocked(rollApi.transition).mockResolvedValue({ data: {} } as any)
 
       const wrapper = mount(RollsView, { global: { plugins: [router] } })
       await flushPromises()
 
       const vm = wrapper.vm as any
-      vm.openLoadModal(makeRoll('r1', RollState.SHELFED))
-      vm.loadedInto = 'Nikon F3'
+      vm.openTransitionModal(makeRoll('r1', RollState.SHELFED), RollState.LOADED)
 
-      await vm.handleLoad()
+      await vm.handleTransition()
       await flushPromises()
 
-      expect(vm.loadTarget).toBeNull()
+      expect(vm.transitionTarget).toBeNull()
       expect(rollApi.getAll).toHaveBeenCalledTimes(2)
+    })
+
+    it('should pass undefined notes when notes field is empty', async () => {
+      vi.mocked(rollApi.transition).mockResolvedValue({ data: {} } as any)
+
+      const wrapper = mount(RollsView, { global: { plugins: [router] } })
+      await flushPromises()
+
+      const vm = wrapper.vm as any
+      vm.openTransitionModal(makeRoll('r1', RollState.LOADED), RollState.FINISHED)
+      vm.transitionNotes = ''
+
+      await vm.handleTransition()
+      await flushPromises()
+
+      expect(rollApi.transition).toHaveBeenCalledWith('r1', RollState.FINISHED, undefined)
     })
   })
 })

--- a/frollz-ui/src/views/__tests__/StocksView.spec.ts
+++ b/frollz-ui/src/views/__tests__/StocksView.spec.ts
@@ -60,7 +60,7 @@ describe('StocksView', () => {
 
   describe('component mounting', () => {
     it('should mount successfully and load data', async () => {
-      const wrapper = mount(StocksView)
+      mount(StocksView)
       await flushPromises()
 
       expect(stockApi.getAll).toHaveBeenCalled()
@@ -413,8 +413,6 @@ describe('StocksView', () => {
       vm.addFilter('manufacturer', 'Manufacturer', 'Kodak')
       await wrapper.vm.$nextTick()
 
-      const chipText = wrapper.find('[data-testid="filter-chip"]')
-        ?? wrapper.findAll('span').find(s => s.text().includes('Manufacturer: Kodak'))
       expect(wrapper.text()).toContain('Manufacturer: Kodak')
     })
 


### PR DESCRIPTION
Closes #34

## Summary
- Extends the roll state machine to cover usage states: **Shelved → Loaded → Finished** (and Loaded → Shelved to unload)
- Adds `POST /rolls/:key/transition` API endpoint; every transition is recorded as a `RollStateHistory` entry
- Replaces the load-specific modal with a unified **Transition Modal** (optional notes) for all state changes
- Adds a **History Modal** showing the full state timeline for a roll
- Adds `rollApi.transition()` and `rollStateApi.getHistory()` to the UI API client
- Replaces deprecated `canLoad`/load-modal tests with `getValidTransitions`/`transition-modal` tests (181 tests total pass: 94 UI + 87 API)
- Adds ESLint configs (`.eslintrc.js` for API, `.eslintrc.cjs` for UI) and fixes all pre-existing lint errors

## Test plan
- [ ] Run `npm test` in `frollz-ui` — all 94 tests pass
- [ ] Run `npm test` in `frollz-api` — all 87 tests pass
- [ ] Manually verify: shelved roll shows "Loaded" button → Transition Modal opens → submitting calls `POST /rolls/:key/transition`
- [ ] Manually verify: loaded roll shows "Finished" and "Shelved" buttons
- [ ] Manually verify: History button opens timeline modal for any roll

🤖 Generated with [Claude Code](https://claude.com/claude-code)