### PR TITLE
feat: switch to GitHub-hosted runners and add PR CI trigger

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -4,11 +4,12 @@ on:
   push:
     branches:
       - main
+  pull_request:
 
 jobs:
   ci-api:
     name: API — Lint & Test
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: frollz-api
@@ -33,7 +34,7 @@ jobs:
 
   ci-ui:
     name: UI — Lint, Type-check & Test
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: frollz-ui
@@ -61,8 +62,9 @@ jobs:
 
   build-and-push:
     name: Build & Push Images
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: [ci-api, ci-ui]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Summary

- Replaces `self-hosted` runners with `ubuntu-latest` on all three jobs — required now that the repo is public (self-hosted runners are a security risk on public repos)
- Adds `pull_request` trigger so CI (lint, type-check, tests) runs on all PRs, not just pushes to `main`
- Gates the `build-and-push` job with `if: github.ref == 'refs/heads/main' && github.event_name == 'push'` so images are only published from main

## Test plan

- [ ] Open a PR to a non-main branch and verify CI jobs run but build-and-push is skipped
- [ ] Merge to main and verify all three jobs run including build-and-push

🤖 Generated with [Claude Code](https://claude.com/claude-code)