### PR TITLE
feat(roll-state): phase 1 foundation — metadata columns + auto-tag seeds (#55)

### DIFF
--- a/frollz-api/db-init/default/0003-tags.json
+++ b/frollz-api/db-init/default/0003-tags.json
@@ -34,5 +34,9 @@
     { "_key": "czech",          "value": "czech",          "color": "#1D4ED8", "isRollScoped": true, "isStockScoped": true },
     { "_key": "modified",       "value": "modified",       "color": "#7C3AED", "isRollScoped": true, "isStockScoped": true },
     { "_key": "halation",       "value": "halation",       "color": "#FCA5A5", "isRollScoped": true, "isStockScoped": true },
-    { "_key": "double-x",       "value": "double-x",       "color": "#D97706", "isRollScoped": true, "isStockScoped": true }
+    { "_key": "double-x",       "value": "double-x",       "color": "#D97706", "isRollScoped": true, "isStockScoped": true },
+    { "_key": "expired",         "value": "expired",         "color": "#9CA3AF", "isRollScoped": true, "isStockScoped": false },
+    { "_key": "pushed",          "value": "pushed",           "color": "#A78BFA", "isRollScoped": true, "isStockScoped": false },
+    { "_key": "pulled",          "value": "pulled",           "color": "#5EEAD4", "isRollScoped": true, "isStockScoped": false },
+    { "_key": "cross-processed", "value": "cross-processed",  "color": "#FB923C", "isRollScoped": true, "isStockScoped": false }
 ]

--- a/frollz-api/migrations/20260318000000_add_roll_state_metadata.ts
+++ b/frollz-api/migrations/20260318000000_add_roll_state_metadata.ts
@@ -1,0 +1,18 @@
+import type { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  const hasMetadata = await knex.schema.hasColumn('roll_states', 'metadata');
+  if (!hasMetadata) {
+    await knex.schema.table('roll_states', (t) => {
+      t.jsonb('metadata').nullable();
+      t.boolean('is_error_correction').nullable().defaultTo(false);
+    });
+  }
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.table('roll_states', (t) => {
+    t.dropColumn('metadata');
+    t.dropColumn('is_error_correction');
+  });
+}

--- a/frollz-api/src/roll-state/dto/create-roll-state.dto.ts
+++ b/frollz-api/src/roll-state/dto/create-roll-state.dto.ts
@@ -4,6 +4,8 @@ import {
   IsString,
   IsOptional,
   IsDate,
+  IsObject,
+  IsBoolean,
   MaxLength,
 } from "class-validator";
 import { Type } from "class-transformer";
@@ -30,4 +32,14 @@ export class CreateRollStateDto {
   @IsString()
   @MaxLength(1000)
   notes?: string;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, unknown>;
+
+  @ApiProperty({ required: false })
+  @IsOptional()
+  @IsBoolean()
+  isErrorCorrection?: boolean;
 }

--- a/frollz-api/src/roll-state/entities/roll-state.entity.ts
+++ b/frollz-api/src/roll-state/entities/roll-state.entity.ts
@@ -21,6 +21,12 @@ export class RollStateHistory {
   notes?: string;
 
   @ApiProperty({ required: false })
+  metadata?: Record<string, unknown>;
+
+  @ApiProperty({ required: false })
+  isErrorCorrection?: boolean;
+
+  @ApiProperty({ required: false })
   createdAt?: Date;
 
   @ApiProperty({ required: false })

--- a/frollz-api/src/roll-state/roll-state.service.ts
+++ b/frollz-api/src/roll-state/roll-state.service.ts
@@ -12,6 +12,12 @@ function mapRollState(row: Record<string, unknown>): RollStateHistory {
     state: row.state as RollStateHistory["state"],
     date: new Date(row.date as string),
     notes: row.notes as string | undefined,
+    metadata: row.metadata
+      ? typeof row.metadata === 'string'
+        ? JSON.parse(row.metadata)
+        : row.metadata
+      : undefined,
+    isErrorCorrection: (row.is_error_correction as boolean) ?? false,
     createdAt: row.created_at ? new Date(row.created_at as string) : undefined,
     updatedAt: row.updated_at ? new Date(row.updated_at as string) : undefined,
   };
@@ -28,9 +34,20 @@ export class RollStateService {
     const date = dto.date ?? now;
 
     await this.databaseService.execute(
-      `INSERT INTO roll_states (id, state_id, roll_id, state, date, notes, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-      [id, stateId, dto.rollKey, dto.state, date, dto.notes ?? null, now, now],
+      `INSERT INTO roll_states (id, state_id, roll_id, state, date, notes, metadata, is_error_correction, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        id,
+        stateId,
+        dto.rollKey,
+        dto.state,
+        date,
+        dto.notes ?? null,
+        dto.metadata != null ? JSON.stringify(dto.metadata) : null,
+        dto.isErrorCorrection ?? false,
+        now,
+        now,
+      ],
     );
 
     return {
@@ -40,6 +57,8 @@ export class RollStateService {
       state: dto.state,
       date,
       notes: dto.notes,
+      metadata: dto.metadata,
+      isErrorCorrection: dto.isErrorCorrection ?? false,
       createdAt: now,
       updatedAt: now,
     };


### PR DESCRIPTION
## Summary

- Adds `metadata` (JSONB) and `is_error_correction` (boolean) columns to `roll_states` via an idempotent migration
- Wires both fields through the entity, DTO (with validation), service INSERT, and response mapper
- Seeds four auto-tags — `expired`, `pushed`, `pulled`, `cross-processed` — with fixed `_key` values for later phase references

## Related issues

Part of #55 (roll state transitions with additional details and auto-tagging).

This PR is Phase 1 (foundation). It unblocks all sub-issues but does not close any individually:

| Sub-issue | What this PR contributes |
|-----------|--------------------------|
| #59 Auto-tagging | Seeds the four auto-tags that will be applied programmatically |
| #60 Error correction | Adds `is_error_correction` column to `roll_states` |
| #61–#68 State metadata | Adds `metadata` JSONB column that each state will populate |

## Test plan

- [x] All 122 existing unit tests pass (`npm test`)
- [x] `docker-compose up -d` — migration runs on startup
- [x] `\d roll_states` in psql confirms `metadata` and `is_error_correction` columns exist
- [x] `GET /api/tags` returns `expired`, `pushed`, `pulled`, `cross-processed`
- [x] POST a new roll state — new columns accept null without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)