### PR TITLE
feat: phase 4 — FINISHED state shot ISO and pushed/pulled auto-tags (#65)

### DIFF
--- a/frollz-api/src/roll/roll.service.spec.ts
+++ b/frollz-api/src/roll/roll.service.spec.ts
@@ -237,4 +237,95 @@ describe("RollService", () => {
       );
     });
   });
+
+  describe("transition to FINISHED", () => {
+    const loadedRollRow = {
+      id: "roll-uuid",
+      roll_id: "roll-00001",
+      stock_key: "stock-1",
+      state: RollState.LOADED,
+      images_url: null,
+      date_obtained: new Date().toISOString(),
+      obtainment_method: "Purchase",
+      obtained_from: "B&H",
+      expiration_date: null,
+      times_exposed_to_xrays: 0,
+      loaded_into: null,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    };
+
+    it("should apply pushed tag when shotISO > stock speed", async () => {
+      db.query
+        .mockResolvedValueOnce([loadedRollRow]) // findOne
+        .mockResolvedValueOnce([{ speed: 400 }]) // syncPushPullTags stock query
+        .mockResolvedValueOnce([loadedRollRow]); // update findOne
+
+      await service.transition("roll-uuid", {
+        targetState: RollState.FINISHED,
+        metadata: { shotISO: 800 },
+      });
+
+      expect(rollTagService.syncAutoTag).toHaveBeenCalledWith("roll-uuid", "pushed", true);
+      expect(rollTagService.syncAutoTag).toHaveBeenCalledWith("roll-uuid", "pulled", false);
+    });
+
+    it("should apply pulled tag when shotISO < stock speed", async () => {
+      db.query
+        .mockResolvedValueOnce([loadedRollRow])
+        .mockResolvedValueOnce([{ speed: 400 }])
+        .mockResolvedValueOnce([loadedRollRow]);
+
+      await service.transition("roll-uuid", {
+        targetState: RollState.FINISHED,
+        metadata: { shotISO: 200 },
+      });
+
+      expect(rollTagService.syncAutoTag).toHaveBeenCalledWith("roll-uuid", "pushed", false);
+      expect(rollTagService.syncAutoTag).toHaveBeenCalledWith("roll-uuid", "pulled", true);
+    });
+
+    it("should remove both tags when shotISO equals stock speed", async () => {
+      db.query
+        .mockResolvedValueOnce([loadedRollRow])
+        .mockResolvedValueOnce([{ speed: 400 }])
+        .mockResolvedValueOnce([loadedRollRow]);
+
+      await service.transition("roll-uuid", {
+        targetState: RollState.FINISHED,
+        metadata: { shotISO: 400 },
+      });
+
+      expect(rollTagService.syncAutoTag).toHaveBeenCalledWith("roll-uuid", "pushed", false);
+      expect(rollTagService.syncAutoTag).toHaveBeenCalledWith("roll-uuid", "pulled", false);
+    });
+
+    it("should remove both tags when no shotISO provided", async () => {
+      db.query
+        .mockResolvedValueOnce([loadedRollRow])
+        .mockResolvedValueOnce([{ speed: 400 }])
+        .mockResolvedValueOnce([loadedRollRow]);
+
+      await service.transition("roll-uuid", {
+        targetState: RollState.FINISHED,
+      });
+
+      expect(rollTagService.syncAutoTag).toHaveBeenCalledWith("roll-uuid", "pushed", false);
+      expect(rollTagService.syncAutoTag).toHaveBeenCalledWith("roll-uuid", "pulled", false);
+    });
+
+    it("should not call syncPushPullTags for non-FINISHED transitions", async () => {
+      db.query.mockResolvedValue([loadedRollRow]);
+
+      await service.transition("roll-uuid", {
+        targetState: RollState.FINISHED,
+      });
+
+      // Only pushed/pulled calls — expired is from update's syncExpiredTag
+      const pushPullCalls = rollTagService.syncAutoTag.mock.calls.filter(
+        ([, tag]) => tag === "pushed" || tag === "pulled",
+      );
+      expect(pushPullCalls.length).toBe(2);
+    });
+  });
 });

--- a/frollz-api/src/roll/roll.service.ts
+++ b/frollz-api/src/roll/roll.service.ts
@@ -94,6 +94,24 @@ export class RollService implements OnModuleInit {
     }
   }
 
+  private async syncPushPullTags(
+    rollKey: string,
+    stockKey: string,
+    shotISO?: number,
+  ): Promise<void> {
+    const stocks = await this.databaseService.query<{ speed: number }>(
+      `SELECT speed FROM stocks WHERE id = ?`,
+      [stockKey],
+    );
+    const stockSpeed = stocks.length > 0 ? Number(stocks[0].speed) : undefined;
+
+    const pushed = !!(shotISO && stockSpeed && shotISO > stockSpeed);
+    const pulled = !!(shotISO && stockSpeed && shotISO < stockSpeed);
+
+    await this.rollTagService.syncAutoTag(rollKey, "pushed", pushed);
+    await this.rollTagService.syncAutoTag(rollKey, "pulled", pulled);
+  }
+
   private async syncExpiredTag(
     rollKey: string,
     expirationDate?: Date | null,
@@ -266,6 +284,11 @@ export class RollService implements OnModuleInit {
       isErrorCorrection: dto.isErrorCorrection,
       metadata: dto.metadata,
     });
+
+    if (dto.targetState === RollState.FINISHED) {
+      const shotISO = dto.metadata?.shotISO as number | undefined;
+      await this.syncPushPullTags(key, roll.stockKey, shotISO);
+    }
 
     return this.update(key, { state: dto.targetState });
   }

--- a/frollz-ui/src/views/RollDetailView.vue
+++ b/frollz-ui/src/views/RollDetailView.vue
@@ -79,11 +79,20 @@
             <!-- Storage state metadata form -->
             <div v-if="pendingMetadataTransition" class="border border-blue-300 dark:border-blue-600 rounded-md p-3 bg-blue-50 dark:bg-blue-900/20">
               <p class="text-sm font-medium text-blue-800 dark:text-blue-200 mb-3">{{ pendingMetadataTransition }} details</p>
-              <label class="block text-xs text-gray-600 dark:text-gray-400">
+              <label v-if="pendingMetadataTransition !== RollState.FINISHED" class="block text-xs text-gray-600 dark:text-gray-400">
                 Storage temperature ({{ temperatureUnit }}) — optional
                 <input
                   v-model="metadataTemperature"
                   type="number"
+                  class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+                />
+              </label>
+              <label v-if="pendingMetadataTransition === RollState.FINISHED" class="block text-xs text-gray-600 dark:text-gray-400">
+                Shot ISO — optional
+                <input
+                  v-model="metadataShotISO"
+                  type="number"
+                  placeholder="e.g. 400"
                   class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
                 />
               </label>
@@ -186,6 +195,7 @@
             </div>
             <p v-if="entry.notes" class="mt-1 text-sm text-gray-600 dark:text-gray-400">{{ entry.notes }}</p>
             <p v-if="entry.metadata?.temperature != null" class="mt-1 text-xs text-gray-500 dark:text-gray-400">{{ entry.metadata.temperature }}{{ temperatureUnit }}</p>
+            <p v-if="entry.metadata?.shotISO != null" class="mt-1 text-xs text-gray-500 dark:text-gray-400">Shot at ISO {{ entry.metadata.shotISO }}</p>
           </li>
         </ol>
       </div>
@@ -213,8 +223,9 @@ const transitionSubmitting = ref(false)
 const pendingTransition = ref<RollState | null>(null)
 const pendingMetadataTransition = ref<RollState | null>(null)
 const metadataTemperature = ref('')
+const metadataShotISO = ref('')
 
-const STATES_REQUIRING_METADATA = new Set([RollState.FROZEN, RollState.REFRIGERATED, RollState.SHELVED])
+const STATES_REQUIRING_METADATA = new Set([RollState.FROZEN, RollState.REFRIGERATED, RollState.SHELVED, RollState.FINISHED])
 const isImperial = navigator.language === 'en-US'
 const temperatureUnit = isImperial ? '°F' : '°C'
 const TEMPERATURE_DEFAULTS: Partial<Record<RollState, number>> = {
@@ -318,6 +329,7 @@ const handleTransition = (targetState: RollState) => {
   if (STATES_REQUIRING_METADATA.has(targetState)) {
     pendingMetadataTransition.value = targetState
     metadataTemperature.value = String(TEMPERATURE_DEFAULTS[targetState] ?? '')
+    metadataShotISO.value = ''
     return
   }
   void executeTransition(targetState)
@@ -327,8 +339,13 @@ const submitMetadataTransition = () => {
   if (!pendingMetadataTransition.value) return
   const target = pendingMetadataTransition.value
   const temp = metadataTemperature.value !== '' ? parseFloat(metadataTemperature.value) : undefined
+  const shotISO = metadataShotISO.value !== '' ? parseFloat(metadataShotISO.value) : undefined
   pendingMetadataTransition.value = null
-  void executeTransition(target, undefined, temp != null ? { temperature: temp } : undefined)
+
+  const metadata: Record<string, unknown> = {}
+  if (temp != null) metadata.temperature = temp
+  if (shotISO != null) metadata.shotISO = shotISO
+  void executeTransition(target, undefined, Object.keys(metadata).length > 0 ? metadata : undefined)
 }
 
 const confirmTransition = (isErrorCorrection: boolean) => {

--- a/frollz-ui/src/views/__tests__/RollDetailView.spec.ts
+++ b/frollz-ui/src/views/__tests__/RollDetailView.spec.ts
@@ -268,6 +268,59 @@ describe('RollDetailView', () => {
       )
     })
 
+    it('should show shot ISO field (not temperature) when clicking Finished', async () => {
+      vi.mocked(rollApi.getById).mockResolvedValue({ data: makeRoll({ state: RollState.LOADED }) } as any)
+      const wrapper = await mountView()
+
+      const buttons = wrapper.findAll('button')
+      const finishedBtn = buttons.find(b => b.text() === 'Finished')
+      await finishedBtn!.trigger('click')
+      await flushPromises()
+
+      expect(wrapper.text()).toContain('Shot ISO')
+      expect(wrapper.text()).not.toContain('temperature')
+      expect(rollApi.transition).not.toHaveBeenCalled()
+    })
+
+    it('should include shotISO in metadata when confirming FINISHED', async () => {
+      vi.mocked(rollApi.getById).mockResolvedValue({ data: makeRoll({ state: RollState.LOADED }) } as any)
+      const wrapper = await mountView()
+
+      const buttons = wrapper.findAll('button')
+      const finishedBtn = buttons.find(b => b.text() === 'Finished')
+      await finishedBtn!.trigger('click')
+      await flushPromises()
+
+      const input = wrapper.find('input[type="number"]')
+      await input.setValue('800')
+
+      const confirmBtn = wrapper.findAll('button').find(b => b.text() === 'Confirm')
+      await confirmBtn!.trigger('click')
+      await flushPromises()
+
+      expect(rollApi.transition).toHaveBeenCalledWith(
+        'r1', RollState.FINISHED, undefined, undefined, { shotISO: 800 },
+      )
+    })
+
+    it('should transition FINISHED with no metadata when shotISO is left blank', async () => {
+      vi.mocked(rollApi.getById).mockResolvedValue({ data: makeRoll({ state: RollState.LOADED }) } as any)
+      const wrapper = await mountView()
+
+      const buttons = wrapper.findAll('button')
+      const finishedBtn = buttons.find(b => b.text() === 'Finished')
+      await finishedBtn!.trigger('click')
+      await flushPromises()
+
+      const confirmBtn = wrapper.findAll('button').find(b => b.text() === 'Confirm')
+      await confirmBtn!.trigger('click')
+      await flushPromises()
+
+      expect(rollApi.transition).toHaveBeenCalledWith(
+        'r1', RollState.FINISHED, undefined, undefined, undefined,
+      )
+    })
+
     it('should dismiss metadata form without transitioning when Cancel is clicked', async () => {
       vi.mocked(rollApi.getById).mockResolvedValue({ data: makeRoll({ state: RollState.ADDED }) } as any)
       const wrapper = await mountView()


### PR DESCRIPTION
## Summary

- Clicking **Finished** now shows an inline form with an optional **Shot ISO** field before the transition fires
- `shotISO` is stored in `roll_states.metadata` and displayed in the history timeline as "Shot at ISO X"
- After transitioning to FINISHED, `pushed` and `pulled` auto-tags are automatically synced:
  - `shotISO > stock speed` → apply `pushed`, remove `pulled`
  - `shotISO < stock speed` → apply `pulled`, remove `pushed`
  - `shotISO = stock speed` or unset → remove both

## Related issues

Closes #65. Part of #55.

## Test plan

- [x] 138 backend unit tests pass
- [x] 129 frontend unit tests pass
- [x] Transition to Finished with shotISO above box speed — confirm `pushed` tag appears
- [x] Transition to Finished with shotISO below box speed — confirm `pulled` tag appears
- [x] Transition to Finished at box speed — confirm neither tag is applied
- [x] Leave shot ISO blank and confirm — confirm transition succeeds with no metadata
- [x] History shows "Shot at ISO X" for entries with shotISO

🤖 Generated with [Claude Code](https://claude.com/claude-code)