### PR TITLE
feat: phase 5 — lab state metadata and cross-processed auto-tag (#66 #67)

### DIFF
--- a/frollz-api/src/roll/roll.service.spec.ts
+++ b/frollz-api/src/roll/roll.service.spec.ts
@@ -238,6 +238,68 @@ describe("RollService", () => {
     });
   });
 
+  describe("transition to SENT_FOR_DEVELOPMENT", () => {
+    const finishedRollRow = {
+      id: "roll-uuid",
+      roll_id: "roll-00001",
+      stock_key: "stock-1",
+      state: RollState.FINISHED,
+      images_url: null,
+      date_obtained: new Date().toISOString(),
+      obtainment_method: "Purchase",
+      obtained_from: "B&H",
+      expiration_date: null,
+      times_exposed_to_xrays: 0,
+      loaded_into: null,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+    };
+
+    it("should apply cross-processed tag when processRequested differs from stock process", async () => {
+      db.query
+        .mockResolvedValueOnce([finishedRollRow])
+        .mockResolvedValueOnce([{ process: "C-41" }])
+        .mockResolvedValueOnce([finishedRollRow]);
+
+      await service.transition("roll-uuid", {
+        targetState: RollState.SENT_FOR_DEVELOPMENT,
+        metadata: { labName: "The Darkroom", deliveryMethod: "Mail in", processRequested: "E-6" },
+      });
+
+      expect(rollTagService.syncAutoTag).toHaveBeenCalledWith("roll-uuid", "cross-processed", true);
+    });
+
+    it("should not apply cross-processed tag when processRequested matches stock process", async () => {
+      db.query
+        .mockResolvedValueOnce([finishedRollRow])
+        .mockResolvedValueOnce([{ process: "C-41" }])
+        .mockResolvedValueOnce([finishedRollRow]);
+
+      await service.transition("roll-uuid", {
+        targetState: RollState.SENT_FOR_DEVELOPMENT,
+        metadata: { labName: "The Darkroom", deliveryMethod: "Mail in", processRequested: "C-41" },
+      });
+
+      expect(rollTagService.syncAutoTag).toHaveBeenCalledWith("roll-uuid", "cross-processed", false);
+    });
+
+    it("should not call syncCrossProcessedTag when processRequested is absent", async () => {
+      db.query
+        .mockResolvedValueOnce([finishedRollRow])
+        .mockResolvedValueOnce([finishedRollRow]);
+
+      await service.transition("roll-uuid", {
+        targetState: RollState.SENT_FOR_DEVELOPMENT,
+        metadata: { labName: "The Darkroom", deliveryMethod: "Mail in" },
+      });
+
+      const crossCalls = rollTagService.syncAutoTag.mock.calls.filter(
+        ([, tag]) => tag === "cross-processed",
+      );
+      expect(crossCalls.length).toBe(0);
+    });
+  });
+
   describe("transition to FINISHED", () => {
     const loadedRollRow = {
       id: "roll-uuid",
@@ -314,7 +376,7 @@ describe("RollService", () => {
       expect(rollTagService.syncAutoTag).toHaveBeenCalledWith("roll-uuid", "pulled", false);
     });
 
-    it("should not call syncPushPullTags for non-FINISHED transitions", async () => {
+    it("should not call syncPushPullTags when transitioning to a non-FINISHED state", async () => {
       db.query.mockResolvedValue([loadedRollRow]);
 
       await service.transition("roll-uuid", {

--- a/frollz-api/src/roll/roll.service.ts
+++ b/frollz-api/src/roll/roll.service.ts
@@ -94,6 +94,21 @@ export class RollService implements OnModuleInit {
     }
   }
 
+  private async syncCrossProcessedTag(
+    rollKey: string,
+    stockKey: string,
+    processRequested?: string,
+  ): Promise<void> {
+    if (!processRequested) return;
+    const stocks = await this.databaseService.query<{ process: string }>(
+      `SELECT process FROM stocks WHERE id = ?`,
+      [stockKey],
+    );
+    if (stocks.length === 0) return;
+    const isCrossProcessed = processRequested !== stocks[0].process;
+    await this.rollTagService.syncAutoTag(rollKey, "cross-processed", isCrossProcessed);
+  }
+
   private async syncPushPullTags(
     rollKey: string,
     stockKey: string,
@@ -288,6 +303,11 @@ export class RollService implements OnModuleInit {
     if (dto.targetState === RollState.FINISHED) {
       const shotISO = dto.metadata?.shotISO as number | undefined;
       await this.syncPushPullTags(key, roll.stockKey, shotISO);
+    }
+
+    if (dto.targetState === RollState.SENT_FOR_DEVELOPMENT) {
+      const processRequested = dto.metadata?.processRequested as string | undefined;
+      await this.syncCrossProcessedTag(key, roll.stockKey, processRequested);
     }
 
     return this.update(key, { state: dto.targetState });

--- a/frollz-ui/src/views/RollDetailView.vue
+++ b/frollz-ui/src/views/RollDetailView.vue
@@ -96,6 +96,47 @@
                   class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
                 />
               </label>
+              <div v-if="pendingMetadataTransition === RollState.SENT_FOR_DEVELOPMENT" class="space-y-2">
+                <label class="block text-xs text-gray-600 dark:text-gray-400">
+                  Lab name <span class="text-red-500">*</span>
+                  <input
+                    v-model="metadataLabName"
+                    type="text"
+                    placeholder="e.g. The Darkroom"
+                    class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+                  />
+                </label>
+                <label class="block text-xs text-gray-600 dark:text-gray-400">
+                  Delivery method <span class="text-red-500">*</span>
+                  <select
+                    v-model="metadataDeliveryMethod"
+                    class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+                  >
+                    <option value="">Select…</option>
+                    <option v-for="m in DELIVERY_METHODS" :key="m" :value="m">{{ m }}</option>
+                  </select>
+                </label>
+                <label class="block text-xs text-gray-600 dark:text-gray-400">
+                  Process requested <span class="text-red-500">*</span>
+                  <select
+                    v-model="metadataProcessRequested"
+                    class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+                  >
+                    <option value="">Select…</option>
+                    <option v-for="p in PROCESSES_REQUESTED" :key="p" :value="p">{{ p }}</option>
+                  </select>
+                </label>
+                <label class="block text-xs text-gray-600 dark:text-gray-400">
+                  Push/pull stops — optional
+                  <input
+                    v-model="metadataPushPullStops"
+                    type="number"
+                    placeholder="+2 push, -1 pull"
+                    class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+                  />
+                </label>
+                <p v-if="metadataFormError" class="text-xs text-red-600 dark:text-red-400">{{ metadataFormError }}</p>
+              </div>
               <div class="flex gap-2 mt-3">
                 <button
                   @click="submitMetadataTransition"
@@ -196,6 +237,9 @@
             <p v-if="entry.notes" class="mt-1 text-sm text-gray-600 dark:text-gray-400">{{ entry.notes }}</p>
             <p v-if="entry.metadata?.temperature != null" class="mt-1 text-xs text-gray-500 dark:text-gray-400">{{ entry.metadata.temperature }}{{ temperatureUnit }}</p>
             <p v-if="entry.metadata?.shotISO != null" class="mt-1 text-xs text-gray-500 dark:text-gray-400">Shot at ISO {{ entry.metadata.shotISO }}</p>
+            <p v-if="entry.metadata?.labName" class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              {{ entry.metadata.labName }} · {{ entry.metadata.deliveryMethod }} · {{ entry.metadata.processRequested }}<span v-if="entry.metadata.pushPullStops != null"> · {{ (entry.metadata.pushPullStops as number) > 0 ? '+' : '' }}{{ entry.metadata.pushPullStops }} stops</span>
+            </p>
           </li>
         </ol>
       </div>
@@ -224,8 +268,16 @@ const pendingTransition = ref<RollState | null>(null)
 const pendingMetadataTransition = ref<RollState | null>(null)
 const metadataTemperature = ref('')
 const metadataShotISO = ref('')
+const metadataLabName = ref('')
+const metadataDeliveryMethod = ref('')
+const metadataProcessRequested = ref('')
+const metadataPushPullStops = ref('')
+const metadataFormError = ref('')
 
-const STATES_REQUIRING_METADATA = new Set([RollState.FROZEN, RollState.REFRIGERATED, RollState.SHELVED, RollState.FINISHED])
+const DELIVERY_METHODS = ['Drop off', 'Mail in'] as const
+const PROCESSES_REQUESTED = ['C-41', 'E-6', 'Black & White', 'Instant'] as const
+
+const STATES_REQUIRING_METADATA = new Set([RollState.FROZEN, RollState.REFRIGERATED, RollState.SHELVED, RollState.FINISHED, RollState.SENT_FOR_DEVELOPMENT])
 const isImperial = navigator.language === 'en-US'
 const temperatureUnit = isImperial ? '°F' : '°C'
 const TEMPERATURE_DEFAULTS: Partial<Record<RollState, number>> = {
@@ -330,6 +382,11 @@ const handleTransition = (targetState: RollState) => {
     pendingMetadataTransition.value = targetState
     metadataTemperature.value = String(TEMPERATURE_DEFAULTS[targetState] ?? '')
     metadataShotISO.value = ''
+    metadataLabName.value = ''
+    metadataDeliveryMethod.value = ''
+    metadataProcessRequested.value = ''
+    metadataPushPullStops.value = ''
+    metadataFormError.value = ''
     return
   }
   void executeTransition(targetState)
@@ -338,13 +395,25 @@ const handleTransition = (targetState: RollState) => {
 const submitMetadataTransition = () => {
   if (!pendingMetadataTransition.value) return
   const target = pendingMetadataTransition.value
+
+  if (target === RollState.SENT_FOR_DEVELOPMENT) {
+    if (!metadataLabName.value.trim()) { metadataFormError.value = 'Lab name is required.'; return }
+    if (!metadataDeliveryMethod.value) { metadataFormError.value = 'Delivery method is required.'; return }
+    if (!metadataProcessRequested.value) { metadataFormError.value = 'Process is required.'; return }
+  }
+
   const temp = metadataTemperature.value !== '' ? parseFloat(metadataTemperature.value) : undefined
   const shotISO = metadataShotISO.value !== '' ? parseFloat(metadataShotISO.value) : undefined
+  const pushPullStops = metadataPushPullStops.value !== '' ? parseInt(metadataPushPullStops.value, 10) : undefined
   pendingMetadataTransition.value = null
 
   const metadata: Record<string, unknown> = {}
   if (temp != null) metadata.temperature = temp
   if (shotISO != null) metadata.shotISO = shotISO
+  if (metadataLabName.value.trim()) metadata.labName = metadataLabName.value.trim()
+  if (metadataDeliveryMethod.value) metadata.deliveryMethod = metadataDeliveryMethod.value
+  if (metadataProcessRequested.value) metadata.processRequested = metadataProcessRequested.value
+  if (pushPullStops != null) metadata.pushPullStops = pushPullStops
   void executeTransition(target, undefined, Object.keys(metadata).length > 0 ? metadata : undefined)
 }
 

--- a/frollz-ui/src/views/__tests__/RollDetailView.spec.ts
+++ b/frollz-ui/src/views/__tests__/RollDetailView.spec.ts
@@ -321,6 +321,63 @@ describe('RollDetailView', () => {
       )
     })
 
+    it('should show lab form when clicking Sent For Development', async () => {
+      vi.mocked(rollApi.getById).mockResolvedValue({ data: makeRoll({ state: RollState.FINISHED }) } as any)
+      const wrapper = await mountView()
+
+      const buttons = wrapper.findAll('button')
+      const sentBtn = buttons.find(b => b.text() === 'Sent For Development')
+      await sentBtn!.trigger('click')
+      await flushPromises()
+
+      expect(wrapper.text()).toContain('Lab name')
+      expect(wrapper.text()).toContain('Delivery method')
+      expect(wrapper.text()).toContain('Process requested')
+      expect(rollApi.transition).not.toHaveBeenCalled()
+    })
+
+    it('should show validation error when required lab fields are missing', async () => {
+      vi.mocked(rollApi.getById).mockResolvedValue({ data: makeRoll({ state: RollState.FINISHED }) } as any)
+      const wrapper = await mountView()
+
+      const buttons = wrapper.findAll('button')
+      const sentBtn = buttons.find(b => b.text() === 'Sent For Development')
+      await sentBtn!.trigger('click')
+      await flushPromises()
+
+      const confirmBtn = wrapper.findAll('button').find(b => b.text() === 'Confirm')
+      await confirmBtn!.trigger('click')
+      await flushPromises()
+
+      expect(wrapper.text()).toContain('required')
+      expect(rollApi.transition).not.toHaveBeenCalled()
+    })
+
+    it('should call transition with lab metadata when all required fields are filled', async () => {
+      vi.mocked(rollApi.getById).mockResolvedValue({ data: makeRoll({ state: RollState.FINISHED }) } as any)
+      const wrapper = await mountView()
+
+      const buttons = wrapper.findAll('button')
+      const sentBtn = buttons.find(b => b.text() === 'Sent For Development')
+      await sentBtn!.trigger('click')
+      await flushPromises()
+
+      const vm = wrapper.vm as any
+      vm.metadataLabName = 'The Darkroom'
+      vm.metadataDeliveryMethod = 'Mail in'
+      vm.metadataProcessRequested = 'C-41'
+      await wrapper.vm.$nextTick()
+
+      const confirmBtn = wrapper.findAll('button').find(b => b.text() === 'Confirm')
+      await confirmBtn!.trigger('click')
+      await flushPromises()
+
+      expect(rollApi.transition).toHaveBeenCalledWith(
+        'r1', RollState.SENT_FOR_DEVELOPMENT, undefined, undefined,
+        expect.objectContaining({ labName: 'The Darkroom', deliveryMethod: 'Mail in', processRequested: 'C-41' }),
+      )
+    })
+
     it('should dismiss metadata form without transitioning when Cancel is clicked', async () => {
       vi.mocked(rollApi.getById).mockResolvedValue({ data: makeRoll({ state: RollState.ADDED }) } as any)
       const wrapper = await mountView()


### PR DESCRIPTION
## Summary

**#66 — SENT_FOR_DEVELOPMENT:**
- Clicking "Sent For Development" opens an inline lab form with three required fields (lab name, delivery method, process requested) and one optional field (push/pull stops)
- Form validates required fields and shows an inline error before allowing submission
- All fields stored in `roll_states.metadata`
- After transition, the `cross-processed` tag is auto-applied if `processRequested` differs from the stock's native process, or removed if it matches
- History timeline displays: lab name · delivery method · process · ±N stops

**#67 — DEVELOPED:**
- No extra metadata needed; transitions immediately (no form)

## Related issues

Closes #66, #67. Part of #55.

## Test plan

- [x] 141 backend unit tests pass
- [x] 132 frontend unit tests pass
- [x] Click "Sent For Development" — confirm lab form appears
- [x] Click Confirm with empty fields — confirm validation error appears
- [x] Fill required fields and confirm — confirm transition fires with correct metadata
- [x] Send a C-41 stock to E-6 development — confirm `cross-processed` tag is applied
- [x] Send a C-41 stock to C-41 development — confirm no `cross-processed` tag
- [x] History shows lab details line for the transition entry
- [x] Click "Developed" — confirm it transitions immediately with no form

🤖 Generated with [Claude Code](https://claude.com/claude-code)