### PR TITLE
feat: date capture for FROZEN, FINISHED, SENT_FOR_DEVELOPMENT transitions (#55)

### DIFF
--- a/frollz-ui/src/views/RollDetailView.vue
+++ b/frollz-ui/src/views/RollDetailView.vue
@@ -348,7 +348,7 @@ const PROCESSES_REQUESTED = ['C-41', 'E-6', 'Black & White', 'Instant'] as const
 const todayISO = () => new Date().toISOString().slice(0, 10)
 
 const STATES_REQUIRING_METADATA = new Set([RollState.FROZEN, RollState.REFRIGERATED, RollState.SHELVED, RollState.LOADED, RollState.FINISHED, RollState.SENT_FOR_DEVELOPMENT, RollState.DEVELOPED, RollState.RECEIVED])
-const STATES_WITH_DATE_CAPTURE = new Set([RollState.REFRIGERATED, RollState.SHELVED, RollState.LOADED, RollState.DEVELOPED])
+const STATES_WITH_DATE_CAPTURE = new Set([RollState.FROZEN, RollState.REFRIGERATED, RollState.SHELVED, RollState.LOADED, RollState.FINISHED, RollState.SENT_FOR_DEVELOPMENT, RollState.DEVELOPED])
 const isImperial = navigator.language === 'en-US'
 const temperatureUnit = isImperial ? '°F' : '°C'
 const TEMPERATURE_DEFAULTS: Partial<Record<RollState, number>> = {

--- a/frollz-ui/src/views/__tests__/RollDetailView.spec.ts
+++ b/frollz-ui/src/views/__tests__/RollDetailView.spec.ts
@@ -235,6 +235,8 @@ describe('RollDetailView', () => {
       await frozenBtn!.trigger('click')
       await flushPromises()
 
+      const vm = wrapper.vm as any
+      vm.metadataDate = '2026-01-10'
       const input = wrapper.find('input[type="number"]')
       await input.setValue('-20')
 
@@ -243,7 +245,7 @@ describe('RollDetailView', () => {
       await flushPromises()
 
       expect(rollApi.transition).toHaveBeenCalledWith(
-        'r1', RollState.FROZEN, undefined, undefined, undefined, { temperature: -20 },
+        'r1', RollState.FROZEN, '2026-01-10', undefined, undefined, { temperature: -20 },
       )
     })
 
@@ -256,6 +258,8 @@ describe('RollDetailView', () => {
       await frozenBtn!.trigger('click')
       await flushPromises()
 
+      const vm = wrapper.vm as any
+      vm.metadataDate = '2026-01-10'
       const input = wrapper.find('input[type="number"]')
       await input.setValue('')
 
@@ -264,7 +268,7 @@ describe('RollDetailView', () => {
       await flushPromises()
 
       expect(rollApi.transition).toHaveBeenCalledWith(
-        'r1', RollState.FROZEN, undefined, undefined, undefined, undefined,
+        'r1', RollState.FROZEN, '2026-01-10', undefined, undefined, undefined,
       )
     })
 
@@ -291,6 +295,8 @@ describe('RollDetailView', () => {
       await finishedBtn!.trigger('click')
       await flushPromises()
 
+      const vm = wrapper.vm as any
+      vm.metadataDate = '2026-02-14'
       const input = wrapper.find('input[type="number"]')
       await input.setValue('800')
 
@@ -299,7 +305,7 @@ describe('RollDetailView', () => {
       await flushPromises()
 
       expect(rollApi.transition).toHaveBeenCalledWith(
-        'r1', RollState.FINISHED, undefined, undefined, undefined, { shotISO: 800 },
+        'r1', RollState.FINISHED, '2026-02-14', undefined, undefined, { shotISO: 800 },
       )
     })
 
@@ -312,12 +318,15 @@ describe('RollDetailView', () => {
       await finishedBtn!.trigger('click')
       await flushPromises()
 
+      const vm = wrapper.vm as any
+      vm.metadataDate = '2026-02-14'
+
       const confirmBtn = wrapper.findAll('button').find(b => b.text() === 'Confirm')
       await confirmBtn!.trigger('click')
       await flushPromises()
 
       expect(rollApi.transition).toHaveBeenCalledWith(
-        'r1', RollState.FINISHED, undefined, undefined, undefined, undefined,
+        'r1', RollState.FINISHED, '2026-02-14', undefined, undefined, undefined,
       )
     })
 
@@ -363,6 +372,7 @@ describe('RollDetailView', () => {
       await flushPromises()
 
       const vm = wrapper.vm as any
+      vm.metadataDate = '2026-03-01'
       vm.metadataLabName = 'The Darkroom'
       vm.metadataDeliveryMethod = 'Mail in'
       vm.metadataProcessRequested = 'C-41'
@@ -373,7 +383,7 @@ describe('RollDetailView', () => {
       await flushPromises()
 
       expect(rollApi.transition).toHaveBeenCalledWith(
-        'r1', RollState.SENT_FOR_DEVELOPMENT, undefined, undefined, undefined,
+        'r1', RollState.SENT_FOR_DEVELOPMENT, '2026-03-01', undefined, undefined,
         expect.objectContaining({ labName: 'The Darkroom', deliveryMethod: 'Mail in', processRequested: 'C-41' }),
       )
     })


### PR DESCRIPTION
## Summary

Completes the date capture requirement from #55 for the three remaining states that were previously missing it:

- **FROZEN** — date picker now shown before confirming (alongside the existing temperature field)
- **FINISHED** — date picker now shown before confirming (alongside the existing shot ISO field)
- **SENT_FOR_DEVELOPMENT** — date picker now shown before confirming (alongside the existing lab fields)

All seven non-RECEIVED states now capture a required user-specified date on transition. RECEIVED uses its own date fields within the scans/negatives metadata.

## Test plan

- [x] Transition a roll to FROZEN — verify date picker appears above the temperature field, defaults to today
- [x] Transition a roll to FINISHED — verify date picker appears above the shot ISO field, defaults to today
- [x] Transition a roll to SENT_FOR_DEVELOPMENT — verify date picker appears above the lab fields, defaults to today
- [x] Verify the state history timeline reflects the user-entered date for all three states
- [x] All 135 UI tests pass

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)