### PR TITLE
fix: make CreateRollDto.state optional, defaulting to ADDED

### DIFF
--- a/frollz-api/src/roll/dto/create-roll.dto.ts
+++ b/frollz-api/src/roll/dto/create-roll.dto.ts
@@ -25,9 +25,10 @@ export class CreateRollDto {
   @MaxLength(255)
   stockKey: string;
 
-  @ApiProperty({ enum: RollState })
+  @ApiProperty({ enum: RollState, required: false, default: RollState.ADDED })
+  @IsOptional()
   @IsEnum(RollState)
-  state: RollState;
+  state?: RollState;
 
   @ApiProperty({ required: false })
   @IsOptional()


### PR DESCRIPTION
## Summary

- `state` in `CreateRollDto` was marked required by the validator (`@IsEnum` with no `@IsOptional`) but `RollService.create()` had a `?? RollState.ADDED` fallback, making that fallback dead code
- Made `state` optional with `@IsOptional()` so the fallback is now live and callers don't need to specify `"Added"` on every create request

## Test plan

- [x] Creating a roll without `state` in the request body succeeds and defaults to `Added`
- [x] Creating a roll with an explicit `state` (e.g. `Shelved` for retroactive entry) still works
- [x] All existing API tests pass

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)