### PR TITLE
fix: validate rollKey query param in RollStateController

### DIFF
--- a/frollz-api/src/roll-state/roll-state.controller.ts
+++ b/frollz-api/src/roll-state/roll-state.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Query } from "@nestjs/common";
+import { Controller, Get, Query, BadRequestException } from "@nestjs/common";
 import { ApiTags, ApiOperation, ApiResponse, ApiQuery } from "@nestjs/swagger";
 import { RollStateService } from "./roll-state.service";
 import { RollStateHistory } from "./entities/roll-state.entity";
@@ -23,6 +23,7 @@ export class RollStateController {
   findByRollKey(
     @Query("rollKey") rollKey: string,
   ): Promise<RollStateHistory[]> {
+    if (!rollKey) throw new BadRequestException("rollKey query parameter is required");
     return this.rollStateService.findByRollKey(rollKey);
   }
 }


### PR DESCRIPTION
## Summary

- `GET /roll-states` documented `rollKey` as required in Swagger but never validated it at runtime
- A missing `rollKey` would silently query `WHERE roll_id = undefined` and return an empty array
- Now returns `400 Bad Request` with a clear message when `rollKey` is absent

## Test plan

- [x] `GET /roll-states` without `rollKey` returns 400
- [x] `GET /roll-states?rollKey=<valid-key>` returns state history as before
- [x] All existing API tests pass

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)