### PR TITLE
fix: extract toSlug to module scope in StockService

### DIFF
--- a/frollz-api/src/stock/stock.service.ts
+++ b/frollz-api/src/stock/stock.service.ts
@@ -1,4 +1,6 @@
 import { Injectable } from "@nestjs/common";
+
+const toSlug = (s: string) => s.toLowerCase().replace(/\s+/g, "-");
 import { DatabaseService } from "../database/database.service";
 import { CreateStockDto } from "./dto/create-stock.dto";
 import { CreateStockMultipleFormatsDto } from "./dto/create-stock-multiple-formats.dto";
@@ -25,7 +27,6 @@ export class StockService {
   constructor(private readonly databaseService: DatabaseService) {}
 
   async create(createStockDto: CreateStockDto): Promise<Stock> {
-    const toSlug = (s: string) => s.toLowerCase().replace(/\s+/g, "-");
     const id = `${toSlug(createStockDto.manufacturer)}-${toSlug(createStockDto.brand)}-${createStockDto.speed}-${createStockDto.formatKey}`;
     const now = new Date();
 
@@ -52,7 +53,6 @@ export class StockService {
   async createMultipleFormats(
     dto: CreateStockMultipleFormatsDto,
   ): Promise<Stock[]> {
-    const toSlug = (s: string) => s.toLowerCase().replace(/\s+/g, "-");
     const now = new Date();
 
     return Promise.all(


### PR DESCRIPTION
## Summary

- `toSlug` was defined as an identical inline arrow function in both `create()` and `createMultipleFormats()`
- Moved to module scope so there's a single definition to maintain

## Test plan

- [x] All existing API tests pass
- [x] Stock creation still generates correct slugged IDs

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)