### PR TITLE
fix: add ECN-2 to process requested dropdown

### DIFF
--- a/frollz-ui/src/views/RollDetailView.vue
+++ b/frollz-ui/src/views/RollDetailView.vue
@@ -325,7 +325,7 @@ const metadataNegativesReceived = ref(false)
 const metadataNegativesDate = ref('')
 
 const DELIVERY_METHODS = ['Drop off', 'Mail in'] as const
-const PROCESSES_REQUESTED = ['C-41', 'E-6', 'Black & White', 'Instant'] as const
+const PROCESSES_REQUESTED = ['C-41', 'E-6', 'ECN-2', 'Black & White', 'Instant'] as const
 
 const todayISO = () => new Date().toISOString().slice(0, 10)
 


### PR DESCRIPTION
## Summary

- Added `ECN-2` to `PROCESSES_REQUESTED` in the SENT_FOR_DEVELOPMENT metadata form
- ECN-2 was already in the backend `Process` enum but was missing from the UI, preventing users from recording cinema stock development (e.g. Kodak Vision3)

## Test plan

- [x] ECN-2 appears in the process dropdown when transitioning a roll to SENT_FOR_DEVELOPMENT
- [x] All existing UI tests pass

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)