### PR TITLE
fix: remove() returns false when record not found (#81)

### DIFF
--- a/frollz-api/src/film-format/film-format.service.ts
+++ b/frollz-api/src/film-format/film-format.service.ts
@@ -90,10 +90,10 @@ export class FilmFormatService {
   }
 
   async remove(key: string): Promise<boolean> {
-    await this.databaseService.execute(
-      `DELETE FROM film_formats WHERE id = ?`,
+    const rows = await this.databaseService.query<{ id: string }>(
+      `DELETE FROM film_formats WHERE id = ? RETURNING id`,
       [key],
     );
-    return true;
+    return rows.length > 0;
   }
 }

--- a/frollz-api/src/roll-tag/roll-tag.service.spec.ts
+++ b/frollz-api/src/roll-tag/roll-tag.service.spec.ts
@@ -127,14 +127,22 @@ describe("RollTagService", () => {
   });
 
   describe("remove", () => {
-    it("should execute DELETE and return true", async () => {
+    it("should return true when the record is deleted", async () => {
+      db.query.mockResolvedValueOnce([{ id: "abc" }]);
       const result = await service.remove("abc");
 
-      expect(db.execute).toHaveBeenCalledWith(
+      expect(db.query).toHaveBeenCalledWith(
         expect.stringContaining("DELETE FROM roll_tags"),
         ["abc"],
       );
       expect(result).toBe(true);
+    });
+
+    it("should return false when the record does not exist", async () => {
+      db.query.mockResolvedValueOnce([]);
+      const result = await service.remove("nonexistent");
+
+      expect(result).toBe(false);
     });
   });
 

--- a/frollz-api/src/roll-tag/roll-tag.service.ts
+++ b/frollz-api/src/roll-tag/roll-tag.service.ts
@@ -64,10 +64,11 @@ export class RollTagService {
   }
 
   async remove(key: string): Promise<boolean> {
-    await this.databaseService.execute(`DELETE FROM roll_tags WHERE id = ?`, [
-      key,
-    ]);
-    return true;
+    const rows = await this.databaseService.query<{ id: string }>(
+      `DELETE FROM roll_tags WHERE id = ? RETURNING id`,
+      [key],
+    );
+    return rows.length > 0;
   }
 
   async syncAutoTag(

--- a/frollz-api/src/roll/roll.service.spec.ts
+++ b/frollz-api/src/roll/roll.service.spec.ts
@@ -500,4 +500,24 @@ describe("RollService", () => {
       expect(pushPullCalls.length).toBe(2);
     });
   });
+
+  describe("remove", () => {
+    it("should return true when the record is deleted", async () => {
+      db.query.mockResolvedValueOnce([{ id: "roll-uuid" }]);
+      const result = await service.remove("roll-uuid");
+
+      expect(db.query).toHaveBeenCalledWith(
+        expect.stringContaining("DELETE FROM rolls"),
+        ["roll-uuid"],
+      );
+      expect(result).toBe(true);
+    });
+
+    it("should return false when the record does not exist", async () => {
+      db.query.mockResolvedValueOnce([]);
+      const result = await service.remove("nonexistent");
+
+      expect(result).toBe(false);
+    });
+  });
 });

--- a/frollz-api/src/roll/roll.service.ts
+++ b/frollz-api/src/roll/roll.service.ts
@@ -298,8 +298,11 @@ export class RollService implements OnModuleInit {
   }
 
   async remove(key: string): Promise<boolean> {
-    await this.databaseService.execute(`DELETE FROM rolls WHERE id = ?`, [key]);
-    return true;
+    const rows = await this.databaseService.query<{ id: string }>(
+      `DELETE FROM rolls WHERE id = ? RETURNING id`,
+      [key],
+    );
+    return rows.length > 0;
   }
 
   async transition(key: string, dto: TransitionRollDto): Promise<Roll | null> {

--- a/frollz-api/src/stock-tag/stock-tag.service.spec.ts
+++ b/frollz-api/src/stock-tag/stock-tag.service.spec.ts
@@ -127,14 +127,22 @@ describe("StockTagService", () => {
   });
 
   describe("remove", () => {
-    it("should execute DELETE and return true", async () => {
+    it("should return true when the record is deleted", async () => {
+      db.query.mockResolvedValueOnce([{ id: "abc" }]);
       const result = await service.remove("abc");
 
-      expect(db.execute).toHaveBeenCalledWith(
+      expect(db.query).toHaveBeenCalledWith(
         expect.stringContaining("DELETE FROM stock_tags"),
         ["abc"],
       );
       expect(result).toBe(true);
+    });
+
+    it("should return false when the record does not exist", async () => {
+      db.query.mockResolvedValueOnce([]);
+      const result = await service.remove("nonexistent");
+
+      expect(result).toBe(false);
     });
   });
 });

--- a/frollz-api/src/stock-tag/stock-tag.service.ts
+++ b/frollz-api/src/stock-tag/stock-tag.service.ts
@@ -64,9 +64,10 @@ export class StockTagService {
   }
 
   async remove(key: string): Promise<boolean> {
-    await this.databaseService.execute(`DELETE FROM stock_tags WHERE id = ?`, [
-      key,
-    ]);
-    return true;
+    const rows = await this.databaseService.query<{ id: string }>(
+      `DELETE FROM stock_tags WHERE id = ? RETURNING id`,
+      [key],
+    );
+    return rows.length > 0;
   }
 }

--- a/frollz-api/src/stock/stock.service.spec.ts
+++ b/frollz-api/src/stock/stock.service.spec.ts
@@ -184,4 +184,24 @@ describe("StockService", () => {
       expect(await service.getSpeeds("999")).toEqual([]);
     });
   });
+
+  describe("remove", () => {
+    it("should return true when the record is deleted", async () => {
+      db.query.mockResolvedValueOnce([{ id: "kodak-gold-200" }]);
+      const result = await service.remove("kodak-gold-200");
+
+      expect(db.query).toHaveBeenCalledWith(
+        expect.stringContaining("DELETE FROM stocks"),
+        ["kodak-gold-200"],
+      );
+      expect(result).toBe(true);
+    });
+
+    it("should return false when the record does not exist", async () => {
+      db.query.mockResolvedValueOnce([]);
+      const result = await service.remove("nonexistent");
+
+      expect(result).toBe(false);
+    });
+  });
 });

--- a/frollz-api/src/stock/stock.service.ts
+++ b/frollz-api/src/stock/stock.service.ts
@@ -159,10 +159,11 @@ export class StockService {
   }
 
   async remove(key: string): Promise<boolean> {
-    await this.databaseService.execute(`DELETE FROM stocks WHERE id = ?`, [
-      key,
-    ]);
-    return true;
+    const rows = await this.databaseService.query<{ id: string }>(
+      `DELETE FROM stocks WHERE id = ? RETURNING id`,
+      [key],
+    );
+    return rows.length > 0;
   }
 
   async getBrands(query: string): Promise<string[]> {

--- a/frollz-api/src/tag/tag.service.spec.ts
+++ b/frollz-api/src/tag/tag.service.spec.ts
@@ -232,14 +232,22 @@ describe("TagService", () => {
   });
 
   describe("remove", () => {
-    it("should execute DELETE and return true", async () => {
+    it("should return true when the record is deleted", async () => {
+      db.query.mockResolvedValueOnce([{ id: "color" }]);
       const result = await service.remove("color");
 
-      expect(db.execute).toHaveBeenCalledWith(
+      expect(db.query).toHaveBeenCalledWith(
         expect.stringContaining("DELETE FROM tags"),
         ["color"],
       );
       expect(result).toBe(true);
+    });
+
+    it("should return false when the record does not exist", async () => {
+      db.query.mockResolvedValueOnce([]);
+      const result = await service.remove("nonexistent");
+
+      expect(result).toBe(false);
     });
   });
 });

--- a/frollz-api/src/tag/tag.service.ts
+++ b/frollz-api/src/tag/tag.service.ts
@@ -100,7 +100,10 @@ export class TagService {
   }
 
   async remove(key: string): Promise<boolean> {
-    await this.databaseService.execute(`DELETE FROM tags WHERE id = ?`, [key]);
-    return true;
+    const rows = await this.databaseService.query<{ id: string }>(
+      `DELETE FROM tags WHERE id = ? RETURNING id`,
+      [key],
+    );
+    return rows.length > 0;
   }
 }


### PR DESCRIPTION
## Summary

- Switched all 6 service `remove()` methods from `execute()` (void) to `query()` with `DELETE ... RETURNING id`
- Return value now reflects whether a row was actually deleted (`false` for nonexistent keys)
- Updated 3 existing `remove()` tests and added new coverage for `roll.service` and `stock.service` — both true and false cases

## Test plan

- [x] All 152 API unit tests pass
- [x] All 135 UI unit tests pass
- [x] API lint clean
- [x] Pre-commit hook (lint + type-check + tests + Semgrep) passes

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)