### PR TITLE
fix: throw ConflictException when deleting entities with dependents (#85)

### DIFF
--- a/frollz-api/src/film-format/film-format.service.spec.ts
+++ b/frollz-api/src/film-format/film-format.service.spec.ts
@@ -1,0 +1,61 @@
+import { ConflictException } from "@nestjs/common";
+import { Test, TestingModule } from "@nestjs/testing";
+import { FilmFormatService } from "./film-format.service";
+import { DatabaseService } from "../database/database.service";
+
+const makeDbService = (
+  overrides: Partial<{ query: jest.Mock; execute: jest.Mock }> = {},
+) => ({
+  query: jest.fn().mockResolvedValue([]),
+  execute: jest.fn().mockResolvedValue(undefined),
+  ...overrides,
+});
+
+describe("FilmFormatService", () => {
+  let service: FilmFormatService;
+  let db: ReturnType<typeof makeDbService>;
+
+  beforeEach(async () => {
+    db = makeDbService();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FilmFormatService,
+        { provide: DatabaseService, useValue: db },
+      ],
+    }).compile();
+
+    service = module.get<FilmFormatService>(FilmFormatService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  describe("remove", () => {
+    it("should return true when the record is deleted", async () => {
+      db.query
+        .mockResolvedValueOnce([]) // no stock dependents
+        .mockResolvedValueOnce([{ id: "35mm" }]); // DELETE RETURNING
+      const result = await service.remove("35mm");
+
+      expect(db.query).toHaveBeenCalledWith(
+        expect.stringContaining("DELETE FROM film_formats"),
+        ["35mm"],
+      );
+      expect(result).toBe(true);
+    });
+
+    it("should return false when the record does not exist", async () => {
+      db.query
+        .mockResolvedValueOnce([]) // no stock dependents
+        .mockResolvedValueOnce([]); // DELETE RETURNING — nothing deleted
+      const result = await service.remove("nonexistent");
+
+      expect(result).toBe(false);
+    });
+
+    it("should throw ConflictException when stocks reference the format", async () => {
+      db.query.mockResolvedValueOnce([{ id: "stock-1" }]); // stock dependent found
+
+      await expect(service.remove("35mm")).rejects.toThrow(ConflictException);
+    });
+  });
+});

--- a/frollz-api/src/film-format/film-format.service.ts
+++ b/frollz-api/src/film-format/film-format.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@nestjs/common";
+import { ConflictException, Injectable } from "@nestjs/common";
 import { randomUUID } from "crypto";
 import { DatabaseService } from "../database/database.service";
 import { CreateFilmFormatDto } from "./dto/create-film-format.dto";
@@ -90,6 +90,16 @@ export class FilmFormatService {
   }
 
   async remove(key: string): Promise<boolean> {
+    const dependents = await this.databaseService.query<{ id: string }>(
+      `SELECT id FROM stocks WHERE format_key = ? LIMIT 1`,
+      [key],
+    );
+    if (dependents.length > 0) {
+      throw new ConflictException(
+        "Cannot delete film format: it is referenced by one or more stocks",
+      );
+    }
+
     const rows = await this.databaseService.query<{ id: string }>(
       `DELETE FROM film_formats WHERE id = ? RETURNING id`,
       [key],

--- a/frollz-api/src/stock/stock.service.spec.ts
+++ b/frollz-api/src/stock/stock.service.spec.ts
@@ -1,3 +1,4 @@
+import { ConflictException } from "@nestjs/common";
 import { Test, TestingModule } from "@nestjs/testing";
 import { StockService } from "./stock.service";
 import { DatabaseService } from "../database/database.service";
@@ -187,7 +188,10 @@ describe("StockService", () => {
 
   describe("remove", () => {
     it("should return true when the record is deleted", async () => {
-      db.query.mockResolvedValueOnce([{ id: "kodak-gold-200" }]);
+      db.query
+        .mockResolvedValueOnce([]) // no roll dependents
+        .mockResolvedValueOnce([]) // no stock_tag dependents
+        .mockResolvedValueOnce([{ id: "kodak-gold-200" }]); // DELETE RETURNING
       const result = await service.remove("kodak-gold-200");
 
       expect(db.query).toHaveBeenCalledWith(
@@ -198,10 +202,31 @@ describe("StockService", () => {
     });
 
     it("should return false when the record does not exist", async () => {
-      db.query.mockResolvedValueOnce([]);
+      db.query
+        .mockResolvedValueOnce([]) // no roll dependents
+        .mockResolvedValueOnce([]) // no stock_tag dependents
+        .mockResolvedValueOnce([]); // DELETE RETURNING — nothing deleted
       const result = await service.remove("nonexistent");
 
       expect(result).toBe(false);
+    });
+
+    it("should throw ConflictException when rolls reference the stock", async () => {
+      db.query.mockResolvedValueOnce([{ id: "roll-1" }]); // roll dependent found
+
+      await expect(service.remove("kodak-gold-200")).rejects.toThrow(
+        ConflictException,
+      );
+    });
+
+    it("should throw ConflictException when stock_tags reference the stock", async () => {
+      db.query
+        .mockResolvedValueOnce([]) // no roll dependents
+        .mockResolvedValueOnce([{ id: "st-1" }]); // stock_tag dependent found
+
+      await expect(service.remove("kodak-gold-200")).rejects.toThrow(
+        ConflictException,
+      );
     });
   });
 });

--- a/frollz-api/src/stock/stock.service.ts
+++ b/frollz-api/src/stock/stock.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@nestjs/common";
+import { ConflictException, Injectable } from "@nestjs/common";
 
 const toSlug = (s: string) => s.toLowerCase().replace(/\s+/g, "-");
 import { DatabaseService } from "../database/database.service";
@@ -159,6 +159,26 @@ export class StockService {
   }
 
   async remove(key: string): Promise<boolean> {
+    const rollDependents = await this.databaseService.query<{ id: string }>(
+      `SELECT id FROM rolls WHERE stock_key = ? LIMIT 1`,
+      [key],
+    );
+    if (rollDependents.length > 0) {
+      throw new ConflictException(
+        "Cannot delete stock: it is referenced by one or more rolls",
+      );
+    }
+
+    const stockTagDependents = await this.databaseService.query<{ id: string }>(
+      `SELECT id FROM stock_tags WHERE stock_key = ? LIMIT 1`,
+      [key],
+    );
+    if (stockTagDependents.length > 0) {
+      throw new ConflictException(
+        "Cannot delete stock: it is referenced by one or more stock tags",
+      );
+    }
+
     const rows = await this.databaseService.query<{ id: string }>(
       `DELETE FROM stocks WHERE id = ? RETURNING id`,
       [key],

--- a/frollz-api/src/tag/tag.service.spec.ts
+++ b/frollz-api/src/tag/tag.service.spec.ts
@@ -1,3 +1,4 @@
+import { ConflictException } from "@nestjs/common";
 import { Test, TestingModule } from "@nestjs/testing";
 import { TagService } from "./tag.service";
 import { DatabaseService } from "../database/database.service";
@@ -233,7 +234,10 @@ describe("TagService", () => {
 
   describe("remove", () => {
     it("should return true when the record is deleted", async () => {
-      db.query.mockResolvedValueOnce([{ id: "color" }]);
+      db.query
+        .mockResolvedValueOnce([]) // no stock_tag dependents
+        .mockResolvedValueOnce([]) // no roll_tag dependents
+        .mockResolvedValueOnce([{ id: "color" }]); // DELETE RETURNING
       const result = await service.remove("color");
 
       expect(db.query).toHaveBeenCalledWith(
@@ -244,10 +248,27 @@ describe("TagService", () => {
     });
 
     it("should return false when the record does not exist", async () => {
-      db.query.mockResolvedValueOnce([]);
+      db.query
+        .mockResolvedValueOnce([]) // no stock_tag dependents
+        .mockResolvedValueOnce([]) // no roll_tag dependents
+        .mockResolvedValueOnce([]); // DELETE RETURNING — nothing deleted
       const result = await service.remove("nonexistent");
 
       expect(result).toBe(false);
+    });
+
+    it("should throw ConflictException when stock_tags reference the tag", async () => {
+      db.query.mockResolvedValueOnce([{ id: "st-1" }]); // stock_tag dependent found
+
+      await expect(service.remove("color")).rejects.toThrow(ConflictException);
+    });
+
+    it("should throw ConflictException when roll_tags reference the tag", async () => {
+      db.query
+        .mockResolvedValueOnce([]) // no stock_tag dependents
+        .mockResolvedValueOnce([{ id: "rt-1" }]); // roll_tag dependent found
+
+      await expect(service.remove("color")).rejects.toThrow(ConflictException);
     });
   });
 });

--- a/frollz-api/src/tag/tag.service.ts
+++ b/frollz-api/src/tag/tag.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@nestjs/common";
+import { ConflictException, Injectable } from "@nestjs/common";
 import { randomUUID } from "crypto";
 import { DatabaseService } from "../database/database.service";
 import { CreateTagDto } from "./dto/create-tag.dto";
@@ -100,6 +100,26 @@ export class TagService {
   }
 
   async remove(key: string): Promise<boolean> {
+    const stockTagDependents = await this.databaseService.query<{ id: string }>(
+      `SELECT id FROM stock_tags WHERE tag_key = ? LIMIT 1`,
+      [key],
+    );
+    if (stockTagDependents.length > 0) {
+      throw new ConflictException(
+        "Cannot delete tag: it is referenced by one or more stock tags",
+      );
+    }
+
+    const rollTagDependents = await this.databaseService.query<{ id: string }>(
+      `SELECT id FROM roll_tags WHERE tag_key = ? LIMIT 1`,
+      [key],
+    );
+    if (rollTagDependents.length > 0) {
+      throw new ConflictException(
+        "Cannot delete tag: it is referenced by one or more roll tags",
+      );
+    }
+
     const rows = await this.databaseService.query<{ id: string }>(
       `DELETE FROM tags WHERE id = ? RETURNING id`,
       [key],


### PR DESCRIPTION
## Summary

- `StockService.remove()` — checks for referencing `rolls` and `stock_tags` before deleting
- `TagService.remove()` — checks for referencing `stock_tags` and `roll_tags` before deleting
- `FilmFormatService.remove()` — checks for referencing `stocks` before deleting
- All three throw `ConflictException` (409) with a descriptive message instead of letting the DB constraint violation bubble up as a 500

## Test plan

- [x] Added conflict and non-conflict test cases to `stock.service.spec.ts` and `tag.service.spec.ts`
- [x] Created first-ever `film-format.service.spec.ts` with full remove coverage
- [x] All 159 API unit tests pass
- [x] All 135 UI unit tests pass
- [x] Pre-commit hook (lint + type-check + tests + Semgrep) passes

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)