### PR TITLE
feat(ui): consume GET /transitions endpoint, remove hardcoded transition maps (#87b)

### DIFF
--- a/frollz-api/migrations/20260318000004_add_transition_tables.ts
+++ b/frollz-api/migrations/20260318000004_add_transition_tables.ts
@@ -160,7 +160,7 @@ export async function up(knex: Knex): Promise<void> {
       from_state_id: stateId("Finished"),
       to_state_id: stateId("Sent For Development"),
       transition_type_id: fwd,
-      requires_date: false,
+      requires_date: true,
     },
     {
       from_state_id: stateId("Sent For Development"),

--- a/frollz-ui/src/services/api-client.ts
+++ b/frollz-ui/src/services/api-client.ts
@@ -1,5 +1,5 @@
 import { api } from './api'
-import type { FilmFormat, Stock, Roll, RollStateHistory, Tag, StockTag, RollTag } from '@/types'
+import type { FilmFormat, Stock, Roll, RollStateHistory, Tag, StockTag, RollTag, TransitionGraph } from '@/types'
 import { Process } from '@/types'
 
 type CreateStockMultipleFormatsPayload = Pick<Stock, 'brand' | 'manufacturer' | 'speed' | 'baseStockKey' | 'boxImageUrl'> & {
@@ -76,6 +76,11 @@ export const rollApi = {
   delete: (key: string) => api.delete(`/rolls/${key}`),
   transition: (key: string, targetState: string, date?: string, notes?: string, isErrorCorrection?: boolean, metadata?: Record<string, unknown>) =>
     api.post<Roll>(`/rolls/${key}/transition`, { targetState, date, notes, isErrorCorrection, metadata }),
+}
+
+// Transition API
+export const transitionApi = {
+  getGraph: () => api.get<TransitionGraph>('/transitions'),
 }
 
 // Roll State History API

--- a/frollz-ui/src/types/index.ts
+++ b/frollz-ui/src/types/index.ts
@@ -92,6 +92,27 @@ export enum RollState {
   RECEIVED = 'Received',
 }
 
+export interface TransitionMetadataField {
+  field: string
+  fieldType: string
+  defaultValue: string | null
+  isRequired: boolean
+}
+
+export interface TransitionEdge {
+  id: string
+  fromState: string
+  toState: string
+  transitionType: string
+  requiresDate: boolean
+  metadata: TransitionMetadataField[]
+}
+
+export interface TransitionGraph {
+  states: string[]
+  transitions: TransitionEdge[]
+}
+
 export interface RollStateHistory {
   _key?: string
   stateId: string

--- a/frollz-ui/src/views/RollDetailView.vue
+++ b/frollz-ui/src/views/RollDetailView.vue
@@ -87,7 +87,7 @@
             <!-- Storage state metadata form -->
             <div v-if="pendingMetadataTransition" class="border border-blue-300 dark:border-blue-600 rounded-md p-3 bg-blue-50 dark:bg-blue-900/20">
               <p class="text-sm font-medium text-blue-800 dark:text-blue-200 mb-3">{{ pendingMetadataTransition }} details</p>
-              <label v-if="STATES_WITH_DATE_CAPTURE.has(pendingMetadataTransition!)" class="block text-xs text-gray-600 dark:text-gray-400 mb-2">
+              <label v-if="requiresDateCapture(pendingMetadataTransition!)" class="block text-xs text-gray-600 dark:text-gray-400 mb-2">
                 Date <span class="text-red-500">*</span>
                 <input v-model="metadataDate" type="date" class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100" />
               </label>
@@ -293,8 +293,8 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
-import { rollApi, rollStateApi, rollTagApi, tagApi } from '@/services/api-client'
-import type { Roll, RollStateHistory, Tag, RollTag } from '@/types'
+import { rollApi, rollStateApi, rollTagApi, tagApi, transitionApi } from '@/services/api-client'
+import type { Roll, RollStateHistory, Tag, RollTag, TransitionGraph } from '@/types'
 import { RollState } from '@/types'
 
 const route = useRoute()
@@ -329,8 +329,6 @@ const PROCESSES_REQUESTED = ['C-41', 'E-6', 'ECN-2', 'Black & White', 'Instant']
 
 const todayISO = () => new Date().toISOString().slice(0, 10)
 
-const STATES_REQUIRING_METADATA = new Set([RollState.FROZEN, RollState.REFRIGERATED, RollState.SHELVED, RollState.LOADED, RollState.FINISHED, RollState.SENT_FOR_DEVELOPMENT, RollState.DEVELOPED, RollState.RECEIVED])
-const STATES_WITH_DATE_CAPTURE = new Set([RollState.FROZEN, RollState.REFRIGERATED, RollState.SHELVED, RollState.LOADED, RollState.FINISHED, RollState.SENT_FOR_DEVELOPMENT, RollState.DEVELOPED])
 const isImperial = navigator.language === 'en-US'
 const temperatureUnit = isImperial ? '°F' : '°C'
 const TEMPERATURE_DEFAULTS: Partial<Record<RollState, number>> = {
@@ -339,44 +337,35 @@ const TEMPERATURE_DEFAULTS: Partial<Record<RollState, number>> = {
   [RollState.SHELVED]: isImperial ? 65 : 18,
 }
 
-const FORWARD_TRANSITIONS: Partial<Record<RollState, RollState[]>> = {
-  [RollState.ADDED]: [RollState.FROZEN, RollState.REFRIGERATED, RollState.SHELVED],
-  [RollState.FROZEN]: [RollState.REFRIGERATED, RollState.SHELVED],
-  [RollState.REFRIGERATED]: [RollState.SHELVED],
-  [RollState.SHELVED]: [RollState.LOADED],
-  [RollState.LOADED]: [RollState.FINISHED],
-  [RollState.FINISHED]: [RollState.SENT_FOR_DEVELOPMENT],
-  [RollState.SENT_FOR_DEVELOPMENT]: [RollState.DEVELOPED],
-  [RollState.DEVELOPED]: [RollState.RECEIVED],
-}
-
-const BACKWARD_TRANSITIONS: Partial<Record<RollState, RollState[]>> = {
-  [RollState.FROZEN]: [RollState.ADDED],
-  [RollState.REFRIGERATED]: [RollState.FROZEN, RollState.ADDED],
-  [RollState.SHELVED]: [RollState.REFRIGERATED, RollState.FROZEN],
-  [RollState.LOADED]: [RollState.SHELVED, RollState.REFRIGERATED, RollState.FROZEN],
-  [RollState.FINISHED]: [RollState.LOADED],
-  [RollState.SENT_FOR_DEVELOPMENT]: [RollState.FINISHED],
-  [RollState.DEVELOPED]: [RollState.SENT_FOR_DEVELOPMENT],
-  [RollState.RECEIVED]: [RollState.DEVELOPED],
-}
-
-const VALID_TRANSITIONS: Partial<Record<RollState, RollState[]>> = Object.fromEntries(
-  Object.values(RollState).map((state) => [
-    state,
-    [
-      ...(FORWARD_TRANSITIONS[state] ?? []),
-      ...(BACKWARD_TRANSITIONS[state] ?? []),
-    ],
-  ]),
-) as Partial<Record<RollState, RollState[]>>
+const transitionGraph = ref<TransitionGraph>({ states: [], transitions: [] })
 
 const isBackwardTransition = (from: RollState, to: RollState): boolean =>
-  (BACKWARD_TRANSITIONS[from] ?? []).includes(to)
+  transitionGraph.value.transitions.some(
+    t => t.fromState === from && t.toState === to && t.transitionType === 'BACKWARD',
+  )
 
 const validTransitions = computed(() =>
-  roll.value ? (VALID_TRANSITIONS[roll.value.state] ?? []) : [],
+  roll.value
+    ? transitionGraph.value.transitions
+        .filter(t => t.fromState === roll.value!.state)
+        .map(t => t.toState as RollState)
+    : [],
 )
+
+const getTransitionEdge = (targetState: RollState) =>
+  transitionGraph.value.transitions.find(
+    t => t.fromState === roll.value?.state && t.toState === targetState,
+  )
+
+const requiresMetadataForm = (targetState: RollState): boolean => {
+  const t = getTransitionEdge(targetState)
+  return !!t && (t.metadata.length > 0 || t.requiresDate)
+}
+
+const requiresDateCapture = (targetState: RollState): boolean => {
+  const t = getTransitionEdge(targetState)
+  return !!t && t.requiresDate
+}
 
 const tagByKey = computed(() => {
   const map: Record<string, Tag> = {}
@@ -430,7 +419,7 @@ const handleTransition = (targetState: RollState) => {
     pendingTransition.value = targetState
     return
   }
-  if (STATES_REQUIRING_METADATA.has(targetState)) {
+  if (requiresMetadataForm(targetState)) {
     pendingMetadataTransition.value = targetState
     metadataTemperature.value = String(TEMPERATURE_DEFAULTS[targetState] ?? '')
     metadataShotISO.value = targetState === RollState.FINISHED && roll.value?.stockSpeed ? String(roll.value.stockSpeed) : ''
@@ -460,7 +449,7 @@ const submitMetadataTransition = () => {
     if (!metadataProcessRequested.value) { metadataFormError.value = 'Process is required.'; return }
   }
 
-  if (STATES_WITH_DATE_CAPTURE.has(target) && !metadataDate.value) {
+  if (requiresDateCapture(target) && !metadataDate.value) {
     metadataFormError.value = 'Date is required.'
     return
   }
@@ -469,7 +458,7 @@ const submitMetadataTransition = () => {
   const shotISO = metadataShotISO.value !== '' ? parseFloat(metadataShotISO.value) : undefined
   const pushPullStops = metadataPushPullStops.value !== '' ? parseInt(metadataPushPullStops.value, 10) : undefined
   let date: string | undefined
-  if (STATES_WITH_DATE_CAPTURE.has(target) && metadataDate.value) {
+  if (requiresDateCapture(target) && metadataDate.value) {
     const [year, month, day] = metadataDate.value.split('-').map(Number)
     const now = new Date()
     date = new Date(year, month - 1, day, now.getHours(), now.getMinutes(), now.getSeconds()).toISOString()
@@ -557,7 +546,11 @@ const loadData = async () => {
 
 onMounted(async () => {
   try {
-    await loadData()
+    const [graphRes] = await Promise.all([
+      transitionApi.getGraph(),
+      loadData(),
+    ])
+    transitionGraph.value = graphRes.data
   } finally {
     loading.value = false
   }

--- a/frollz-ui/src/views/__tests__/RollDetailView.spec.ts
+++ b/frollz-ui/src/views/__tests__/RollDetailView.spec.ts
@@ -3,9 +3,9 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { createRouter, createMemoryHistory } from 'vue-router'
 import RollDetailView from '@/views/RollDetailView.vue'
-import { rollApi, rollStateApi, rollTagApi, tagApi } from '@/services/api-client'
+import { rollApi, rollStateApi, rollTagApi, tagApi, transitionApi } from '@/services/api-client'
 import { RollState } from '@/types'
-import type { Roll, RollStateHistory, Tag, RollTag } from '@/types'
+import type { Roll, RollStateHistory, Tag, RollTag, TransitionGraph, TransitionEdge } from '@/types'
 
 vi.mock('@/services/api-client', () => ({
   rollApi: {
@@ -23,7 +23,60 @@ vi.mock('@/services/api-client', () => ({
   tagApi: {
     getAll: vi.fn(),
   },
+  transitionApi: {
+    getGraph: vi.fn(),
+  },
 }))
+
+const edge = (
+  id: string,
+  fromState: string,
+  toState: string,
+  transitionType: 'FORWARD' | 'BACKWARD',
+  requiresDate: boolean,
+  metadata: TransitionEdge['metadata'] = [],
+): TransitionEdge => ({ id, fromState, toState, transitionType, requiresDate, metadata })
+
+const makeGraph = (): TransitionGraph => ({
+  states: ['Added', 'Frozen', 'Refrigerated', 'Shelved', 'Loaded', 'Finished', 'Sent For Development', 'Developed', 'Received'],
+  transitions: [
+    // FORWARD
+    edge('e1',  'Added',                'Frozen',               'FORWARD', true,  [{ field: 'temperature', fieldType: 'number', defaultValue: null, isRequired: false }]),
+    edge('e2',  'Added',                'Refrigerated',         'FORWARD', true,  [{ field: 'temperature', fieldType: 'number', defaultValue: null, isRequired: false }]),
+    edge('e3',  'Added',                'Shelved',              'FORWARD', true,  [{ field: 'temperature', fieldType: 'number', defaultValue: null, isRequired: false }]),
+    edge('e4',  'Frozen',               'Refrigerated',         'FORWARD', true,  [{ field: 'temperature', fieldType: 'number', defaultValue: null, isRequired: false }]),
+    edge('e5',  'Frozen',               'Shelved',              'FORWARD', true,  [{ field: 'temperature', fieldType: 'number', defaultValue: null, isRequired: false }]),
+    edge('e6',  'Refrigerated',         'Shelved',              'FORWARD', true,  [{ field: 'temperature', fieldType: 'number', defaultValue: null, isRequired: false }]),
+    edge('e7',  'Shelved',              'Loaded',               'FORWARD', true,  []),
+    edge('e8',  'Loaded',               'Finished',             'FORWARD', true,  [{ field: 'shotISO', fieldType: 'number', defaultValue: null, isRequired: false }]),
+    edge('e9',  'Finished',             'Sent For Development', 'FORWARD', true,  [
+      { field: 'labName',           fieldType: 'string',  defaultValue: null, isRequired: false },
+      { field: 'deliveryMethod',    fieldType: 'string',  defaultValue: null, isRequired: false },
+      { field: 'processRequested',  fieldType: 'string',  defaultValue: null, isRequired: false },
+      { field: 'pushPullStops',     fieldType: 'number',  defaultValue: null, isRequired: false },
+    ]),
+    edge('e10', 'Sent For Development', 'Developed',            'FORWARD', true,  []),
+    edge('e11', 'Developed',            'Received',             'FORWARD', false, [
+      { field: 'scansReceived',     fieldType: 'boolean', defaultValue: null, isRequired: false },
+      { field: 'scansUrl',          fieldType: 'string',  defaultValue: null, isRequired: false },
+      { field: 'negativesReceived', fieldType: 'boolean', defaultValue: null, isRequired: false },
+      { field: 'negativesDate',     fieldType: 'date',    defaultValue: null, isRequired: false },
+    ]),
+    // BACKWARD
+    edge('e12', 'Frozen',               'Added',                'BACKWARD', false, []),
+    edge('e13', 'Refrigerated',         'Frozen',               'BACKWARD', false, []),
+    edge('e14', 'Refrigerated',         'Added',                'BACKWARD', false, []),
+    edge('e15', 'Shelved',              'Refrigerated',         'BACKWARD', false, []),
+    edge('e16', 'Shelved',              'Frozen',               'BACKWARD', false, []),
+    edge('e17', 'Loaded',               'Shelved',              'BACKWARD', false, []),
+    edge('e18', 'Loaded',               'Refrigerated',         'BACKWARD', false, []),
+    edge('e19', 'Loaded',               'Frozen',               'BACKWARD', false, []),
+    edge('e20', 'Finished',             'Loaded',               'BACKWARD', false, []),
+    edge('e21', 'Sent For Development', 'Finished',             'BACKWARD', false, []),
+    edge('e22', 'Developed',            'Sent For Development', 'BACKWARD', false, []),
+    edge('e23', 'Received',             'Developed',            'BACKWARD', false, []),
+  ],
+})
 
 const router = createRouter({
   history: createMemoryHistory(),
@@ -89,6 +142,7 @@ describe('RollDetailView', () => {
     vi.mocked(rollApi.transition).mockResolvedValue({ data: makeRoll() } as any)
     vi.mocked(rollTagApi.create).mockResolvedValue({ data: makeRollTag('rt-new', 't1') } as any)
     vi.mocked(rollTagApi.delete).mockResolvedValue({} as any)
+    vi.mocked(transitionApi.getGraph).mockResolvedValue({ data: makeGraph() } as any)
   })
 
   describe('data loading', () => {


### PR DESCRIPTION
## Summary

- `RollDetailView.vue` now fetches `GET /transitions` on mount alongside roll data
- `validTransitions`, `isBackwardTransition`, metadata form visibility, and date capture all derived from the API response
- Removed: `FORWARD_TRANSITIONS`, `BACKWARD_TRANSITIONS`, `VALID_TRANSITIONS`, `STATES_REQUIRING_METADATA`, `STATES_WITH_DATE_CAPTURE`
- Added `TransitionGraph`, `TransitionEdge`, `TransitionMetadataField` types to `src/types/index.ts`
- Added `transitionApi.getGraph()` to `api-client.ts`
- Also fixes a bug in the seed migration from PR #111: `requires_date` was incorrectly `false` for Finished→Sent For Development

## Test plan

- [x] All 136 UI unit tests pass
- [x] All 164 API unit tests pass
- [x] Transition buttons render correctly for each roll state
- [x] Forward transitions show correct metadata forms and date pickers
- [x] Backward transitions show error correction prompt
- [x] History annotation (forward/backward/initial) still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)