### PR TITLE
fix(security): move DB credentials out of source into .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Copy this file to .env before running docker-compose.
+# All three variables are required — startup will fail if any are missing.
+
+POSTGRES_DATABASE=frollz
+POSTGRES_USER=frollz
+# Use a strong, unique password — never commit the real value
+POSTGRES_PASSWORD=changeme

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Claude Code local settings (personal overrides, not for version control)
 .claude/settings.local.json
+
+# Local environment overrides — never commit credentials
+.env

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,8 @@ git config core.hooksPath .githooks
 
 This activates the pre-commit hook at `.githooks/pre-commit`, which runs UI lint, UI type-check, UI tests, API lint, API tests, and Semgrep SAST before every commit. This mirrors CI exactly — if the hook passes, CI will pass.
 
+Before starting the stack, copy `.env.example` to `.env` and fill in values. `docker-compose.yml` does not supply defaults — startup will fail if these variables are not set.
+
 ### GitHub Issues
 
 **Before starting any work on a new issue, always run these steps in order — no exceptions:**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,9 +17,9 @@ services:
     image: postgres:18-alpine
     container_name: frollz-postgres
     environment:
-      - POSTGRES_DB=frollz
-      - POSTGRES_USER=frollz
-      - POSTGRES_PASSWORD=frollz
+      - POSTGRES_DB=${POSTGRES_DATABASE}
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
     ports:
       - "5432:5432"
     volumes:
@@ -37,9 +37,9 @@ services:
       - NODE_ENV=development
       - POSTGRES_HOST=postgres
       - POSTGRES_PORT=5432
-      - POSTGRES_DATABASE=frollz
-      - POSTGRES_USER=frollz
-      - POSTGRES_PASSWORD=frollz
+      - POSTGRES_DATABASE=${POSTGRES_DATABASE}
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
       - PORT=3000
       - DISABLE_DEFAULT_DATA_IMPORT=false
     ports:


### PR DESCRIPTION
## Summary

- `docker-compose.yml` now reads `POSTGRES_DATABASE`, `POSTGRES_USER`, and `POSTGRES_PASSWORD` from the environment with no inline defaults — startup fails fast if a `.env` file is not present
- Added `.env.example` with placeholder values documenting required variables
- Added `.env` to `.gitignore` to prevent credentials from ever being committed

## Test plan

- [x] Copy `.env.example` to `.env`, set values, verify `docker-compose up` starts cleanly
- [x] Remove `.env` and verify `docker-compose up` fails with a missing variable error
- [x] Confirm `.env` is gitignored (`git status` shows no `.env` after creating one)

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)