### PR TITLE
fix(security): use Knex identifier binding to eliminate SQL interpolation

### DIFF
--- a/frollz-api/src/database/database.service.spec.ts
+++ b/frollz-api/src/database/database.service.spec.ts
@@ -33,14 +33,17 @@ describe("DatabaseService — onModuleInit", () => {
 
     expect(knex.migrate.latest).toHaveBeenCalled();
 
-    const rawCalls: string[] = knex.raw.mock.calls.map(
-      ([sql]: [string]) => sql,
+    const rawCalls: [string, string[] | undefined][] = knex.raw.mock.calls.map(
+      ([sql, params]: [string, string[] | undefined]) => [sql, params],
     );
-    expect(rawCalls.some((s) => /is_system = true/.test(s))).toBe(true);
-    expect(rawCalls.some((s) => /INSERT INTO film_formats/.test(s))).toBe(true);
-    expect(rawCalls.some((s) => /INSERT INTO stocks/.test(s))).toBe(true);
-    expect(rawCalls.some((s) => /INSERT INTO tags/.test(s))).toBe(true);
-    expect(rawCalls.some((s) => /INSERT INTO stock_tags/.test(s))).toBe(true);
+    expect(rawCalls.some(([sql]) => /is_system = true/.test(sql))).toBe(true);
+    const tableInserts = rawCalls.filter(([sql]) =>
+      /INSERT INTO \?\?/.test(sql),
+    );
+    expect(tableInserts.some(([, p]) => p?.[0] === "film_formats")).toBe(true);
+    expect(tableInserts.some(([, p]) => p?.[0] === "stocks")).toBe(true);
+    expect(tableInserts.some(([, p]) => p?.[0] === "tags")).toBe(true);
+    expect(tableInserts.some(([, p]) => p?.[0] === "stock_tags")).toBe(true);
   });
 
   it("should always populate system tags even when DISABLE_DEFAULT_DATA_IMPORT is set", async () => {
@@ -53,13 +56,14 @@ describe("DatabaseService — onModuleInit", () => {
 
     await service.onModuleInit();
 
-    const rawCalls: string[] = knex.raw.mock.calls.map(
-      ([sql]: [string]) => sql,
+    const rawCalls: [string, string[] | undefined][] = knex.raw.mock.calls.map(
+      ([sql, params]: [string, string[] | undefined]) => [sql, params],
     );
-    expect(rawCalls.some((s) => /is_system = true/.test(s))).toBe(true);
-    expect(rawCalls.some((s) => /INSERT INTO film_formats/.test(s))).toBe(
-      false,
+    expect(rawCalls.some(([sql]) => /is_system = true/.test(sql))).toBe(true);
+    const tableInserts = rawCalls.filter(([sql]) =>
+      /INSERT INTO \?\?/.test(sql),
     );
+    expect(tableInserts.some(([, p]) => p?.[0] === "film_formats")).toBe(false);
     expect(logSpy).toHaveBeenCalledWith(
       expect.stringContaining("DISABLE_DEFAULT_DATA_IMPORT"),
     );

--- a/frollz-api/src/database/database.service.ts
+++ b/frollz-api/src/database/database.service.ts
@@ -66,7 +66,8 @@ export class DatabaseService implements OnModuleInit {
     for (const { main, default: def } of mappings) {
       try {
         await this.knex.raw(
-          `INSERT INTO ${main} SELECT * FROM ${def} ON CONFLICT (id) DO NOTHING`,
+          "INSERT INTO ?? SELECT * FROM ?? ON CONFLICT (id) DO NOTHING",
+          [main, def],
         );
         this.logger.log(`Populated ${main} from ${def}`);
       } catch (error) {


### PR DESCRIPTION
## Summary

- Replaced raw string interpolation of table names (`INSERT INTO ${main}`) in `DatabaseService.populateMainTables()` with Knex's `??` identifier binding, which properly quotes and escapes identifiers
- Updated tests to assert on binding arguments rather than the SQL template string

The table names were hardcoded at the call site so this was not exploitable in practice, but the pattern was dangerous and would become a real SQLi vector if any future caller passed user-influenced input.

## Test plan

- [x] All existing `DatabaseService` unit tests pass
- [x] `docker-compose up` starts cleanly and seed data populates as before

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)