### PR TITLE
fix(security): add HTTP security headers to Nginx

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -14,6 +14,13 @@ server {
     listen 80;
     server_name localhost;
 
+    # Security headers
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    # img-src includes https: for external box art URLs; connect-src includes ws:/wss: for Vite HMR
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' ws: wss:;" always;
+
     # Serve UI static files
     location / {
         proxy_pass http://frollz-ui:5173;


### PR DESCRIPTION
## Summary

Added four security headers to the Nginx server block:

- `X-Frame-Options: SAMEORIGIN` — prevents clickjacking
- `X-Content-Type-Options: nosniff` — prevents MIME type sniffing
- `Referrer-Policy: strict-origin-when-cross-origin` — limits referrer leakage
- `Content-Security-Policy` — restricts resource origins; allows `unsafe-inline` for Vue/Vite, external `https:` for box art images, and `ws:/wss:` for Vite HMR

**HSTS excluded intentionally** — it is only safe over HTTPS and will be added as part of #118.
**`X-XSS-Protection` excluded intentionally** — modern guidance omits it as it can introduce vulnerabilities in older browsers; CSP provides the same protection.

## Test plan

- [x] Restart Nginx container and verify headers are present in browser devtools (Network tab → response headers)
- [x] Confirm Vite HMR still works in dev (WebSocket connects, hot reload fires)
- [x] Confirm box art images load (external `https:` URLs)
- [x] Confirm no console CSP violations on normal app usage

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)