### PR TITLE
fix(security): apply per-endpoint rate limits to mutation and expensive routes

### DIFF
--- a/frollz-api/src/app.module.ts
+++ b/frollz-api/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module } from "@nestjs/common";
 import { ConfigModule } from "@nestjs/config";
 import { ThrottlerModule, ThrottlerGuard } from "@nestjs/throttler";
+import { ThrottleLimits } from "./common/throttle-limits";
 import { APP_GUARD } from "@nestjs/core";
 import { DatabaseModule } from "./database/database.module";
 import { FilmFormatModule } from "./film-format/film-format.module";
@@ -17,12 +18,7 @@ import { TransitionModule } from "./transition/transition.module";
     ConfigModule.forRoot({
       isGlobal: true,
     }),
-    ThrottlerModule.forRoot([
-      {
-        ttl: 60000,
-        limit: 100,
-      },
-    ]),
+    ThrottlerModule.forRoot([ThrottleLimits._100_REQUESTS_PER_MINUTE]),
     DatabaseModule,
     FilmFormatModule,
     StockModule,

--- a/frollz-api/src/common/throttle-limits.ts
+++ b/frollz-api/src/common/throttle-limits.ts
@@ -1,0 +1,6 @@
+export const ThrottleLimits = {
+  _10_REQUESTS_PER_MINUTE: { ttl: 60000, limit: 10 },
+  _20_REQUESTS_PER_MINUTE: { ttl: 60000, limit: 20 },
+  _30_REQUESTS_PER_MINUTE: { ttl: 60000, limit: 30 },
+  _100_REQUESTS_PER_MINUTE: { ttl: 60000, limit: 100 },
+} as const;

--- a/frollz-api/src/film-format/film-format.controller.ts
+++ b/frollz-api/src/film-format/film-format.controller.ts
@@ -8,6 +8,8 @@ import {
   Delete,
   NotFoundException,
 } from "@nestjs/common";
+import { Throttle } from "@nestjs/throttler";
+import { ThrottleLimits } from "../common/throttle-limits";
 import { ApiTags, ApiOperation, ApiResponse } from "@nestjs/swagger";
 import { FilmFormatService } from "./film-format.service";
 import { CreateFilmFormatDto } from "./dto/create-film-format.dto";
@@ -20,6 +22,7 @@ export class FilmFormatController {
   constructor(private readonly filmFormatService: FilmFormatService) {}
 
   @Post()
+  @Throttle({ default: ThrottleLimits._20_REQUESTS_PER_MINUTE })
   @ApiOperation({ summary: "Create a new film format" })
   @ApiResponse({
     status: 201,
@@ -60,6 +63,7 @@ export class FilmFormatController {
   }
 
   @Patch(":key")
+  @Throttle({ default: ThrottleLimits._20_REQUESTS_PER_MINUTE })
   @ApiOperation({ summary: "Update a film format" })
   @ApiResponse({
     status: 200,
@@ -82,6 +86,7 @@ export class FilmFormatController {
   }
 
   @Delete(":key")
+  @Throttle({ default: ThrottleLimits._20_REQUESTS_PER_MINUTE })
   @ApiOperation({ summary: "Delete a film format" })
   @ApiResponse({ status: 200, description: "Film format deleted successfully" })
   @ApiResponse({ status: 404, description: "Film format not found" })

--- a/frollz-api/src/roll-tag/roll-tag.controller.ts
+++ b/frollz-api/src/roll-tag/roll-tag.controller.ts
@@ -8,6 +8,8 @@ import {
   NotFoundException,
   Query,
 } from "@nestjs/common";
+import { Throttle } from "@nestjs/throttler";
+import { ThrottleLimits } from "../common/throttle-limits";
 import { ApiTags, ApiOperation, ApiResponse, ApiQuery } from "@nestjs/swagger";
 import { RollTagService } from "./roll-tag.service";
 import { CreateRollTagDto } from "./dto/create-roll-tag.dto";
@@ -19,6 +21,7 @@ export class RollTagController {
   constructor(private readonly rollTagService: RollTagService) {}
 
   @Post()
+  @Throttle({ default: ThrottleLimits._20_REQUESTS_PER_MINUTE })
   @ApiOperation({ summary: "Associate a tag with a roll" })
   @ApiResponse({
     status: 201,
@@ -66,6 +69,7 @@ export class RollTagController {
   }
 
   @Delete(":key")
+  @Throttle({ default: ThrottleLimits._20_REQUESTS_PER_MINUTE })
   @ApiOperation({ summary: "Remove a roll-tag association" })
   @ApiResponse({ status: 200, description: "RollTag deleted successfully" })
   @ApiResponse({ status: 404, description: "RollTag not found" })

--- a/frollz-api/src/roll/roll.controller.ts
+++ b/frollz-api/src/roll/roll.controller.ts
@@ -8,6 +8,8 @@ import {
   Delete,
   NotFoundException,
 } from "@nestjs/common";
+import { Throttle } from "@nestjs/throttler";
+import { ThrottleLimits } from "../common/throttle-limits";
 import { ApiTags, ApiOperation, ApiResponse } from "@nestjs/swagger";
 import { RollService } from "./roll.service";
 import { CreateRollDto } from "./dto/create-roll.dto";
@@ -21,6 +23,7 @@ export class RollController {
   constructor(private readonly rollService: RollService) {}
 
   @Post()
+  @Throttle({ default: ThrottleLimits._20_REQUESTS_PER_MINUTE })
   @ApiOperation({ summary: "Create a new roll" })
   @ApiResponse({
     status: 201,
@@ -66,6 +69,7 @@ export class RollController {
   }
 
   @Patch(":key")
+  @Throttle({ default: ThrottleLimits._20_REQUESTS_PER_MINUTE })
   @ApiOperation({ summary: "Update a roll" })
   @ApiResponse({
     status: 200,
@@ -85,6 +89,7 @@ export class RollController {
   }
 
   @Delete(":key")
+  @Throttle({ default: ThrottleLimits._20_REQUESTS_PER_MINUTE })
   @ApiOperation({ summary: "Delete a roll" })
   @ApiResponse({ status: 200, description: "Roll deleted successfully" })
   @ApiResponse({ status: 404, description: "Roll not found" })
@@ -97,6 +102,7 @@ export class RollController {
   }
 
   @Post(":key/transition")
+  @Throttle({ default: ThrottleLimits._20_REQUESTS_PER_MINUTE })
   @ApiOperation({ summary: "Transition a roll to a new storage state" })
   @ApiResponse({
     status: 200,

--- a/frollz-api/src/stock-tag/stock-tag.controller.ts
+++ b/frollz-api/src/stock-tag/stock-tag.controller.ts
@@ -8,6 +8,8 @@ import {
   NotFoundException,
   Query,
 } from "@nestjs/common";
+import { Throttle } from "@nestjs/throttler";
+import { ThrottleLimits } from "../common/throttle-limits";
 import { ApiTags, ApiOperation, ApiResponse, ApiQuery } from "@nestjs/swagger";
 import { StockTagService } from "./stock-tag.service";
 import { CreateStockTagDto } from "./dto/create-stock-tag.dto";
@@ -19,6 +21,7 @@ export class StockTagController {
   constructor(private readonly stockTagService: StockTagService) {}
 
   @Post()
+  @Throttle({ default: ThrottleLimits._20_REQUESTS_PER_MINUTE })
   @ApiOperation({ summary: "Associate a tag with a stock" })
   @ApiResponse({
     status: 201,
@@ -66,6 +69,7 @@ export class StockTagController {
   }
 
   @Delete(":key")
+  @Throttle({ default: ThrottleLimits._20_REQUESTS_PER_MINUTE })
   @ApiOperation({ summary: "Remove a stock-tag association" })
   @ApiResponse({ status: 200, description: "StockTag deleted successfully" })
   @ApiResponse({ status: 404, description: "StockTag not found" })

--- a/frollz-api/src/stock/stock.controller.ts
+++ b/frollz-api/src/stock/stock.controller.ts
@@ -9,6 +9,8 @@ import {
   NotFoundException,
   Query,
 } from "@nestjs/common";
+import { Throttle } from "@nestjs/throttler";
+import { ThrottleLimits } from "../common/throttle-limits";
 import { ApiTags, ApiOperation, ApiQuery, ApiResponse } from "@nestjs/swagger";
 import { StockService } from "./stock.service";
 import { CreateStockDto } from "./dto/create-stock.dto";
@@ -22,6 +24,7 @@ export class StockController {
   constructor(private readonly stockService: StockService) {}
 
   @Post()
+  @Throttle({ default: ThrottleLimits._20_REQUESTS_PER_MINUTE })
   @ApiOperation({ summary: "Create a new stock" })
   @ApiResponse({
     status: 201,
@@ -33,6 +36,7 @@ export class StockController {
   }
 
   @Post("bulk")
+  @Throttle({ default: ThrottleLimits._10_REQUESTS_PER_MINUTE })
   @ApiOperation({ summary: "Create stocks for multiple formats at once" })
   @ApiResponse({
     status: 201,
@@ -57,6 +61,7 @@ export class StockController {
   }
 
   @Get("brands")
+  @Throttle({ default: ThrottleLimits._30_REQUESTS_PER_MINUTE })
   @ApiOperation({ summary: "Get distinct brand names matching a query" })
   @ApiQuery({
     name: "q",
@@ -73,6 +78,7 @@ export class StockController {
   }
 
   @Get("manufacturers")
+  @Throttle({ default: ThrottleLimits._30_REQUESTS_PER_MINUTE })
   @ApiOperation({ summary: "Get distinct manufacturer names matching a query" })
   @ApiQuery({
     name: "q",
@@ -89,6 +95,7 @@ export class StockController {
   }
 
   @Get("speeds")
+  @Throttle({ default: ThrottleLimits._30_REQUESTS_PER_MINUTE })
   @ApiOperation({ summary: "Get distinct speed values matching a query" })
   @ApiQuery({
     name: "q",
@@ -121,6 +128,7 @@ export class StockController {
   }
 
   @Patch(":key")
+  @Throttle({ default: ThrottleLimits._20_REQUESTS_PER_MINUTE })
   @ApiOperation({ summary: "Update a stock" })
   @ApiResponse({
     status: 200,
@@ -140,6 +148,7 @@ export class StockController {
   }
 
   @Delete(":key")
+  @Throttle({ default: ThrottleLimits._20_REQUESTS_PER_MINUTE })
   @ApiOperation({ summary: "Delete a stock" })
   @ApiResponse({ status: 200, description: "Stock deleted successfully" })
   @ApiResponse({ status: 404, description: "Stock not found" })

--- a/frollz-api/src/tag/tag.controller.ts
+++ b/frollz-api/src/tag/tag.controller.ts
@@ -8,6 +8,8 @@ import {
   Delete,
   NotFoundException,
 } from "@nestjs/common";
+import { Throttle } from "@nestjs/throttler";
+import { ThrottleLimits } from "../common/throttle-limits";
 import { ApiTags, ApiOperation, ApiResponse } from "@nestjs/swagger";
 import { TagService } from "./tag.service";
 import { CreateTagDto } from "./dto/create-tag.dto";
@@ -20,6 +22,7 @@ export class TagController {
   constructor(private readonly tagService: TagService) {}
 
   @Post()
+  @Throttle({ default: ThrottleLimits._20_REQUESTS_PER_MINUTE })
   @ApiOperation({ summary: "Create a new tag" })
   @ApiResponse({
     status: 201,
@@ -58,6 +61,7 @@ export class TagController {
   }
 
   @Patch(":key")
+  @Throttle({ default: ThrottleLimits._20_REQUESTS_PER_MINUTE })
   @ApiOperation({ summary: "Update a tag" })
   @ApiResponse({
     status: 200,
@@ -77,6 +81,7 @@ export class TagController {
   }
 
   @Delete(":key")
+  @Throttle({ default: ThrottleLimits._20_REQUESTS_PER_MINUTE })
   @ApiOperation({ summary: "Delete a tag" })
   @ApiResponse({ status: 200, description: "Tag deleted successfully" })
   @ApiResponse({ status: 404, description: "Tag not found" })


### PR DESCRIPTION
## Summary

The global throttle (100 req/min) was applied uniformly across all endpoints. This PR adds per-endpoint overrides for routes where that limit is too permissive:

| Limit | Endpoints |
|-------|-----------|
| 10/min | `POST /stocks/bulk` — creates N rows per request |
| 20/min | All `POST`, `PATCH`, `DELETE` handlers across every controller |
| 30/min | `GET /stocks/brands`, `GET /stocks/manufacturers`, `GET /stocks/speeds` — unbounded `LIKE` queries |
| 100/min (unchanged) | All read endpoints, `GET /transitions`, `GET /roll-states` |

## Test plan

- [x] Normal app usage (browsing stocks, rolls, tags) is not rate limited
- [x] Submitting forms (create/update/delete) still works within normal usage
- [x] Typeahead fields still respond for normal typing speed
- [x] Rapid scripted mutations (>20/min) receive a `429 Too Many Requests`

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)