### PR TITLE
fix(security): validate and strip transition metadata against DB-driven schema

### DIFF
--- a/frollz-api/src/roll/roll.service.spec.ts
+++ b/frollz-api/src/roll/roll.service.spec.ts
@@ -6,6 +6,7 @@ import { RollStateService } from "../roll-state/roll-state.service";
 import { RollTagService } from "../roll-tag/roll-tag.service";
 import { RollState } from "./entities/roll.entity";
 import { TransitionService } from "../transition/transition.service";
+import type { TransitionEdge } from "../transition/entities/transition.entity";
 
 const makeDbService = (
   overrides: Partial<{ query: jest.Mock; execute: jest.Mock }> = {},
@@ -24,8 +25,18 @@ const makeRollTagService = () => ({
   syncAutoTag: jest.fn().mockResolvedValue(undefined),
 });
 
+const makeEdge = (overrides: Partial<TransitionEdge> = {}): TransitionEdge => ({
+  id: "edge-1",
+  fromState: RollState.SHELVED,
+  toState: RollState.LOADED,
+  transitionType: "FORWARD",
+  requiresDate: true,
+  metadata: [],
+  ...overrides,
+});
+
 const makeTransitionService = () => ({
-  isValidTransition: jest.fn().mockResolvedValue(true),
+  getTransitionEdge: jest.fn().mockResolvedValue(makeEdge()),
 });
 
 describe("RollService", () => {
@@ -176,19 +187,22 @@ describe("RollService", () => {
       );
     });
 
-    it("should reject invalid transitions when TransitionService returns false", async () => {
-      transitionService.isValidTransition.mockResolvedValueOnce(false);
+    it("should reject invalid transitions when TransitionService returns null", async () => {
+      transitionService.getTransitionEdge.mockResolvedValueOnce(null);
       await expect(
         service.transition("roll-uuid", { targetState: RollState.FINISHED }),
       ).rejects.toThrow(BadRequestException);
     });
 
     it("should allow valid backward transitions", async () => {
+      transitionService.getTransitionEdge.mockResolvedValueOnce(
+        makeEdge({ fromState: RollState.SHELVED, toState: RollState.FROZEN }),
+      );
       await expect(
         service.transition("roll-uuid", { targetState: RollState.FROZEN }),
       ).resolves.not.toThrow();
 
-      expect(transitionService.isValidTransition).toHaveBeenCalledWith(
+      expect(transitionService.getTransitionEdge).toHaveBeenCalledWith(
         RollState.SHELVED,
         RollState.FROZEN,
       );
@@ -229,7 +243,19 @@ describe("RollService", () => {
       );
     });
 
-    it("should pass metadata to the state history entry", async () => {
+    it("should pass validated metadata to the state history entry", async () => {
+      transitionService.getTransitionEdge.mockResolvedValueOnce(
+        makeEdge({
+          metadata: [
+            {
+              field: "temperature",
+              fieldType: "number",
+              defaultValue: null,
+              isRequired: false,
+            },
+          ],
+        }),
+      );
       await service.transition("roll-uuid", {
         targetState: RollState.LOADED,
         metadata: { temperature: -18 },
@@ -240,7 +266,72 @@ describe("RollService", () => {
       );
     });
 
-    it("should pass metadata: undefined when not set", async () => {
+    it("should strip unknown metadata keys not defined on the edge", async () => {
+      transitionService.getTransitionEdge.mockResolvedValueOnce(
+        makeEdge({
+          metadata: [
+            {
+              field: "temperature",
+              fieldType: "number",
+              defaultValue: null,
+              isRequired: false,
+            },
+          ],
+        }),
+      );
+      await service.transition("roll-uuid", {
+        targetState: RollState.LOADED,
+        metadata: { temperature: -18, __proto__: "evil", unknownKey: "bad" },
+      });
+
+      expect(rollStateService.create).toHaveBeenCalledWith(
+        expect.objectContaining({ metadata: { temperature: -18 } }),
+      );
+    });
+
+    it("should throw when a metadata value is not a primitive", async () => {
+      transitionService.getTransitionEdge.mockResolvedValueOnce(
+        makeEdge({
+          metadata: [
+            {
+              field: "temperature",
+              fieldType: "number",
+              defaultValue: null,
+              isRequired: false,
+            },
+          ],
+        }),
+      );
+      await expect(
+        service.transition("roll-uuid", {
+          targetState: RollState.LOADED,
+          metadata: { temperature: { nested: "object" } },
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it("should throw when a required metadata field is missing", async () => {
+      transitionService.getTransitionEdge.mockResolvedValueOnce(
+        makeEdge({
+          metadata: [
+            {
+              field: "processRequested",
+              fieldType: "string",
+              defaultValue: null,
+              isRequired: true,
+            },
+          ],
+        }),
+      );
+      await expect(
+        service.transition("roll-uuid", {
+          targetState: RollState.LOADED,
+          metadata: {},
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it("should pass metadata: undefined when edge has no metadata fields", async () => {
       await service.transition("roll-uuid", {
         targetState: RollState.LOADED,
       });
@@ -330,7 +421,39 @@ describe("RollService", () => {
       updated_at: new Date().toISOString(),
     };
 
+    const sentForDevEdge = makeEdge({
+      fromState: RollState.FINISHED,
+      toState: RollState.SENT_FOR_DEVELOPMENT,
+      metadata: [
+        {
+          field: "labName",
+          fieldType: "string",
+          defaultValue: null,
+          isRequired: false,
+        },
+        {
+          field: "deliveryMethod",
+          fieldType: "string",
+          defaultValue: null,
+          isRequired: false,
+        },
+        {
+          field: "processRequested",
+          fieldType: "string",
+          defaultValue: null,
+          isRequired: false,
+        },
+        {
+          field: "pushPullStops",
+          fieldType: "number",
+          defaultValue: null,
+          isRequired: false,
+        },
+      ],
+    });
+
     it("should apply cross-processed tag when processRequested differs from stock process", async () => {
+      transitionService.getTransitionEdge.mockResolvedValueOnce(sentForDevEdge);
       db.query
         .mockResolvedValueOnce([finishedRollRow])
         .mockResolvedValueOnce([{ process: "C-41" }])
@@ -353,6 +476,7 @@ describe("RollService", () => {
     });
 
     it("should not apply cross-processed tag when processRequested matches stock process", async () => {
+      transitionService.getTransitionEdge.mockResolvedValueOnce(sentForDevEdge);
       db.query
         .mockResolvedValueOnce([finishedRollRow])
         .mockResolvedValueOnce([{ process: "C-41" }])
@@ -375,6 +499,7 @@ describe("RollService", () => {
     });
 
     it("should not call syncCrossProcessedTag when processRequested is absent", async () => {
+      transitionService.getTransitionEdge.mockResolvedValueOnce(sentForDevEdge);
       db.query
         .mockResolvedValueOnce([finishedRollRow])
         .mockResolvedValueOnce([finishedRollRow]);
@@ -408,7 +533,21 @@ describe("RollService", () => {
       updated_at: new Date().toISOString(),
     };
 
+    const finishedEdge = makeEdge({
+      fromState: RollState.LOADED,
+      toState: RollState.FINISHED,
+      metadata: [
+        {
+          field: "shotISO",
+          fieldType: "number",
+          defaultValue: null,
+          isRequired: false,
+        },
+      ],
+    });
+
     it("should apply pushed tag when shotISO > stock speed", async () => {
+      transitionService.getTransitionEdge.mockResolvedValueOnce(finishedEdge);
       db.query
         .mockResolvedValueOnce([loadedRollRow]) // findOne
         .mockResolvedValueOnce([{ speed: 400 }]) // syncPushPullTags stock query
@@ -432,6 +571,7 @@ describe("RollService", () => {
     });
 
     it("should apply pulled tag when shotISO < stock speed", async () => {
+      transitionService.getTransitionEdge.mockResolvedValueOnce(finishedEdge);
       db.query
         .mockResolvedValueOnce([loadedRollRow])
         .mockResolvedValueOnce([{ speed: 400 }])
@@ -455,6 +595,7 @@ describe("RollService", () => {
     });
 
     it("should remove both tags when shotISO equals stock speed", async () => {
+      transitionService.getTransitionEdge.mockResolvedValueOnce(finishedEdge);
       db.query
         .mockResolvedValueOnce([loadedRollRow])
         .mockResolvedValueOnce([{ speed: 400 }])
@@ -478,6 +619,7 @@ describe("RollService", () => {
     });
 
     it("should remove both tags when no shotISO provided", async () => {
+      transitionService.getTransitionEdge.mockResolvedValueOnce(finishedEdge);
       db.query
         .mockResolvedValueOnce([loadedRollRow])
         .mockResolvedValueOnce([{ speed: 400 }])
@@ -500,6 +642,7 @@ describe("RollService", () => {
     });
 
     it("should not call syncPushPullTags when transitioning to a non-FINISHED state", async () => {
+      transitionService.getTransitionEdge.mockResolvedValueOnce(finishedEdge);
       db.query.mockResolvedValue([loadedRollRow]);
 
       await service.transition("roll-uuid", {

--- a/frollz-api/src/roll/roll.service.ts
+++ b/frollz-api/src/roll/roll.service.ts
@@ -8,6 +8,7 @@ import { Roll, RollState } from "./entities/roll.entity";
 import { RollStateService } from "../roll-state/roll-state.service";
 import { RollTagService } from "../roll-tag/roll-tag.service";
 import { TransitionService } from "../transition/transition.service";
+import { TransitionMetadataField } from "../transition/entities/transition.entity";
 
 const ROLLS_WITH_STOCK_QUERY = `
   SELECT r.*, s.brand AS stock_name, s.speed AS stock_speed, f.format AS format_name
@@ -263,15 +264,17 @@ export class RollService implements OnModuleInit {
     const roll = await this.findOne(key);
     if (!roll) return null;
 
-    const valid = await this.transitionService.isValidTransition(
+    const edge = await this.transitionService.getTransitionEdge(
       roll.state,
       dto.targetState,
     );
-    if (!valid) {
+    if (!edge) {
       throw new BadRequestException(
         `Cannot transition from ${roll.state} to ${dto.targetState}`,
       );
     }
+
+    const metadata = this.validateAndStripMetadata(dto.metadata, edge.metadata);
 
     await this.rollStateService.create({
       rollKey: key,
@@ -279,21 +282,55 @@ export class RollService implements OnModuleInit {
       date: dto.date ? new Date(dto.date) : new Date(),
       notes: dto.notes,
       isErrorCorrection: dto.isErrorCorrection,
-      metadata: dto.metadata,
+      metadata,
     });
 
     if (dto.targetState === RollState.FINISHED) {
-      const shotISO = dto.metadata?.shotISO as number | undefined;
+      const shotISO = metadata?.shotISO as number | undefined;
       await this.syncPushPullTags(key, roll.stockKey, shotISO);
     }
 
     if (dto.targetState === RollState.SENT_FOR_DEVELOPMENT) {
-      const processRequested = dto.metadata?.processRequested as
-        | string
-        | undefined;
+      const processRequested = metadata?.processRequested as string | undefined;
       await this.syncCrossProcessedTag(key, roll.stockKey, processRequested);
     }
 
     return this.update(key, { state: dto.targetState });
+  }
+
+  private validateAndStripMetadata(
+    incoming: Record<string, unknown> | undefined,
+    expectedFields: TransitionMetadataField[],
+  ): Record<string, string | number | boolean> | undefined {
+    if (expectedFields.length === 0) return undefined;
+
+    const result: Record<string, string | number | boolean> = {};
+
+    for (const field of expectedFields) {
+      const value = incoming?.[field.field];
+
+      if (value === undefined || value === null) {
+        if (field.isRequired) {
+          throw new BadRequestException(
+            `Metadata field '${field.field}' is required`,
+          );
+        }
+        continue;
+      }
+
+      if (
+        typeof value !== "string" &&
+        typeof value !== "number" &&
+        typeof value !== "boolean"
+      ) {
+        throw new BadRequestException(
+          `Metadata field '${field.field}' must be a string, number, or boolean`,
+        );
+      }
+
+      result[field.field] = value;
+    }
+
+    return Object.keys(result).length > 0 ? result : undefined;
   }
 }

--- a/frollz-api/src/transition/transition.service.spec.ts
+++ b/frollz-api/src/transition/transition.service.spec.ts
@@ -125,21 +125,32 @@ describe("TransitionService", () => {
     });
   });
 
-  describe("isValidTransition", () => {
-    it("should return true when the transition exists in the DB", async () => {
-      db.query.mockResolvedValueOnce([{ id: "edge-1" }]);
-      const result = await service.isValidTransition("Shelved", "Loaded");
-      expect(result).toBe(true);
+  describe("getTransitionEdge", () => {
+    it("should return the edge with metadata when transition exists", async () => {
+      db.query.mockResolvedValueOnce([FROZEN_EDGE]);
+      const edge = await service.getTransitionEdge("Added", "Frozen");
+      expect(edge).not.toBeNull();
+      expect(edge!.fromState).toBe("Added");
+      expect(edge!.toState).toBe("Frozen");
+      expect(edge!.metadata).toHaveLength(1);
+      expect(edge!.metadata[0].field).toBe("temperature");
       expect(db.query).toHaveBeenCalledWith(
         expect.stringContaining("WHERE fs.name = ? AND ts.name = ?"),
-        ["Shelved", "Loaded"],
+        ["Added", "Frozen"],
       );
     });
 
-    it("should return false when no matching transition row exists", async () => {
+    it("should return an edge with empty metadata when no fields exist", async () => {
+      db.query.mockResolvedValueOnce([LOADED_EDGE]);
+      const edge = await service.getTransitionEdge("Shelved", "Loaded");
+      expect(edge).not.toBeNull();
+      expect(edge!.metadata).toEqual([]);
+    });
+
+    it("should return null when no matching transition exists", async () => {
       db.query.mockResolvedValueOnce([]);
-      const result = await service.isValidTransition("Shelved", "Received");
-      expect(result).toBe(false);
+      const edge = await service.getTransitionEdge("Shelved", "Received");
+      expect(edge).toBeNull();
     });
   });
 });

--- a/frollz-api/src/transition/transition.service.ts
+++ b/frollz-api/src/transition/transition.service.ts
@@ -18,6 +18,25 @@ interface TransitionRow {
   is_required: boolean | null;
 }
 
+const TRANSITION_SELECT = `
+  SELECT
+    t.id,
+    fs.name AS from_state,
+    ts.name AS to_state,
+    tt.name AS transition_type,
+    t.requires_date,
+    tm.field,
+    tmft.name AS field_type,
+    tm.default_value,
+    tm.is_required
+  FROM transitions t
+  JOIN transition_states fs ON t.from_state_id = fs.id
+  JOIN transition_states ts ON t.to_state_id = ts.id
+  JOIN transition_types tt ON t.transition_type_id = tt.id
+  LEFT JOIN transition_metadata tm ON tm.transition_id = t.id
+  LEFT JOIN transition_metadata_field_types tmft ON tm.field_type_id = tmft.id
+`;
+
 @Injectable()
 export class TransitionService {
   constructor(private readonly databaseService: DatabaseService) {}
@@ -27,31 +46,33 @@ export class TransitionService {
       this.databaseService.query<{ name: string }>(
         `SELECT name FROM transition_states ORDER BY name`,
       ),
-      this.databaseService.query<TransitionRow>(`
-        SELECT
-          t.id,
-          fs.name AS from_state,
-          ts.name AS to_state,
-          tt.name AS transition_type,
-          t.requires_date,
-          tm.field,
-          tmft.name AS field_type,
-          tm.default_value,
-          tm.is_required
-        FROM transitions t
-        JOIN transition_states fs ON t.from_state_id = fs.id
-        JOIN transition_states ts ON t.to_state_id = ts.id
-        JOIN transition_types tt ON t.transition_type_id = tt.id
-        LEFT JOIN transition_metadata tm ON tm.transition_id = t.id
-        LEFT JOIN transition_metadata_field_types tmft ON tm.field_type_id = tmft.id
-        ORDER BY t.id, tm.field
-      `),
+      this.databaseService.query<TransitionRow>(
+        `${TRANSITION_SELECT} ORDER BY t.id, tm.field`,
+      ),
     ]);
 
-    const states = stateRows.map((r) => r.name);
+    return {
+      states: stateRows.map((r) => r.name),
+      transitions: this.buildEdges(transitionRows),
+    };
+  }
 
+  async getTransitionEdge(
+    fromState: string,
+    toState: string,
+  ): Promise<TransitionEdge | null> {
+    const rows = await this.databaseService.query<TransitionRow>(
+      `${TRANSITION_SELECT} WHERE fs.name = ? AND ts.name = ? ORDER BY tm.field`,
+      [fromState, toState],
+    );
+
+    if (rows.length === 0) return null;
+    return this.buildEdges(rows)[0];
+  }
+
+  private buildEdges(rows: TransitionRow[]): TransitionEdge[] {
     const edgeMap = new Map<string, TransitionEdge>();
-    for (const row of transitionRows) {
+    for (const row of rows) {
       if (!edgeMap.has(row.id)) {
         edgeMap.set(row.id, {
           id: row.id,
@@ -72,22 +93,6 @@ export class TransitionService {
         edgeMap.get(row.id)!.metadata.push(metaField);
       }
     }
-
-    return { states, transitions: Array.from(edgeMap.values()) };
-  }
-
-  async isValidTransition(
-    fromState: string,
-    toState: string,
-  ): Promise<boolean> {
-    const rows = await this.databaseService.query<{ id: string }>(
-      `SELECT t.id
-       FROM transitions t
-       JOIN transition_states fs ON t.from_state_id = fs.id
-       JOIN transition_states ts ON t.to_state_id = ts.id
-       WHERE fs.name = ? AND ts.name = ?`,
-      [fromState, toState],
-    );
-    return rows.length > 0;
+    return Array.from(edgeMap.values());
   }
 }


### PR DESCRIPTION
## Summary

- Replaced `isValidTransition` (boolean check, separate DB query) with `getTransitionEdge(from, to): TransitionEdge | null` — a single query that returns the full edge including expected metadata fields, or null for an invalid transition
- Extracted the row→edge mapping into a private `buildEdges` helper shared between `getGraph` and `getTransitionEdge`, eliminating duplication
- `RollService.transition` now calls `validateAndStripMetadata` before persisting state:
  - **Unknown keys are silently stripped** — only fields defined on the transition edge survive
  - **Values must be `string`, `number`, or `boolean`** — objects and arrays throw `400 Bad Request`
  - **Required fields missing from the payload throw `400 Bad Request`**
- Fully data-driven: adding a new metadata field to the DB requires no API changes

## Why not a static DTO?
A hardcoded `TransitionMetadataDto` would re-couple the API to the DB schema in the same way the old hardcoded transition maps did — new fields added to the DB would be silently stripped by `whitelist: true`. Service-layer validation against the live edge definition is the correct approach given the data-driven state machine.

## Test plan
- [ ] All 168 unit tests pass
- [ ] Transition with valid metadata fields persists correctly
- [ ] Transition with an unknown key (e.g. `__proto__`) has that key stripped silently
- [ ] Transition with a nested object value returns `400`
- [ ] Transition missing a required field returns `400`

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)