### PR TITLE
fix(security): add @MaxLength(100) to typeahead query params

### DIFF
--- a/frollz-api/src/stock/dto/typeahead-query.dto.ts
+++ b/frollz-api/src/stock/dto/typeahead-query.dto.ts
@@ -1,0 +1,8 @@
+import { IsOptional, IsString, MaxLength } from "class-validator";
+
+export class TypeaheadQueryDto {
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  q?: string;
+}

--- a/frollz-api/src/stock/stock.controller.spec.ts
+++ b/frollz-api/src/stock/stock.controller.spec.ts
@@ -72,7 +72,7 @@ describe("StockController", () => {
     it("should return brands from the service", async () => {
       service.getBrands.mockResolvedValue(["Portra 400", "Portra 800"]);
 
-      const result = await controller.getBrands("por");
+      const result = await controller.getBrands({ q: "por" });
 
       expect(service.getBrands).toHaveBeenCalledWith("por");
       expect(result).toEqual(["Portra 400", "Portra 800"]);
@@ -81,7 +81,7 @@ describe("StockController", () => {
     it("should pass empty string when q is undefined", async () => {
       service.getBrands.mockResolvedValue([]);
 
-      await controller.getBrands(undefined as any);
+      await controller.getBrands({});
 
       expect(service.getBrands).toHaveBeenCalledWith("");
     });
@@ -89,7 +89,7 @@ describe("StockController", () => {
     it("should return an empty array when no brands match", async () => {
       service.getBrands.mockResolvedValue([]);
 
-      const result = await controller.getBrands("zzz");
+      const result = await controller.getBrands({ q: "zzz" });
 
       expect(result).toEqual([]);
     });
@@ -99,7 +99,7 @@ describe("StockController", () => {
     it("should return manufacturers from the service", async () => {
       service.getManufacturers.mockResolvedValue(["Kodak", "Konica"]);
 
-      const result = await controller.getManufacturers("ko");
+      const result = await controller.getManufacturers({ q: "ko" });
 
       expect(service.getManufacturers).toHaveBeenCalledWith("ko");
       expect(result).toEqual(["Kodak", "Konica"]);
@@ -108,7 +108,7 @@ describe("StockController", () => {
     it("should pass empty string when q is undefined", async () => {
       service.getManufacturers.mockResolvedValue([]);
 
-      await controller.getManufacturers(undefined as any);
+      await controller.getManufacturers({});
 
       expect(service.getManufacturers).toHaveBeenCalledWith("");
     });
@@ -116,7 +116,7 @@ describe("StockController", () => {
     it("should return an empty array when no manufacturers match", async () => {
       service.getManufacturers.mockResolvedValue([]);
 
-      const result = await controller.getManufacturers("zzz");
+      const result = await controller.getManufacturers({ q: "zzz" });
 
       expect(result).toEqual([]);
     });
@@ -126,7 +126,7 @@ describe("StockController", () => {
     it("should return speeds from the service", async () => {
       service.getSpeeds.mockResolvedValue([400, 800]);
 
-      const result = await controller.getSpeeds("4");
+      const result = await controller.getSpeeds({ q: "4" });
 
       expect(service.getSpeeds).toHaveBeenCalledWith("4");
       expect(result).toEqual([400, 800]);
@@ -135,7 +135,7 @@ describe("StockController", () => {
     it("should pass empty string when q is undefined", async () => {
       service.getSpeeds.mockResolvedValue([]);
 
-      await controller.getSpeeds(undefined as any);
+      await controller.getSpeeds({});
 
       expect(service.getSpeeds).toHaveBeenCalledWith("");
     });
@@ -143,7 +143,7 @@ describe("StockController", () => {
     it("should return an empty array when no speeds match", async () => {
       service.getSpeeds.mockResolvedValue([]);
 
-      const result = await controller.getSpeeds("999");
+      const result = await controller.getSpeeds({ q: "999" });
 
       expect(result).toEqual([]);
     });

--- a/frollz-api/src/stock/stock.controller.ts
+++ b/frollz-api/src/stock/stock.controller.ts
@@ -16,6 +16,7 @@ import { StockService } from "./stock.service";
 import { CreateStockDto } from "./dto/create-stock.dto";
 import { CreateStockMultipleFormatsDto } from "./dto/create-stock-multiple-formats.dto";
 import { UpdateStockDto } from "./dto/update-stock.dto";
+import { TypeaheadQueryDto } from "./dto/typeahead-query.dto";
 import { Stock } from "./entities/stock.entity";
 
 @ApiTags("stocks")
@@ -73,7 +74,7 @@ export class StockController {
     description: "Matching brand names",
     type: [String],
   })
-  getBrands(@Query("q") q: string): Promise<string[]> {
+  getBrands(@Query() { q }: TypeaheadQueryDto): Promise<string[]> {
     return this.stockService.getBrands(q ?? "");
   }
 
@@ -90,7 +91,7 @@ export class StockController {
     description: "Matching manufacturer names",
     type: [String],
   })
-  getManufacturers(@Query("q") q: string): Promise<string[]> {
+  getManufacturers(@Query() { q }: TypeaheadQueryDto): Promise<string[]> {
     return this.stockService.getManufacturers(q ?? "");
   }
 
@@ -107,7 +108,7 @@ export class StockController {
     description: "Matching speed values",
     type: [Number],
   })
-  getSpeeds(@Query("q") q: string): Promise<number[]> {
+  getSpeeds(@Query() { q }: TypeaheadQueryDto): Promise<number[]> {
     return this.stockService.getSpeeds(q ?? "");
   }
 


### PR DESCRIPTION
## Summary

The `q` parameter on `/stocks/brands`, `/stocks/manufacturers`, and `/stocks/speeds` previously accepted an unbounded string, which was passed directly into a `LIKE %q%` DB query. A 10MB input would force an expensive full-table scan on every request.

- Added `TypeaheadQueryDto` with `@IsOptional @IsString @MaxLength(100)`
- Switched all three endpoints from `@Query("q") q: string` to `@Query() { q }: TypeaheadQueryDto`
- The global `ValidationPipe` now rejects any `q` longer than 100 characters with a `400 Bad Request` before the query ever reaches the service

## Test plan

- [x] Normal typeahead usage (short query strings) still works
- [x] `GET /api/stocks/brands?q=<101 chars>` returns `400`
- [x] `GET /api/stocks/brands` (no `q`) still returns all brands

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)