### PR TITLE
fix: resolve vite.config.ts merge conflict — use env-driven proxy target

### DIFF
--- a/frollz-ui/vite.config.ts
+++ b/frollz-ui/vite.config.ts
@@ -17,8 +17,8 @@ export default defineConfig({
       // Proxy /api to the API service — allows the UI dev server to reach the
       // API without CORS issues. API_PROXY_TARGET is set by docker-compose.dev.yml;
       // falls back to localhost for running outside Docker.
-      "/api": {
-        target: process.env.API_PROXY_TARGET || "http://localhost:3000",
+      '/api': {
+        target: process.env.API_PROXY_TARGET || 'http://localhost:3000',
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
## Summary

- Resolves an unresolved merge conflict in `frollz-ui/vite.config.ts`
- Kept the upstream env-driven version (`process.env.API_PROXY_TARGET || 'http://localhost:3000'`) over the stashed hardcoded `http://frollz-api:3000`

## Why

The hardcoded hostname only works inside Docker. The env-driven version handles both:
- **Docker Compose dev**: `docker-compose.dev.yml` already sets `API_PROXY_TARGET=http://frollz-api:3000`
- **Local dev (no Docker)**: falls back to `http://localhost:3000`
- **Production (self-hosted)**: proxy config is irrelevant — SPA is served by NestJS same-origin

## Test plan

- [ ] `npm run lint` passes in `frollz-ui`
- [ ] All 136 UI tests pass
- [ ] All 168 API tests pass
- [ ] Semgrep SAST clean

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)