### PR TITLE
fix: update postgres volume mount for postgres 18 image layout

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -63,11 +63,10 @@ services:
       - POSTGRES_DB=${POSTGRES_DATABASE}
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-      - PGDATA=/var/lib/postgresql/data
     ports:
       - "5432:5432"
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
     networks:
       - frollz-network
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,9 +33,8 @@ services:
       - POSTGRES_DB=${POSTGRES_DATABASE}
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-      - PGDATA=/var/lib/postgresql/data
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
     networks:
       - frollz-network
     restart: unless-stopped


### PR DESCRIPTION
## Summary

- Removes the explicit `PGDATA=/var/lib/postgresql/data` env var from both compose files
- Changes volume mount from `/var/lib/postgresql/data` → `/var/lib/postgresql` in both `docker-compose.yml` and `docker-compose.dev.yml`

## Why

`postgres:18` changed the data directory layout — data now lives in a major-version subdirectory (`/var/lib/postgresql/18/data`) and the image expects the volume mounted at the parent `/var/lib/postgresql`. Mounting at the old `/data` path conflicts with this and prevents the container from starting.

This was introduced when we upgraded to `postgres:18-alpine` in #95.

## Migration note for existing installs

Anyone with an existing `postgres_data` volume (from a pre-18 image) must drop and recreate it — the old pg17-format data can't be read by pg18 directly:

```bash
docker-compose down -v   # ⚠️ destroys volume — all local data lost
docker-compose up -d
```

## Test plan

- [ ] `docker-compose -f docker-compose.dev.yml up -d` starts cleanly with a fresh volume
- [ ] `docker-compose up -d` starts cleanly with a fresh volume
- [ ] All 304 tests pass (confirmed by pre-commit hook)

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)