### PR TITLE
feat(ui): add eslint-plugin-vuejs-accessibility (#189)

### DIFF
--- a/frollz-ui/eslint.config.cjs
+++ b/frollz-ui/eslint.config.cjs
@@ -4,6 +4,7 @@ const tseslint = require("typescript-eslint");
 const vueParser = require("vue-eslint-parser");
 const skipFormatting = require("@vue/eslint-config-prettier/skip-formatting");
 const gitignore = require("eslint-config-flat-gitignore").default;
+const vueA11y = require("eslint-plugin-vuejs-accessibility");
 module.exports = [
 	gitignore(),
 	{
@@ -16,6 +17,7 @@ module.exports = [
 	},
 	...pluginVue.configs["flat/essential"],
 	...tseslint.configs.recommended,
+	...vueA11y.configs["flat/recommended"],
 	skipFormatting,
 	{
 		files: ["**/*.vue"],

--- a/frollz-ui/package-lock.json
+++ b/frollz-ui/package-lock.json
@@ -34,6 +34,7 @@
         "eslint": "^10.0.3",
         "eslint-config-flat-gitignore": "^2.2.1",
         "eslint-plugin-vue": "^10.8.0",
+        "eslint-plugin-vuejs-accessibility": "^2.5.0",
         "globals": "^17.4.0",
         "jsdom": "^29.0.0",
         "npm-run-all2": "^8.0.4",
@@ -2172,6 +2173,16 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -2901,6 +2912,24 @@
         "@typescript-eslint/parser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-plugin-vuejs-accessibility": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vuejs-accessibility/-/eslint-plugin-vuejs-accessibility-2.5.0.tgz",
+      "integrity": "sha512-oZ2fL4tS91Cm/ezH3BueNP+FtpbbeS627OSqqgp9/lsN//glmoPcLBT6D53xwGocLtyBybaT99tX4ThBh8+ytA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.3.0",
+        "vue-eslint-parser": "^9.0.0 || ^10.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0",
+        "globals": ">= 13.12.1"
       }
     },
     "node_modules/eslint-scope": {

--- a/frollz-ui/package.json
+++ b/frollz-ui/package.json
@@ -39,6 +39,7 @@
     "eslint": "^10.0.3",
     "eslint-config-flat-gitignore": "^2.2.1",
     "eslint-plugin-vue": "^10.8.0",
+    "eslint-plugin-vuejs-accessibility": "^2.5.0",
     "globals": "^17.4.0",
     "jsdom": "^29.0.0",
     "npm-run-all2": "^8.0.4",

--- a/frollz-ui/src/components/SpeedTypeaheadInput.vue
+++ b/frollz-ui/src/components/SpeedTypeaheadInput.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="relative">
+    <!-- eslint-disable-next-line vuejs-accessibility/form-control-has-label -- Full ARIA combobox pattern (including label association) addressed in #201 -->
     <input
       :value="rawInput"
       type="text"
@@ -17,6 +18,7 @@
       v-if="isOpen && suggestions.length > 0"
       class="absolute z-10 mt-1 w-full bg-white dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-md shadow-lg max-h-60 overflow-auto"
     >
+      <!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions -- Will be converted to role="option" with full ARIA combobox in #201 -->
       <li
         v-for="(suggestion, i) in suggestions"
         :key="suggestion"

--- a/frollz-ui/src/components/TypeaheadInput.vue
+++ b/frollz-ui/src/components/TypeaheadInput.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="relative">
+    <!-- eslint-disable-next-line vuejs-accessibility/form-control-has-label -- Full ARIA combobox pattern (including label association) addressed in #201 -->
     <input
       v-model="inputValue"
       type="text"
@@ -16,6 +17,7 @@
       v-if="isOpen && suggestions.length > 0"
       class="absolute z-10 mt-1 w-full bg-white dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-md shadow-lg max-h-60 overflow-auto"
     >
+      <!-- eslint-disable-next-line vuejs-accessibility/no-static-element-interactions -- Will be converted to role="option" with full ARIA combobox in #201 -->
       <li
         v-for="(suggestion, i) in suggestions"
         :key="suggestion"

--- a/frollz-ui/src/views/FilmFormatsView.vue
+++ b/frollz-ui/src/views/FilmFormatsView.vue
@@ -58,6 +58,7 @@
     <div v-if="showCreateForm" class="fixed inset-0 bg-black bg-opacity-50 dark:bg-opacity-70 flex items-center justify-center z-50">
       <div class="bg-white dark:bg-gray-800 rounded-lg p-6 max-w-md w-full mx-4">
         <h3 class="text-lg font-semibold dark:text-gray-100 mb-4">Add Film Format</h3>
+        <!-- eslint-disable vuejs-accessibility/label-has-for, vuejs-accessibility/form-control-has-label -- for/id label associations will be added in #199 -->
         <form @submit.prevent="createFormat">
           <div class="mb-4">
             <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">Form Factor</label>
@@ -100,6 +101,7 @@
             </button>
           </div>
         </form>
+        <!-- eslint-enable vuejs-accessibility/label-has-for, vuejs-accessibility/form-control-has-label -->
       </div>
     </div>
   </div>

--- a/frollz-ui/src/views/RollDetailView.vue
+++ b/frollz-ui/src/views/RollDetailView.vue
@@ -96,6 +96,7 @@
               </button>
             </div>
             <!-- Storage state metadata form -->
+            <!-- eslint-disable vuejs-accessibility/label-has-for, vuejs-accessibility/form-control-has-label -- for/id label associations will be added in #199 -->
             <div v-if="pendingMetadataTransition" class="border border-blue-300 dark:border-blue-600 rounded-md p-3 bg-blue-50 dark:bg-blue-900/20">
               <p class="text-sm font-medium text-blue-800 dark:text-blue-200 mb-3">{{ pendingMetadataTransition }} details</p>
               <label v-if="requiresDateCapture(pendingMetadataTransition!)" class="block text-xs text-gray-600 dark:text-gray-400 mb-2">
@@ -231,6 +232,7 @@
             <div v-if="transitionError" class="text-sm text-red-600 dark:text-red-400">{{ transitionError }}</div>
           </div>
         </div>
+        <!-- eslint-enable vuejs-accessibility/label-has-for, vuejs-accessibility/form-control-has-label -->
 
         <!-- Child rolls card (bulk rolls only) -->
         <div v-if="roll.transitionProfile === 'bulk'" class="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6">

--- a/frollz-ui/src/views/RollsView.vue
+++ b/frollz-ui/src/views/RollsView.vue
@@ -77,6 +77,7 @@
                 @click="roll.formatName && addFilter('formatName', 'Format', roll.formatName)"
               >{{ roll.formatName ?? '—' }}</td>
               <td class="px-6 py-4 whitespace-nowrap">
+                <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events, vuejs-accessibility/no-static-element-interactions -- filter chip; will be converted to a button in #202 -->
                 <span
                   class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full cursor-pointer hover:opacity-80"
                   :class="getStateColor(roll.state)"
@@ -111,6 +112,7 @@
     <div v-if="showModal" class="fixed inset-0 bg-gray-500 bg-opacity-75 dark:bg-gray-900 dark:bg-opacity-80 flex items-center justify-center z-50">
       <div class="bg-white dark:bg-gray-800 rounded-lg shadow-xl p-6 w-full max-w-lg max-h-screen overflow-y-auto">
         <h2 class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-4">Add Roll</h2>
+        <!-- eslint-disable vuejs-accessibility/label-has-for, vuejs-accessibility/form-control-has-label -- for/id label associations will be added in #199 -->
         <form @submit.prevent="handleSubmit">
           <div class="space-y-4">
             <!-- Bulk roll toggle -->
@@ -237,6 +239,7 @@
             </button>
           </div>
         </form>
+        <!-- eslint-enable vuejs-accessibility/label-has-for, vuejs-accessibility/form-control-has-label -->
       </div>
     </div>
   </div>

--- a/frollz-ui/src/views/StocksView.vue
+++ b/frollz-ui/src/views/StocksView.vue
@@ -70,6 +70,7 @@
                 @click="addFilter('format', 'Format', stock.format ?? '')"
               >{{ stock.format }}</td>
               <td class="px-6 py-4 whitespace-nowrap">
+                <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events, vuejs-accessibility/no-static-element-interactions -- filter chip; will be converted to a button in #202 -->
                 <span
                   class="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 cursor-pointer hover:bg-blue-200 dark:hover:bg-blue-800"
                   @click="addFilter('process', 'Process', stock.process)"
@@ -83,6 +84,7 @@
               >ISO {{ stock.speed }}</td>
               <td class="px-6 py-4 text-sm text-gray-500 dark:text-gray-400">
                 <div class="flex flex-wrap gap-1">
+                  <!-- eslint-disable-next-line vuejs-accessibility/click-events-have-key-events, vuejs-accessibility/no-static-element-interactions -- filter chip; will be converted to a button in #202 -->
                   <span
                     v-for="tag in stockTagMap[stock._key!]"
                     :key="tag._key"
@@ -111,6 +113,7 @@
     <div v-if="showModal" class="fixed inset-0 bg-gray-500 bg-opacity-75 dark:bg-gray-900 dark:bg-opacity-80 flex items-center justify-center z-50">
       <div class="bg-white dark:bg-gray-800 rounded-lg shadow-xl p-6 w-full max-w-lg max-h-screen overflow-y-auto">
         <h2 class="text-xl font-bold text-gray-900 dark:text-gray-100 mb-4">Add Stock</h2>
+        <!-- eslint-disable vuejs-accessibility/label-has-for, vuejs-accessibility/form-control-has-label -- for/id label associations will be added in #199 -->
         <form @submit.prevent="handleSubmit">
           <div class="space-y-4">
             <div>
@@ -220,6 +223,7 @@
             </button>
           </div>
         </form>
+        <!-- eslint-enable vuejs-accessibility/label-has-for, vuejs-accessibility/form-control-has-label -->
       </div>
     </div>
   </div>

--- a/frollz-ui/src/views/TagsView.vue
+++ b/frollz-ui/src/views/TagsView.vue
@@ -21,6 +21,7 @@
             <tr v-for="tag in paginatedTags" :key="tag._key">
               <td class="px-6 py-4 whitespace-nowrap">
                 <template v-if="editingKey === tag._key">
+                  <!-- eslint-disable-next-line vuejs-accessibility/form-control-has-label -- inline table edit; column header is the visual label; full label associations in #199 -->
                   <input
                     v-model="editForm.color"
                     type="color"
@@ -36,6 +37,7 @@
               </td>
               <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
                 <template v-if="editingKey === tag._key">
+                  <!-- eslint-disable-next-line vuejs-accessibility/form-control-has-label -- inline table edit; column header is the visual label; full label associations in #199 -->
                   <input
                     v-model="editForm.value"
                     type="text"
@@ -50,6 +52,7 @@
                 </template>
               </td>
               <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
+                <!-- eslint-disable-next-line vuejs-accessibility/form-control-has-label -- inline table edit; column header is the visual label; full label associations in #199 -->
                 <input
                   type="checkbox"
                   :checked="editingKey === tag._key ? editForm.isRollScoped : tag.isRollScoped"
@@ -59,6 +62,7 @@
                 />
               </td>
               <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
+                <!-- eslint-disable-next-line vuejs-accessibility/form-control-has-label -- inline table edit; column header is the visual label; full label associations in #199 -->
                 <input
                   type="checkbox"
                   :checked="editingKey === tag._key ? editForm.isStockScoped : tag.isStockScoped"


### PR DESCRIPTION
## Summary
- Installs `eslint-plugin-vuejs-accessibility` and configures `flat/recommended` ruleset in `frollz-ui/eslint.config.cjs`
- `npm run lint` now enforces Vue-specific a11y rules (missing labels, invalid ARIA roles, etc.) at lint time
- All 58 pre-existing violations suppressed with `eslint-disable` comments referencing the appropriate follow-up issues — no violations silently ignored without a paper trail

## Suppression map
| Rule(s) | Files | Follow-up |
|---|---|---|
| `form-control-has-label`, `label-has-for` | RollsView, StocksView, FilmFormatsView, RollDetailView, TagsView | #199 |
| `form-control-has-label`, `no-static-element-interactions` | TypeaheadInput, SpeedTypeaheadInput | #201 |
| `click-events-have-key-events`, `no-static-element-interactions` | RollsView, StocksView filter chips | #202 |

## Test plan
- [x] `npm run lint` passes with zero errors
- [x] `npm run type-check` passes
- [x] All 136 UI tests pass
- [x] Pre-commit hook passes end-to-end

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)