### PR TITLE
feat(ui): integrate axe-core into Vitest component tests (#190)

### DIFF
--- a/frollz-ui/package-lock.json
+++ b/frollz-ui/package-lock.json
@@ -31,6 +31,7 @@
         "@vue/test-utils": "^2.4.6",
         "@vue/tsconfig": "^0.9.0",
         "autoprefixer": "^10.4.27",
+        "axe-core": "^4.11.1",
         "eslint": "^10.0.3",
         "eslint-config-flat-gitignore": "^2.2.1",
         "eslint-plugin-vue": "^10.8.0",
@@ -44,6 +45,7 @@
         "typescript-eslint": "^8.57.1",
         "vite": "^8.0.0",
         "vitest": "^4.1.0",
+        "vitest-axe": "^0.1.0",
         "vue-eslint-parser": "^10.4.0",
         "vue-tsc": "^3.2.6"
       }
@@ -2172,6 +2174,16 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -2255,6 +2267,16 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.1.tgz",
+      "integrity": "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/axios": {
@@ -2427,6 +2449,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/chokidar": {
@@ -2613,6 +2648,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -3451,6 +3493,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
@@ -4186,6 +4238,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "11.2.7",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
@@ -4288,6 +4347,16 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -4873,6 +4942,20 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -5079,6 +5162,19 @@
       "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
@@ -5644,6 +5740,24 @@
         "vite": {
           "optional": false
         }
+      }
+    },
+    "node_modules/vitest-axe": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/vitest-axe/-/vitest-axe-0.1.0.tgz",
+      "integrity": "sha512-jvtXxeQPg8R/2ANTY8QicA5pvvdRP4F0FsVUAHANJ46YCDASie/cuhlSzu0DGcLmZvGBSBNsNuK3HqfaeknyvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.0.0",
+        "axe-core": "^4.4.2",
+        "chalk": "^5.0.1",
+        "dom-accessibility-api": "^0.5.14",
+        "lodash-es": "^4.17.21",
+        "redent": "^3.0.0"
+      },
+      "peerDependencies": {
+        "vitest": ">=0.16.0"
       }
     },
     "node_modules/vitest/node_modules/picomatch": {

--- a/frollz-ui/package.json
+++ b/frollz-ui/package.json
@@ -36,6 +36,7 @@
     "@vue/test-utils": "^2.4.6",
     "@vue/tsconfig": "^0.9.0",
     "autoprefixer": "^10.4.27",
+    "axe-core": "^4.11.1",
     "eslint": "^10.0.3",
     "eslint-config-flat-gitignore": "^2.2.1",
     "eslint-plugin-vue": "^10.8.0",
@@ -49,6 +50,7 @@
     "typescript-eslint": "^8.57.1",
     "vite": "^8.0.0",
     "vitest": "^4.1.0",
+    "vitest-axe": "^0.1.0",
     "vue-eslint-parser": "^10.4.0",
     "vue-tsc": "^3.2.6"
   },

--- a/frollz-ui/src/components/__tests__/NavBar.spec.ts
+++ b/frollz-ui/src/components/__tests__/NavBar.spec.ts
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { createRouter, createMemoryHistory } from 'vue-router'
+import { axe } from 'vitest-axe'
+import NavBar from '@/components/NavBar.vue'
+
+// jsdom does not implement window.matchMedia; stub it so theme store initialises cleanly
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+})
+
+const router = createRouter({
+  history: createMemoryHistory(),
+  routes: [
+    { path: '/', name: 'dashboard', component: { template: '<div/>' } },
+    { path: '/formats', name: 'formats', component: { template: '<div/>' } },
+    { path: '/stocks', name: 'stocks', component: { template: '<div/>' } },
+    { path: '/rolls', name: 'rolls', component: { template: '<div/>' } },
+    { path: '/tags', name: 'tags', component: { template: '<div/>' } },
+  ],
+})
+
+const axeOptions = {
+  runOnly: { type: 'tag' as const, values: ['wcag2a', 'wcag2aa', 'wcag21aa'] },
+}
+
+describe('NavBar', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('renders without a11y violations', async () => {
+    const wrapper = mount(NavBar, {
+      global: { plugins: [router] },
+    })
+    await router.isReady()
+
+    const results = await axe(wrapper.element, axeOptions)
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/frollz-ui/src/components/__tests__/SpeedTypeaheadInput.spec.ts
+++ b/frollz-ui/src/components/__tests__/SpeedTypeaheadInput.spec.ts
@@ -1,0 +1,26 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { axe } from 'vitest-axe'
+import SpeedTypeaheadInput from '@/components/SpeedTypeaheadInput.vue'
+
+const axeOptions = {
+  runOnly: { type: 'tag' as const, values: ['wcag2a', 'wcag2aa', 'wcag21aa'] },
+}
+
+const fetchOptions = vi.fn().mockResolvedValue([])
+
+describe('SpeedTypeaheadInput', () => {
+  it('renders without a11y violations when an aria-label is provided', async () => {
+    // Component is designed to receive label context from the parent via $attrs
+    // (aria-label or a wrapping <label>). Test with aria-label to represent
+    // correct consumer usage; full ARIA combobox pattern is addressed in #201.
+    const wrapper = mount(SpeedTypeaheadInput, {
+      props: { modelValue: undefined, fetchOptions },
+      attrs: { 'aria-label': 'Film speed (ISO)' },
+    })
+
+    const results = await axe(wrapper.element, axeOptions)
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/frollz-ui/src/components/__tests__/TypeaheadInput.spec.ts
+++ b/frollz-ui/src/components/__tests__/TypeaheadInput.spec.ts
@@ -1,0 +1,26 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { axe } from 'vitest-axe'
+import TypeaheadInput from '@/components/TypeaheadInput.vue'
+
+const axeOptions = {
+  runOnly: { type: 'tag' as const, values: ['wcag2a', 'wcag2aa', 'wcag21aa'] },
+}
+
+const fetchOptions = vi.fn().mockResolvedValue([])
+
+describe('TypeaheadInput', () => {
+  it('renders without a11y violations when an aria-label is provided', async () => {
+    // Component is designed to receive label context from the parent via $attrs
+    // (aria-label or a wrapping <label>). Test with aria-label to represent
+    // correct consumer usage; full ARIA combobox pattern is addressed in #201.
+    const wrapper = mount(TypeaheadInput, {
+      props: { modelValue: '', fetchOptions },
+      attrs: { 'aria-label': 'Stock brand' },
+    })
+
+    const results = await axe(wrapper.element, axeOptions)
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/frollz-ui/src/test-setup.ts
+++ b/frollz-ui/src/test-setup.ts
@@ -1,0 +1,4 @@
+import { expect } from 'vitest'
+import * as vitestAxeMatchers from 'vitest-axe/matchers'
+
+expect.extend(vitestAxeMatchers)

--- a/frollz-ui/src/views/__tests__/RollsView.spec.ts
+++ b/frollz-ui/src/views/__tests__/RollsView.spec.ts
@@ -2,9 +2,14 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
 import { createRouter, createMemoryHistory } from 'vue-router'
+import { axe } from 'vitest-axe'
 import RollsView from '@/views/RollsView.vue'
 import { rollApi, stockApi } from '@/services/api-client'
 import { RollState, ObtainmentMethod } from '@/types'
+
+const axeOptions = {
+  runOnly: { type: 'tag' as const, values: ['wcag2a', 'wcag2aa', 'wcag21aa'] },
+}
 
 vi.mock('@/services/api-client', () => ({
   rollApi: {
@@ -41,6 +46,18 @@ describe('RollsView', () => {
     vi.clearAllMocks()
     vi.mocked(rollApi.getAll).mockResolvedValue({ data: [] } as any)
     vi.mocked(stockApi.getAll).mockResolvedValue({ data: [] } as any)
+  })
+
+  describe('accessibility', () => {
+    it('renders the roll list without a11y violations', async () => {
+      vi.mocked(rollApi.getAll).mockResolvedValue({ data: [] } as any)
+
+      const wrapper = mount(RollsView, { global: { plugins: [router] } })
+      await flushPromises()
+
+      const results = await axe(wrapper.element, axeOptions)
+      expect(results).toHaveNoViolations()
+    })
   })
 
   describe('shelved spelling', () => {

--- a/frollz-ui/vite.config.ts
+++ b/frollz-ui/vite.config.ts
@@ -27,5 +27,6 @@ export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
+    setupFiles: ['./src/test-setup.ts'],
   },
 })


### PR DESCRIPTION
## Summary
- Installs `axe-core` + `vitest-axe`; wires `toHaveNoViolations` via a global `setupFiles` entry in `vite.config.ts`
- `npm run test` now enforces WCAG 2.1 AA at test time — any new axe violation fails the suite
- Adds axe checks to all four AC-required components: `NavBar`, `TypeaheadInput`, `SpeedTypeaheadInput`, and `RollsView` (empty-list render)
- All four pass with zero violations

## Test plan
- [x] `npm run test` passes (140 tests, 9 files)
- [x] `npm run type-check` passes (namespace import workaround for `verbatimModuleSyntax`)
- [x] `npm run lint` passes
- [x] Pre-commit hook passes end-to-end

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)