### PR TITLE
feat(ci): add Lighthouse CI with self-hosted LHCI server (#191)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -73,10 +73,41 @@ jobs:
       - name: Scan
         run: semgrep scan --config p/default --config p/typescript --metrics=off --error
 
+  lighthouse:
+    name: Lighthouse CI
+    runs-on: ubuntu-latest
+    needs: [ci-ui]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+          cache-dependency-path: frollz-ui/package-lock.json
+
+      - name: Install UI dependencies
+        working-directory: frollz-ui
+        run: npm ci
+
+      - name: Build UI
+        working-directory: frollz-ui
+        run: npm run build
+
+      - name: Install Lighthouse CI
+        run: npm install -g @lhci/cli
+
+      - name: Run Lighthouse CI
+        run: lhci autorun
+        env:
+          LHCI_SERVER_BASE_URL: ${{ secrets.LHCI_SERVER_BASE_URL }}
+          LHCI_TOKEN: ${{ secrets.LHCI_TOKEN }}
+
   build-and-push:
     name: Build & Push Images
     runs-on: ubuntu-latest
-    needs: [ci-api, ci-ui, semgrep]
+    needs: [ci-api, ci-ui, semgrep, lighthouse]
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
     permissions:
       contents: read

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -56,6 +56,20 @@ services:
     command: npm run dev
     restart: unless-stopped
 
+  lhci-server:
+    image: patrickhulce/lhci-server
+    container_name: frollz-lhci
+    ports:
+      - "${LHCI_PORT:-9001}:9001"
+    environment:
+      - LHCI_STORAGE__SQL_DIALECT=sqlite
+      - LHCI_STORAGE__SQL_DATABASE_PATH=/data/lhci.db
+    volumes:
+      - lhci_data:/data
+    networks:
+      - frollz-network
+    restart: unless-stopped
+
   postgres:
     image: postgres:18-alpine
     container_name: frollz-postgres
@@ -73,6 +87,7 @@ services:
 
 volumes:
   postgres_data:
+  lhci_data:
 
 networks:
   frollz-network:

--- a/docs/accessibility-baseline.md
+++ b/docs/accessibility-baseline.md
@@ -14,39 +14,64 @@
 | `eslint-plugin-vuejs-accessibility` | `npm run lint` in `frollz-ui` | Added in #189; enforces rules at lint time |
 | `axe-core` (WCAG 2.1 AA ruleset) | `npm run test` in `frollz-ui` | Added in #190; runs against NavBar, TypeaheadInput, SpeedTypeaheadInput, RollsView (empty state) |
 | Manual code review | Source files read directly | All five views + shared components inspected for structural, semantic, and interaction issues |
-| Lighthouse | **Requires a live running instance** | See [Lighthouse instructions](#lighthouse-instructions) below |
+| Lighthouse CI | GitHub Actions `lighthouse` job — runs on every PR | Added in #191; audits `/`, `/rolls`, `/stocks` against WCAG 2.1 AA thresholds |
 
 ---
 
-## Lighthouse Instructions
+## Lighthouse CI
 
-Lighthouse requires a running application. To record baseline scores:
+Lighthouse CI runs automatically on every PR via GitHub Actions (`lighthouse` job in `ci-cd.yml`). It builds the UI, serves it statically, and audits three key routes.
+
+**Score thresholds (configured in `lighthouserc.js`):**
+
+| Category | Minimum |
+|---|---|
+| Accessibility | 90 |
+| Best Practices | 90 |
+| Performance | 80 (mobile) |
+
+CI will report failures until the v0.2.0 accessibility issues (#199–#206) are resolved. This is intentional — the gate enforces that work is complete before scores pass.
+
+### Self-hosted LHCI Dashboard
+
+The LHCI server is included in the dev stack (`docker-compose.dev.yml`) and stores historical scores:
 
 ```bash
-# 1. Start the dev stack
-docker compose -f docker-compose.dev.yml up -d
-
-# 2. Run Lighthouse CLI against each route
-npx lighthouse http://localhost:5173/           --output json --output-path lighthouse-dashboard.json
-npx lighthouse http://localhost:5173/rolls      --output json --output-path lighthouse-rolls.json
-npx lighthouse http://localhost:5173/stocks     --output json --output-path lighthouse-stocks.json
-npx lighthouse http://localhost:5173/formats    --output json --output-path lighthouse-formats.json
-npx lighthouse http://localhost:5173/tags       --output json --output-path lighthouse-tags.json
+docker compose -f docker-compose.dev.yml up -d lhci-server
+# Dashboard: http://localhost:9001
 ```
 
-**Expected pre-fix score range:** 60–70 / 100 on all routes.
-Primary score drivers: missing form labels (−20 to −30), missing modal ARIA roles (−10), and heading hierarchy issues (−5).
+To connect CI to your running dashboard, add these GitHub repository secrets:
 
-Update this table after running:
+| Secret | Description |
+|---|---|
+| `LHCI_SERVER_BASE_URL` | Public URL of your LHCI server (e.g. `https://lhci.example.com`) |
+| `LHCI_TOKEN` | Build token — generate with `lhci wizard` |
+
+```bash
+# One-time setup: generate project + token
+npx @lhci/cli wizard --serverBaseUrl http://localhost:9001
+```
+
+Without these secrets CI still collects, asserts, and uploads to temporary public storage.
+
+### Manual Run
+
+```bash
+cd frollz-ui && npm run build && cd ..
+npx @lhci/cli autorun
+```
+
+**Expected pre-fix score range:** 60–70 / 100 on accessibility.
+Primary drivers: missing form labels (−20 to −30), missing modal ARIA roles (−10).
+
+Update this table after first successful CI run:
 
 | Route | Lighthouse A11y Score | Date |
 |---|---|---|
 | `/` (Dashboard) | TBD | — |
 | `/rolls` | TBD | — |
-| `/rolls/:key` | TBD | — |
 | `/stocks` | TBD | — |
-| `/formats` | TBD | — |
-| `/tags` | TBD | — |
 
 ---
 

--- a/docs/accessibility-baseline.md
+++ b/docs/accessibility-baseline.md
@@ -60,6 +60,7 @@ Without these secrets CI still collects, asserts, and uploads to temporary publi
 ```bash
 cd frollz-ui && npm run build && cd ..
 npx @lhci/cli autorun
+# Requires serve: npm install -g serve  (or npx serve is used automatically)
 ```
 
 **Expected pre-fix score range:** 60–70 / 100 on accessibility.

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -1,0 +1,35 @@
+/** @type {import('@lhci/cli').LighthouseRcConfig} */
+module.exports = {
+  ci: {
+    collect: {
+      // LHCI's built-in static server serves index.html as SPA fallback for
+      // all unmatched paths, so Vue Router history-mode routes work correctly.
+      staticDistDir: './frollz-ui/dist',
+      url: [
+        'http://localhost/',          // Dashboard
+        'http://localhost/rolls',     // Roll list
+        'http://localhost/stocks',    // Stocks
+      ],
+      numberOfRuns: 1,
+    },
+    assert: {
+      assertions: {
+        // Target thresholds for v0.2.0 — will pass once #199-#206 are merged.
+        // Until then CI reports failures as expected signal that work remains.
+        'categories:accessibility': ['error', { minScore: 0.9 }],
+        'categories:best-practices': ['error', { minScore: 0.9 }],
+        'categories:performance': ['error', { minScore: 0.8 }],
+      },
+    },
+    upload: process.env.LHCI_SERVER_BASE_URL
+      ? {
+          target: 'lhci',
+          serverBaseUrl: process.env.LHCI_SERVER_BASE_URL,
+          token: process.env.LHCI_TOKEN,
+        }
+      : {
+          // No server configured — store results temporarily for inspection in CI logs
+          target: 'temporary-public-storage',
+        },
+  },
+}

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -2,13 +2,13 @@
 module.exports = {
   ci: {
     collect: {
-      // LHCI's built-in static server serves index.html as SPA fallback for
-      // all unmatched paths, so Vue Router history-mode routes work correctly.
-      staticDistDir: './frollz-ui/dist',
+      // `serve -s` (single-page app mode) serves index.html for all unmatched
+      // paths, so Vue Router history-mode routes return 200 instead of 404.
+      startServerCommand: 'npx serve -s ./frollz-ui/dist -l 3000',
       url: [
-        'http://localhost/',          // Dashboard
-        'http://localhost/rolls',     // Roll list
-        'http://localhost/stocks',    // Stocks
+        'http://localhost:3000/',          // Dashboard
+        'http://localhost:3000/rolls',     // Roll list
+        'http://localhost:3000/stocks',    // Stocks
       ],
       numberOfRuns: 1,
     },


### PR DESCRIPTION
## Summary

- Adds `lighthouserc.js` with WCAG 2.1 AA score thresholds (accessibility ≥90, best-practices ≥90, performance ≥80) auditing `/`, `/rolls`, and `/stocks`
- Adds `lighthouse` GitHub Actions job to `ci-cd.yml` — runs after `ci-ui`, builds the SPA, and runs `lhci autorun`; gated on `build-and-push`
- Adds self-hosted `lhci-server` service (SQLite-backed) to `docker-compose.dev.yml` with `lhci_data` volume
- Adds LHCI setup docs and expected pre-fix score range to `docs/accessibility-baseline.md`

CI thresholds are set at target values intentionally — failures are expected until the v0.2.0 accessibility issues (#199–#206) are resolved. The gate enforces that work is complete before scores pass.

## Test plan

- [ ] `lhci autorun` passes locally after `cd frollz-ui && npm run build`
- [ ] `lighthouse` CI job appears in Actions on this PR
- [ ] Optional: run `docker compose -f docker-compose.dev.yml up -d lhci-server` and verify dashboard at `http://localhost:9001`
- [ ] Optional: run `npx @lhci/cli wizard --serverBaseUrl http://localhost:9001` to generate token and test upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)