### PR TITLE
Bug/219 roll state history incorrect order

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -85,6 +85,25 @@ services:
       - frollz-network
     restart: unless-stopped
 
+  pgadmin:
+    image: dpage/pgadmin4
+    container_name: pgadmin
+    user: root
+    environment:
+      PGADMIN_DEFAULT_EMAIL: ${POSTGRES_USER}@localhost.com
+      PGADMIN_DEFAULT_PASSWORD: ${POSTGRES_PASSWORD}
+      PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED: "False"
+      PGADMIN_DISABLE_POSTFIX: "True"
+      PGADMIN_REPLACE_SERVERS_ON_STARTUP: "True"
+      PGADMIN_CONFIG_SERVER_MODE: "False"
+    ports:
+      - "8080:80" # Access pgAdmin in your browser at http://localhost:8080
+    networks:
+      - frollz-network
+    depends_on:
+      - postgres # Ensure PostgreSQL starts before pgAdmin
+    entrypoint: >
+      /bin/sh -c "echo \"$PGADMIN_PGPASS\" >> /root/.ogpass; chmod 600 /pgpass; echo '$PGADMIN_SERVER_JSON' >> /pgadmin4/servers.json; /entrypoint.sh"
 volumes:
   postgres_data:
   lhci_data:

--- a/docs/entity-relationship.md
+++ b/docs/entity-relationship.md
@@ -68,8 +68,6 @@ erDiagram
         text notes
         jsonb metadata
         boolean is_error_correction
-        timestamp created_at
-        timestamp updated_at
     }
 
     roll_tags {

--- a/frollz-api/migrations/20260319000000_remove_roll_state_dates.ts
+++ b/frollz-api/migrations/20260319000000_remove_roll_state_dates.ts
@@ -1,0 +1,41 @@
+import type { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  // set date = created_at for all existing roll states
+  await knex("roll_states").update({
+    date: knex.ref("created_at"),
+  });
+
+  // make date default to now and remove created_at and updated_at
+  await knex.schema.alterTable("roll_states", (table) => {
+    table
+      .timestamp("date", { useTz: true })
+      .notNullable()
+      .defaultTo(knex.fn.now())
+      .alter();
+    table.dropColumn("created_at");
+    table.dropColumn("updated_at");
+  });
+}
+
+export async function down(knex: Knex): Promise<void> {
+  // add created_at and updated_at columns back
+  await knex.schema.alterTable("roll_states", (table) => {
+    table
+      .timestamp("created_at", { useTz: true })
+      .notNullable()
+      .defaultTo(knex.fn.now());
+    table.timestamp("updated_at", { useTz: true });
+  });
+
+  // set created_at = date for all existing roll states
+  await knex("roll_states").update({
+    created_at: knex.ref("date"),
+    updated_at: knex.ref("date"),
+  });
+
+  // remove default from date and make it nullable
+  await knex.schema.alterTable("roll_states", (table) => {
+    table.timestamp("date", { useTz: true }).notNullable().alter();
+  });
+}

--- a/frollz-api/src/roll-state/roll-state.service.ts
+++ b/frollz-api/src/roll-state/roll-state.service.ts
@@ -34,19 +34,16 @@ export class RollStateService {
     const date = dto.date ?? now;
 
     await this.databaseService.execute(
-      `INSERT INTO roll_states (id, state_id, roll_id, state, date, notes, metadata, is_error_correction, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO roll_states (id, state_id, roll_id, state, notes, metadata, is_error_correction)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
       [
         id,
         stateId,
         dto.rollKey,
         dto.state,
-        date,
         dto.notes ?? null,
         dto.metadata != null ? JSON.stringify(dto.metadata) : null,
         dto.isErrorCorrection ?? false,
-        now,
-        now,
       ],
     );
 
@@ -59,14 +56,12 @@ export class RollStateService {
       notes: dto.notes,
       metadata: dto.metadata,
       isErrorCorrection: dto.isErrorCorrection ?? false,
-      createdAt: now,
-      updatedAt: now,
     };
   }
 
   async findByRollKey(rollKey: string): Promise<RollStateHistory[]> {
     const rows = await this.databaseService.query(
-      `SELECT * FROM roll_states WHERE roll_id = ? ORDER BY date ASC`,
+      `SELECT * FROM roll_states WHERE roll_id = ? ORDER BY date DESC`,
       [rollKey],
     );
     return rows.map(mapRollState);

--- a/frollz-api/src/roll/roll.service.spec.ts
+++ b/frollz-api/src/roll/roll.service.spec.ts
@@ -169,8 +169,6 @@ describe("RollService", () => {
       times_exposed_to_xrays: 0,
       loaded_into: null,
       transition_profile: "standard",
-      created_at: new Date().toISOString(),
-      updated_at: new Date().toISOString(),
     };
 
     beforeEach(() => {

--- a/frollz-api/src/roll/roll.service.ts
+++ b/frollz-api/src/roll/roll.service.ts
@@ -18,7 +18,6 @@ const ROLLS_WITH_CHILD_COUNT_QUERY = `
   LEFT JOIN film_formats f ON s.format_key = f.id
 `;
 
-
 function mapRoll(row: Record<string, unknown>): Roll {
   return {
     _key: row.id as string,


### PR DESCRIPTION
## What does this PR do?

This PR Fixes #219 by having the DB always insert the roll state time and eliminate accepting those dates from the API

## How was it tested?

Ran regression suite, tested listing, verified with UI


## Checklist

- [x] Tests added or updated
- [x] All tests pass (`npm test` in `frollz-api/` and `frollz-ui/`)
- [x] Lint passes (`npm run lint` in both)
- [x] No `console.log` left in committed code
- [x] PR targets the `development` branch (not `main`)
