### PR TITLE
feat(ui): dashboard — responsive widget grid with skeleton loading and empty/error states (#198)

### DIFF
--- a/frollz-ui/src/components/StatCard.vue
+++ b/frollz-ui/src/components/StatCard.vue
@@ -1,0 +1,14 @@
+<template>
+  <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md">
+    <h2 class="text-lg font-semibold text-gray-700 dark:text-gray-300 mb-2">{{ label }}</h2>
+    <p class="text-3xl font-bold" :class="colorClass">{{ value }}</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  label: string
+  value: number
+  colorClass: string
+}>()
+</script>

--- a/frollz-ui/src/views/Dashboard.vue
+++ b/frollz-ui/src/views/Dashboard.vue
@@ -2,32 +2,59 @@
   <div>
     <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-8">Dashboard</h1>
 
-    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
-      <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md">
-        <h2 class="text-lg font-semibold text-gray-700 dark:text-gray-300 mb-2">Total Rolls</h2>
-        <p class="text-3xl font-bold text-primary-600 dark:text-primary-400">{{ stats.totalRolls }}</p>
-      </div>
-
-      <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md">
-        <h2 class="text-lg font-semibold text-gray-700 dark:text-gray-300 mb-2">Available Stocks</h2>
-        <p class="text-3xl font-bold text-green-600 dark:text-green-400">{{ stats.totalStocks }}</p>
-      </div>
-
-      <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md">
-        <h2 class="text-lg font-semibold text-gray-700 dark:text-gray-300 mb-2">Currently Loaded</h2>
-        <p class="text-3xl font-bold text-yellow-600 dark:text-yellow-400">{{ stats.loadedRolls }}</p>
-      </div>
-
-      <div class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md">
-        <h2 class="text-lg font-semibold text-gray-700 dark:text-gray-300 mb-2">Developed</h2>
-        <p class="text-3xl font-bold text-blue-600 dark:text-blue-400">{{ stats.developedRolls }}</p>
-      </div>
-    </div>
+    <!-- Stat cards -->
+    <section
+      aria-label="Dashboard statistics"
+      :aria-busy="loading"
+      class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8"
+    >
+      <template v-if="loading">
+        <div v-for="n in 4" :key="n" class="bg-white dark:bg-gray-800 p-6 rounded-lg shadow-md animate-pulse">
+          <div class="h-5 bg-gray-200 dark:bg-gray-700 rounded w-3/4 mb-3"></div>
+          <div class="h-9 bg-gray-200 dark:bg-gray-700 rounded w-1/2"></div>
+        </div>
+      </template>
+      <template v-else>
+        <StatCard label="Total Rolls" :value="stats.totalRolls" colorClass="text-primary-600 dark:text-primary-400" />
+        <StatCard label="Available Stocks" :value="stats.totalStocks" colorClass="text-green-600 dark:text-green-400" />
+        <StatCard label="Currently Loaded" :value="stats.loadedRolls" colorClass="text-yellow-600 dark:text-yellow-400" />
+        <StatCard label="Developed" :value="stats.developedRolls" colorClass="text-blue-600 dark:text-blue-400" />
+      </template>
+    </section>
 
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
-      <div class="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6">
+      <div class="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6" :aria-busy="loading">
         <h2 class="text-xl font-semibold text-gray-800 dark:text-gray-200 mb-4">Recent Rolls</h2>
-        <div class="space-y-4">
+
+        <!-- Skeleton -->
+        <div v-if="loading" class="space-y-4" aria-hidden="true">
+          <div v-for="n in 5" :key="n" class="animate-pulse flex justify-between items-center py-2 border-b border-gray-100 dark:border-gray-700 last:border-b-0">
+            <div class="space-y-2">
+              <div class="h-4 bg-gray-200 dark:bg-gray-700 rounded w-24"></div>
+              <div class="h-3 bg-gray-200 dark:bg-gray-700 rounded w-16"></div>
+            </div>
+            <div class="h-5 bg-gray-200 dark:bg-gray-700 rounded-full w-20"></div>
+          </div>
+        </div>
+
+        <!-- Error state -->
+        <p v-else-if="hasError" class="py-4 text-sm text-red-600 dark:text-red-400">
+          Could not load dashboard data. Please refresh to try again.
+        </p>
+
+        <!-- Empty state -->
+        <div v-else-if="recentRolls.length === 0" class="py-8 text-center">
+          <p class="text-gray-500 dark:text-gray-400 mb-4">No rolls yet.</p>
+          <RouterLink
+            to="/rolls?action=create"
+            class="inline-block bg-primary-600 text-white px-4 py-2 rounded-md hover:bg-primary-700 font-medium text-sm"
+          >
+            Add your first roll
+          </RouterLink>
+        </div>
+
+        <!-- Roll list -->
+        <div v-else class="space-y-4">
           <div v-for="roll in recentRolls" :key="roll._key" class="flex justify-between items-center py-2 border-b border-gray-100 dark:border-gray-700 last:border-b-0">
             <div>
               <p class="font-medium">{{ roll.rollId }}</p>
@@ -71,7 +98,12 @@
 import { ref, onMounted } from 'vue'
 import { RouterLink } from 'vue-router'
 import { rollApi, stockApi } from '@/services/api-client'
+import { RollState } from '@/types'
 import type { Roll } from '@/types'
+import StatCard from '@/components/StatCard.vue'
+
+const loading = ref(true)
+const hasError = ref(false)
 
 const stats = ref({
   totalRolls: 0,
@@ -96,15 +128,19 @@ const loadStats = async () => {
     const rolls = rollsResponse.data
     stats.value.totalRolls = rolls.length
     stats.value.totalStocks = stocksResponse.data.length
-    stats.value.loadedRolls = rolls.filter(r => r.state === 'Loaded').length
-    stats.value.developedRolls = rolls.filter(r => r.state === 'Developed').length
+    stats.value.loadedRolls = rolls.filter(r => r.state === RollState.LOADED).length
+    stats.value.developedRolls = rolls.filter(
+      r => r.state === RollState.DEVELOPED || r.state === RollState.RECEIVED
+    ).length
 
-    // Get recent rolls (last 5)
-    recentRolls.value = rolls
+    recentRolls.value = [...rolls]
       .sort((a, b) => new Date(b.dateObtained).getTime() - new Date(a.dateObtained).getTime())
       .slice(0, 5)
   } catch (error) {
     console.error('Error loading dashboard stats:', error)
+    hasError.value = true
+  } finally {
+    loading.value = false
   }
 }
 


### PR DESCRIPTION
## Summary

- Extracts a reusable `StatCard` component, eliminating four copy-pasted card blocks
- Adds `animate-pulse` skeleton loaders for the stat grid and recent rolls list while data loads
- Adds `aria-busy` on the stat `<section>` and recent rolls panel during loading (a11y)
- Separates error state from empty state — API failure no longer falsely triggers the "Add your first roll" CTA
- Adds minimal empty state with CTA when the rolls list is confirmed empty
- Fixes stat filters to use `RollState` enum values instead of hardcoded strings
- Includes `RollState.RECEIVED` in the "Developed" count (rolls back from the lab are developed)
- Avoids mutating the API response array during sort (`[...rolls].sort()`)

Closes #198

## Test plan
- [x] Load the dashboard with rolls in the database — stat cards and recent rolls render correctly after skeleton fades
- [x] Verify "Developed" count includes rolls in both `Developed` and `Received` states
- [x] Load at 375px viewport width — all four stat cards stack full-width, panels stack vertically
- [x] Load with an empty database — "No rolls yet. Add your first roll" CTA appears
- [x] Simulate API failure (e.g. disable network in DevTools) — error message appears, no false empty state CTA

🤖 Generated with [Claude Code](https://claude.com/claude-code)