### PR TITLE
feat(ui): mobile-friendly form inputs — 16px font size and full-width layout (#200)

### DIFF
--- a/frollz-ui/src/views/RollDetailView.vue
+++ b/frollz-ui/src/views/RollDetailView.vue
@@ -100,7 +100,7 @@
               <p class="text-sm font-medium text-blue-800 dark:text-blue-200 mb-3">{{ pendingMetadataTransition }} details</p>
               <label v-if="requiresDateCapture(pendingMetadataTransition!)" for="meta-date" class="block text-xs text-gray-600 dark:text-gray-400 mb-2">
                 Date <span class="text-red-500" aria-hidden="true">*</span>
-                <input id="meta-date" v-model="metadataDate" type="date" required aria-required="true" class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100" />
+                <input id="meta-date" v-model="metadataDate" type="date" required aria-required="true" class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-base sm:text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100" />
               </label>
               <label v-if="pendingMetadataTransition === RollState.FROZEN || pendingMetadataTransition === RollState.REFRIGERATED || pendingMetadataTransition === RollState.SHELVED" for="meta-temperature" class="block text-xs text-gray-600 dark:text-gray-400">
                 Storage temperature ({{ temperatureUnit }}) — optional
@@ -108,7 +108,7 @@
                   id="meta-temperature"
                   v-model="metadataTemperature"
                   type="number"
-                  class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+                  class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-base sm:text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
                 />
               </label>
               <label v-if="pendingMetadataTransition === RollState.FINISHED" for="meta-shot-iso" class="block text-xs text-gray-600 dark:text-gray-400">
@@ -118,7 +118,7 @@
                   v-model="metadataShotISO"
                   type="number"
                   placeholder="e.g. 400"
-                  class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+                  class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-base sm:text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
                 />
               </label>
               <div v-if="pendingMetadataTransition === RollState.SENT_FOR_DEVELOPMENT" class="space-y-2">
@@ -131,7 +131,7 @@
                     required
                     aria-required="true"
                     placeholder="e.g. The Darkroom"
-                    class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+                    class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-base sm:text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
                   />
                 </label>
                 <label for="meta-delivery-method" class="block text-xs text-gray-600 dark:text-gray-400">
@@ -141,7 +141,7 @@
                     v-model="metadataDeliveryMethod"
                     required
                     aria-required="true"
-                    class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+                    class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-base sm:text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
                   >
                     <option value="">Select…</option>
                     <option v-for="m in DELIVERY_METHODS" :key="m" :value="m">{{ m }}</option>
@@ -154,7 +154,7 @@
                     v-model="metadataProcessRequested"
                     required
                     aria-required="true"
-                    class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+                    class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-base sm:text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
                   >
                     <option value="">Select…</option>
                     <option v-for="p in PROCESSES_REQUESTED" :key="p" :value="p">{{ p }}</option>
@@ -167,7 +167,7 @@
                     v-model="metadataPushPullStops"
                     type="number"
                     placeholder="+2 push, -1 pull"
-                    class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+                    class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-base sm:text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
                   />
                 </label>
               </div>
@@ -180,11 +180,11 @@
                 <div v-if="metadataScansReceived" class="pl-5 space-y-2">
                   <label for="meta-scans-date" class="block text-xs text-gray-600 dark:text-gray-400">
                     Scans date
-                    <input id="meta-scans-date" v-model="metadataScansDate" type="date" class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100" />
+                    <input id="meta-scans-date" v-model="metadataScansDate" type="date" class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-base sm:text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100" />
                   </label>
                   <label for="meta-scans-url" class="block text-xs text-gray-600 dark:text-gray-400">
                     Scans URL — optional
-                    <input id="meta-scans-url" v-model="metadataScansUrl" type="url" placeholder="https://…" class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100" />
+                    <input id="meta-scans-url" v-model="metadataScansUrl" type="url" placeholder="https://…" class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-base sm:text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100" />
                   </label>
                 </div>
                 <label for="meta-negatives-received" class="flex items-center gap-2 text-xs text-gray-600 dark:text-gray-400 cursor-pointer">
@@ -194,7 +194,7 @@
                 <div v-if="metadataNegativesReceived" class="pl-5">
                   <label for="meta-negatives-date" class="block text-xs text-gray-600 dark:text-gray-400">
                     Negatives date
-                    <input id="meta-negatives-date" v-model="metadataNegativesDate" type="date" class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100" />
+                    <input id="meta-negatives-date" v-model="metadataNegativesDate" type="date" class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-base sm:text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100" />
                   </label>
                 </div>
               </div>
@@ -238,7 +238,7 @@
                 rows="2"
                 aria-label="Transition notes (optional)"
                 placeholder="Notes for this transition (optional)..."
-                class="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
+                class="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-base sm:text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
               ></textarea>
             </div>
             <div v-if="transitionError" role="alert" class="text-sm text-red-600 dark:text-red-400">{{ transitionError }}</div>

--- a/frollz-ui/src/views/RollsView.vue
+++ b/frollz-ui/src/views/RollsView.vue
@@ -161,7 +161,7 @@
                 <select
                   id="roll-parent"
                   v-model="form.parentRollId"
-                  class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+                  class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-base sm:text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
                   @change="onParentRollChange"
                 >
                   <option value="">None — standalone roll</option>
@@ -180,7 +180,7 @@
                   v-model="form.stockKey"
                   :required="!form.parentRollId"
                   aria-required="true"
-                  class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+                  class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-base sm:text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
                 >
                   <option value="" disabled>Select a stock</option>
                   <option v-for="stock in sortedStocks" :key="stock._key" :value="stock._key">
@@ -199,7 +199,7 @@
                   v-model="form.state"
                   required
                   aria-required="true"
-                  class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+                  class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-base sm:text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
                 >
                   <option v-for="s in rollStateOptions" :key="s" :value="s">{{ s }}</option>
                 </select>
@@ -213,7 +213,7 @@
                   type="date"
                   required
                   aria-required="true"
-                  class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+                  class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-base sm:text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
                 />
               </label>
             </div>
@@ -226,7 +226,7 @@
                     v-model="form.obtainmentMethod"
                     required
                     aria-required="true"
-                    class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+                    class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-base sm:text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
                   >
                     <option v-for="m in obtainmentMethodOptions" :key="m" :value="m">{{ m }}</option>
                   </select>
@@ -241,7 +241,7 @@
                     required
                     aria-required="true"
                     placeholder="e.g. B&H Photo"
-                    class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
+                    class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-base sm:text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
                   />
                 </label>
               </div>
@@ -251,7 +251,7 @@
                     id="roll-expiration-date"
                     v-model="form.expirationDate"
                     type="date"
-                    class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+                    class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-base sm:text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
                   />
                 </label>
               </div>
@@ -268,7 +268,7 @@
                   v-model.number="form.timesExposedToXrays"
                   type="number"
                   min="0"
-                  class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+                  class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-base sm:text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
                 />
               </label>
             </div>

--- a/frollz-ui/src/views/StocksView.vue
+++ b/frollz-ui/src/views/StocksView.vue
@@ -167,7 +167,7 @@
                 :fetchOptions="(q) => stockApi.getBrands(q).then(r => r.data)"
                 required
                 placeholder="e.g. Portra 400"
-                class="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
+                class="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-base sm:text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
               />
             </div>
             <div>
@@ -180,7 +180,7 @@
                 :fetchOptions="(q) => stockApi.getManufacturers(q).then(r => r.data)"
                 required
                 placeholder="e.g. Kodak"
-                class="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
+                class="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-base sm:text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
               />
             </div>
             <div>
@@ -190,7 +190,7 @@
                   v-model="form.process"
                   required
                   aria-required="true"
-                  class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+                  class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-base sm:text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
                 >
                   <option value="" disabled>Select a process</option>
                   <option v-for="p in processOptions" :key="p" :value="p">{{ p }}</option>
@@ -230,7 +230,7 @@
                 required
                 min="1"
                 placeholder="e.g. 400"
-                class="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
+                class="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-base sm:text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
               />
             </div>
             <div>
@@ -257,7 +257,7 @@
                     v-model="form.boxImageUrl"
                     type="url"
                     placeholder="https://..."
-                    class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
+                    class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-base sm:text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
                   />
               </label>
             </div>

--- a/frollz-ui/src/views/TagsView.vue
+++ b/frollz-ui/src/views/TagsView.vue
@@ -52,7 +52,7 @@
                 v-model="editForm.value"
                 type="text"
                 aria-label="Value"
-                class="flex-1 border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+                class="flex-1 border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-base sm:text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
               />
             </div>
             <div class="flex gap-6 text-sm">
@@ -118,7 +118,7 @@
                     v-model="editForm.value"
                     type="text"
                     aria-label="Value"
-                    class="border border-gray-300 dark:border-gray-600 rounded-md px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+                    class="w-full border border-gray-300 dark:border-gray-600 rounded-md px-2 py-1 text-base sm:text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
                   />
                 </template>
                 <template v-else>


### PR DESCRIPTION
## Summary

- Replaces `text-sm` (14px) with `text-base sm:text-sm` on all form inputs across `RollsView`, `StocksView`, `RollDetailView`, and `TagsView` — prevents iOS auto-zoom on focus (WCAG 1.4.4)
- Adds `w-full` to the `TagsView` desktop inline edit input so it fills its table cell

## Test plan

- [x] Open the Add Roll modal on a 375px viewport — inputs should be 16px, no auto-zoom on focus
- [x] Open the Add Stock modal on mobile — same check
- [x] Trigger a state transition on a roll detail page — metadata form inputs should be 16px on mobile
- [x] Open the Tags page, edit a tag on desktop — value input should fill the table cell
- [x] Verify desktop appearance is unchanged (inputs remain compact at `sm:text-sm`)

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)