### PR TITLE
feat(a11y): loading states, async feedback, and live regions (#203)

### DIFF
--- a/frollz-ui/src/App.vue
+++ b/frollz-ui/src/App.vue
@@ -1,15 +1,17 @@
 <template>
   <div id="app" class="min-h-screen bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
     <NavBar />
-    <main class="max-w-screen-xl mx-auto page-x py-8">
+    <main id="main-content" tabindex="-1" class="max-w-screen-xl mx-auto page-x py-8 focus:outline-none">
       <RouterView />
     </main>
+    <AppAnnouncer />
   </div>
 </template>
 
 <script setup lang="ts">
 import { RouterView } from 'vue-router'
 import NavBar from '@/components/NavBar.vue'
+import AppAnnouncer from '@/components/AppAnnouncer.vue'
 import { useThemeStore } from '@/stores/theme'
 
 useThemeStore()

--- a/frollz-ui/src/components/AppAnnouncer.vue
+++ b/frollz-ui/src/components/AppAnnouncer.vue
@@ -1,0 +1,32 @@
+<template>
+  <!-- Always-present sr-only live regions — screen readers listen here for announcements -->
+  <div role="status" aria-live="polite" aria-atomic="true" class="sr-only">{{ politeMessage }}</div>
+  <div role="alert" aria-live="assertive" aria-atomic="true" class="sr-only">{{ assertiveMessage }}</div>
+
+  <!-- Visual toast (aria-hidden because the live regions above handle AT) -->
+  <Transition
+    enter-active-class="transition duration-200 ease-out"
+    enter-from-class="translate-y-2 opacity-0"
+    leave-active-class="transition duration-150 ease-in"
+    leave-to-class="translate-y-2 opacity-0"
+  >
+    <div
+      v-if="store.message"
+      aria-hidden="true"
+      class="fixed bottom-4 right-4 z-[60] px-4 py-3 rounded-lg shadow-lg text-sm font-medium text-white"
+      :class="store.type === 'success' ? 'bg-green-600 dark:bg-green-700' : 'bg-red-600 dark:bg-red-700'"
+    >
+      {{ store.message }}
+    </div>
+  </Transition>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useNotificationStore } from '@/stores/notification'
+
+const store = useNotificationStore()
+
+const politeMessage = computed(() => (store.type === 'success' ? store.message : ''))
+const assertiveMessage = computed(() => (store.type === 'error' ? store.message : ''))
+</script>

--- a/frollz-ui/src/router/index.ts
+++ b/frollz-ui/src/router/index.ts
@@ -1,4 +1,5 @@
 import { createRouter, createWebHistory } from 'vue-router'
+import { nextTick } from 'vue'
 import Dashboard from '@/views/Dashboard.vue'
 import StocksView from '@/views/StocksView.vue'
 import RollsView from '@/views/RollsView.vue'
@@ -40,6 +41,13 @@ const router = createRouter({
       component: TagsView
     }
   ]
+})
+
+// Move focus to <main> after each navigation so screen reader users land at the top of new content
+router.afterEach(() => {
+  nextTick(() => {
+    document.getElementById('main-content')?.focus()
+  })
 })
 
 export default router

--- a/frollz-ui/src/stores/notification.ts
+++ b/frollz-ui/src/stores/notification.ts
@@ -1,0 +1,26 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+export const useNotificationStore = defineStore('notification', () => {
+  const message = ref('')
+  const type = ref<'success' | 'error'>('success')
+  let timer: ReturnType<typeof setTimeout> | null = null
+
+  const announce = (msg: string, msgType: 'success' | 'error' = 'success', duration = 4000) => {
+    if (timer) clearTimeout(timer)
+    // Clear first so the same message can be re-announced
+    message.value = ''
+    // rAF ensures the DOM registers the empty state before the new message
+    requestAnimationFrame(() => {
+      message.value = msg
+      type.value = msgType
+      if (duration > 0) {
+        timer = setTimeout(() => {
+          message.value = ''
+        }, duration)
+      }
+    })
+  }
+
+  return { message, type, announce }
+})

--- a/frollz-ui/src/views/FilmFormatsView.vue
+++ b/frollz-ui/src/views/FilmFormatsView.vue
@@ -11,7 +11,7 @@
     </div>
 
     <!-- Mobile card list (hidden on md+) -->
-    <div class="md:hidden space-y-3">
+    <div class="md:hidden space-y-3" :aria-busy="isLoading" aria-label="Film formats list">
       <p v-if="filmFormats.length === 0" class="text-center py-8 text-gray-400 dark:text-gray-500 italic">No formats found.</p>
       <div
         v-for="format in filmFormats"
@@ -33,7 +33,7 @@
     </div>
 
     <!-- Desktop table (hidden below md) -->
-    <div class="hidden md:block bg-white dark:bg-gray-800 rounded-lg shadow-md">
+    <div class="hidden md:block bg-white dark:bg-gray-800 rounded-lg shadow-md" :aria-busy="isLoading" aria-label="Film formats table">
       <div class="overflow-x-auto">
         <table class="min-w-full">
           <thead class="bg-gray-50 dark:bg-gray-700">
@@ -135,8 +135,12 @@ import { ref, onMounted } from 'vue'
 import { filmFormatApi } from '@/services/api-client'
 import type { FilmFormat, FormFactor, Format } from '@/types'
 import BaseModal from '@/components/BaseModal.vue'
+import { useNotificationStore } from '@/stores/notification'
+
+const notification = useNotificationStore()
 
 const filmFormats = ref<FilmFormat[]>([])
+const isLoading = ref(false)
 const showCreateForm = ref(false)
 const createError = ref('')
 const newFormat = ref({
@@ -149,11 +153,14 @@ const formatDate = (date?: Date) => {
 }
 
 const loadFormats = async () => {
+  isLoading.value = true
   try {
     const response = await filmFormatApi.getAll()
     filmFormats.value = response.data
   } catch (error) {
     console.error('Error loading film formats:', error)
+  } finally {
+    isLoading.value = false
   }
 }
 
@@ -164,6 +171,7 @@ const createFormat = async () => {
     showCreateForm.value = false
     newFormat.value = { formFactor: '' as FormFactor, format: '' as Format }
     await loadFormats()
+    notification.announce('Film format added')
   } catch (error) {
     console.error('Error creating film format:', error)
     createError.value = 'Failed to create film format. Please try again.'

--- a/frollz-ui/src/views/RollDetailView.vue
+++ b/frollz-ui/src/views/RollDetailView.vue
@@ -7,7 +7,7 @@
       >← Back to Rolls</button>
     </div>
 
-    <div v-if="loading" class="text-center py-12 text-gray-400 dark:text-gray-500">Loading...</div>
+    <div v-if="loading" role="status" aria-label="Loading roll detail" class="text-center py-12 text-gray-400 dark:text-gray-500">Loading...</div>
 
     <div v-else-if="!roll" class="text-center py-12 text-gray-400 dark:text-gray-500">Roll not found.</div>
 
@@ -340,9 +340,11 @@ import { useRoute, useRouter } from 'vue-router'
 import { rollApi, rollStateApi, rollTagApi, tagApi, transitionApi } from '@/services/api-client'
 import type { Roll, RollStateHistory, Tag, RollTag, TransitionGraph } from '@/types'
 import { RollState } from '@/types'
+import { useNotificationStore } from '@/stores/notification'
 
 const route = useRoute()
 const router = useRouter()
+const notification = useNotificationStore()
 
 const roll = ref<Roll | null>(null)
 const parentRoll = ref<Roll | null>(null)
@@ -546,6 +548,7 @@ const executeTransition = async (targetState: RollState, isErrorCorrection?: boo
     await rollApi.transition(roll.value._key!, targetState, date, transitionNotes.value || undefined, isErrorCorrection, metadata)
     transitionNotes.value = ''
     await loadData()
+    notification.announce(`Roll moved to ${targetState}`)
   } catch {
     transitionError.value = 'Failed to transition roll. Please try again.'
   } finally {

--- a/frollz-ui/src/views/RollsView.vue
+++ b/frollz-ui/src/views/RollsView.vue
@@ -28,7 +28,7 @@
     </div>
 
     <!-- Mobile card list (hidden on md+) -->
-    <div class="md:hidden space-y-3">
+    <div class="md:hidden space-y-3" :aria-busy="isLoading" aria-label="Rolls list">
       <p v-if="filteredRolls.length === 0" class="text-center py-8 text-gray-400 dark:text-gray-500 italic">No rolls found.</p>
       <RouterLink
         v-for="roll in filteredRolls"
@@ -52,7 +52,7 @@
     </div>
 
     <!-- Desktop table (hidden below md) -->
-    <div class="hidden md:block bg-white dark:bg-gray-800 rounded-lg shadow-md">
+    <div class="hidden md:block bg-white dark:bg-gray-800 rounded-lg shadow-md" :aria-busy="isLoading" aria-label="Rolls table">
       <div class="overflow-x-auto">
         <table class="min-w-full">
           <thead class="bg-gray-50 dark:bg-gray-700">
@@ -301,6 +301,7 @@ const router = useRouter()
 
 const rolls = ref<Roll[]>([])
 const stocks = ref<Stock[]>([])
+const isLoading = ref(false)
 const showModal = ref(false)
 
 type ActiveFilter = { field: string; label: string; value: string }
@@ -458,11 +459,14 @@ const handleSubmit = async () => {
 }
 
 const loadRolls = async () => {
+  isLoading.value = true
   try {
     const response = await rollApi.getAll()
     rolls.value = response.data
   } catch (err) {
     console.error('Error loading rolls:', err)
+  } finally {
+    isLoading.value = false
   }
 }
 

--- a/frollz-ui/src/views/StocksView.vue
+++ b/frollz-ui/src/views/StocksView.vue
@@ -28,7 +28,7 @@
     </div>
 
     <!-- Mobile card list (hidden on md+) -->
-    <div class="md:hidden space-y-3">
+    <div class="md:hidden space-y-3" :aria-busy="isLoading" aria-label="Stocks list">
       <p v-if="sortedStocks.length === 0" class="text-center py-8 text-gray-400 dark:text-gray-500 italic">No stocks found.</p>
       <div
         v-for="stock in sortedStocks"
@@ -62,7 +62,7 @@
     </div>
 
     <!-- Desktop table (hidden below md) -->
-    <div class="hidden md:block bg-white dark:bg-gray-800 rounded-lg shadow-md">
+    <div class="hidden md:block bg-white dark:bg-gray-800 rounded-lg shadow-md" :aria-busy="isLoading" aria-label="Stocks table">
       <div class="overflow-x-auto">
         <table class="min-w-full">
           <thead class="bg-gray-50 dark:bg-gray-700">
@@ -286,14 +286,17 @@ import { Process, FormFactor } from '@/types'
 import TypeaheadInput from '@/components/TypeaheadInput.vue'
 import BaseModal from '@/components/BaseModal.vue'
 import SpeedTypeaheadInput from '@/components/SpeedTypeaheadInput.vue'
+import { useNotificationStore } from '@/stores/notification'
 
 const router = useRouter()
+const notification = useNotificationStore()
 
 const stocks = ref<Stock[]>([])
 const formats = ref<FilmFormat[]>([])
 const allTags = ref<Tag[]>([])
 // Map from stockKey -> Tag[]
 const stockTagMap = ref<Record<string, Tag[]>>({})
+const isLoading = ref(false)
 const showModal = ref(false)
 const submitting = ref(false)
 const error = ref('')
@@ -441,6 +444,7 @@ const handleSubmit = async () => {
 
     await loadStocks()
     closeModal()
+    notification.announce('Stock added')
   } catch (_) {
     error.value = 'Failed to add stock. Please try again.'
   } finally {
@@ -470,12 +474,15 @@ const buildStockTagMap = async () => {
 }
 
 const loadStocks = async () => {
+  isLoading.value = true
   try {
     const response = await stockApi.getAll()
     stocks.value = response.data
     await buildStockTagMap()
   } catch (err) {
     console.error('Error loading stocks:', err)
+  } finally {
+    isLoading.value = false
   }
 }
 

--- a/frollz-ui/src/views/TagsView.vue
+++ b/frollz-ui/src/views/TagsView.vue
@@ -5,7 +5,7 @@
     </div>
 
     <!-- Mobile card list (hidden on md+) -->
-    <div class="md:hidden space-y-3">
+    <div class="md:hidden space-y-3" :aria-busy="isLoading" aria-label="Tags list">
       <p v-if="tags.length === 0" class="text-center py-8 text-gray-400 dark:text-gray-500 italic">No tags found.</p>
       <div
         v-for="tag in paginatedTags"
@@ -81,7 +81,7 @@
     </div>
 
     <!-- Desktop table (hidden below md) -->
-    <div class="hidden md:block bg-white dark:bg-gray-800 rounded-lg shadow-md">
+    <div class="hidden md:block bg-white dark:bg-gray-800 rounded-lg shadow-md" :aria-busy="isLoading" aria-label="Tags table">
       <div class="overflow-x-auto">
         <table class="min-w-full">
           <thead class="bg-gray-50 dark:bg-gray-700">
@@ -254,10 +254,14 @@ import { ref, computed, onMounted } from 'vue'
 import { tagApi, stockTagApi } from '@/services/api-client'
 import type { Tag } from '@/types'
 import BaseModal from '@/components/BaseModal.vue'
+import { useNotificationStore } from '@/stores/notification'
+
+const notification = useNotificationStore()
 
 const PAGE_SIZE = 10
 
 const tags = ref<Tag[]>([])
+const isLoading = ref(false)
 const currentPage = ref(1)
 
 const editingKey = ref<string | null>(null)
@@ -278,11 +282,14 @@ const paginatedTags = computed(() => {
 const formatDate = (date?: Date) => date ? new Date(date).toLocaleDateString() : '-'
 
 const loadTags = async () => {
+  isLoading.value = true
   try {
     const response = await tagApi.getAll()
     tags.value = response.data
   } catch (err) {
     console.error('Error loading tags:', err)
+  } finally {
+    isLoading.value = false
   }
 }
 
@@ -320,6 +327,7 @@ const saveEdit = async (key: string) => {
     })
     editingKey.value = null
     await loadTags()
+    notification.announce('Tag saved')
   } catch (err) {
     console.error('Error saving tag:', err)
   }
@@ -340,6 +348,7 @@ const confirmScopeChange = async () => {
     scopeChangeWarning.value = null
     editingKey.value = null
     await loadTags()
+    notification.announce('Tag saved')
   } catch (err) {
     console.error('Error saving tag with scope change:', err)
   }
@@ -369,6 +378,7 @@ const executeDelete = async () => {
     await tagApi.delete(tag._key!)
     deleteTarget.value = null
     await loadTags()
+    notification.announce('Tag deleted')
   } catch (err) {
     console.error('Error deleting tag:', err)
   }

--- a/frollz-ui/src/views/__tests__/FilmFormatsView.spec.ts
+++ b/frollz-ui/src/views/__tests__/FilmFormatsView.spec.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
 import { axe } from 'vitest-axe'
 import FilmFormatsView from '@/views/FilmFormatsView.vue'
 import { filmFormatApi } from '@/services/api-client'
@@ -25,6 +26,7 @@ describe('FilmFormatsView', () => {
   ]
 
   beforeEach(() => {
+    setActivePinia(createPinia())
     vi.clearAllMocks()
     vi.mocked(filmFormatApi.getAll).mockResolvedValue({ data: mockFormats } as any)
     vi.mocked(filmFormatApi.create).mockResolvedValue({ data: mockFormats[0] } as any)

--- a/frollz-ui/src/views/__tests__/RollDetailView.spec.ts
+++ b/frollz-ui/src/views/__tests__/RollDetailView.spec.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
 import { createRouter, createMemoryHistory } from 'vue-router'
 import { axe } from 'vitest-axe'
 import RollDetailView from '@/views/RollDetailView.vue'
@@ -139,6 +140,7 @@ const mountView = async (rollKey = 'r1') => {
 
 describe('RollDetailView', () => {
   beforeEach(() => {
+    setActivePinia(createPinia())
     vi.clearAllMocks()
     vi.mocked(rollApi.getById).mockResolvedValue({ data: makeRoll() } as any)
     vi.mocked(rollStateApi.getHistory).mockResolvedValue({ data: [] } as any)

--- a/frollz-ui/src/views/__tests__/RollsView.spec.ts
+++ b/frollz-ui/src/views/__tests__/RollsView.spec.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
 import { createRouter, createMemoryHistory } from 'vue-router'
 import { axe } from 'vitest-axe'
 import RollsView from '@/views/RollsView.vue'
@@ -43,6 +44,7 @@ const makeRoll = (key: string, state: RollState, overrides: Record<string, any> 
 
 describe('RollsView', () => {
   beforeEach(() => {
+    setActivePinia(createPinia())
     vi.clearAllMocks()
     vi.mocked(rollApi.getAll).mockResolvedValue({ data: [] } as any)
     vi.mocked(stockApi.getAll).mockResolvedValue({ data: [] } as any)

--- a/frollz-ui/src/views/__tests__/StocksView.spec.ts
+++ b/frollz-ui/src/views/__tests__/StocksView.spec.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
 import { axe } from 'vitest-axe'
 import StocksView from '@/views/StocksView.vue'
 import { stockApi, filmFormatApi, tagApi, stockTagApi } from '@/services/api-client'
@@ -51,6 +52,7 @@ describe('StocksView', () => {
   ]
 
   beforeEach(() => {
+    setActivePinia(createPinia())
     vi.clearAllMocks()
 
     // Setup default mock returns

--- a/frollz-ui/src/views/__tests__/TagsView.spec.ts
+++ b/frollz-ui/src/views/__tests__/TagsView.spec.ts
@@ -1,6 +1,7 @@
 // @vitest-environment jsdom
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
 import { axe } from 'vitest-axe'
 import TagsView from '@/views/TagsView.vue'
 import { tagApi, stockTagApi } from '@/services/api-client'
@@ -29,6 +30,7 @@ describe('TagsView', () => {
   ]
 
   beforeEach(() => {
+    setActivePinia(createPinia())
     vi.clearAllMocks()
     vi.mocked(tagApi.getAll).mockResolvedValue({ data: mockTags } as any)
     vi.mocked(stockTagApi.getAll).mockResolvedValue({ data: [] } as any)


### PR DESCRIPTION
## Summary

- Add `stores/notification.ts` (Pinia) — `announce(msg, type)` for polite/assertive AT announcements
- Add `components/AppAnnouncer.vue` — two always-present `aria-live` regions (sr-only) + animated visual toast; mounted in `App.vue`
- `App.vue` `<main>` gets `id="main-content"` + `tabindex="-1"` for programmatic focus
- `router/index.ts` `afterEach` hook focuses `<main>` after every navigation
- All list views (Rolls, Stocks, FilmFormats, Tags) add `isLoading` + `aria-busy` on table/card containers
- Successful mutations announce via the store: stock added, format added, tag saved/deleted, roll state transitioned
- `RollDetailView` loading spinner gets `role="status"` + `aria-label="Loading roll detail"`
- All 5 view test files updated with `setActivePinia(createPinia())` in `beforeEach`

Closes #203

## Test plan

- [x] Navigate between pages — focus moves to `<main>` (verify with keyboard: Tab should start from page content, not nav)
- [x] Add a stock/format/tag — toast appears bottom-right with success message
- [x] Transition a roll — toast announces new state
- [x] Use a screen reader — success messages announced politely without interrupting
- [x] Load views slowly (throttle network) — `aria-busy="true"` is present during fetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)