### PR TITLE
feat(a11y): skip-to-content link, landmark regions, and page titles (#204)

### DIFF
--- a/frollz-ui/src/App.vue
+++ b/frollz-ui/src/App.vue
@@ -1,9 +1,19 @@
 <template>
   <div id="app" class="min-h-screen bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
-    <NavBar />
+    <!-- Skip navigation — visually hidden until focused (WCAG 2.4.1 Bypass Blocks) -->
+    <a
+      href="#main-content"
+      class="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-[100] focus:px-4 focus:py-2 focus:bg-primary-600 focus:text-white focus:rounded-md focus:font-medium focus:shadow-lg"
+    >Skip to main content</a>
+    <header>
+      <NavBar />
+    </header>
     <main id="main-content" tabindex="-1" class="max-w-screen-xl mx-auto page-x py-8 focus:outline-none">
       <RouterView />
     </main>
+    <footer class="py-4 text-center text-sm text-gray-400 dark:text-gray-600">
+      <p>Frollz &mdash; Film Roll Tracker</p>
+    </footer>
     <AppAnnouncer />
   </div>
 </template>

--- a/frollz-ui/src/components/NavBar.vue
+++ b/frollz-ui/src/components/NavBar.vue
@@ -1,5 +1,5 @@
 <template>
-  <nav class="bg-white dark:bg-gray-800 shadow-lg">
+  <nav aria-label="Main navigation" class="bg-white dark:bg-gray-800 shadow-lg">
     <div class="max-w-screen-xl mx-auto page-x">
       <div class="flex justify-between items-center py-4">
         <!-- Brand -->

--- a/frollz-ui/src/components/__tests__/App.spec.ts
+++ b/frollz-ui/src/components/__tests__/App.spec.ts
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { createRouter, createMemoryHistory } from 'vue-router'
+import { axe } from 'vitest-axe'
+import App from '@/App.vue'
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+})
+
+const router = createRouter({
+  history: createMemoryHistory(),
+  routes: [{ path: '/', component: { template: '<div><h1>Dashboard</h1></div>' } }],
+})
+
+const axeOptions = {
+  runOnly: { type: 'tag' as const, values: ['wcag2a', 'wcag2aa', 'wcag21aa'] },
+}
+
+describe('App', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('skip link is the first focusable element and targets #main-content', async () => {
+    const wrapper = mount(App, {
+      global: { plugins: [router] },
+      attachTo: document.body,
+    })
+    await router.isReady()
+    await flushPromises()
+
+    const firstLink = wrapper.find('a[href="#main-content"]')
+    expect(firstLink.exists()).toBe(true)
+    expect(firstLink.text()).toBe('Skip to main content')
+
+    // Verify it is the first focusable element in the DOM
+    const allFocusable = wrapper.findAll('a, button, [tabindex]')
+    expect(allFocusable[0].attributes('href')).toBe('#main-content')
+
+    wrapper.unmount()
+  })
+
+  it('page structure uses semantic landmarks: header, main, footer', async () => {
+    const wrapper = mount(App, {
+      global: { plugins: [router] },
+      attachTo: document.body,
+    })
+    await router.isReady()
+    await flushPromises()
+
+    expect(wrapper.find('header').exists()).toBe(true)
+    expect(wrapper.find('main#main-content').exists()).toBe(true)
+    expect(wrapper.find('footer').exists()).toBe(true)
+
+    wrapper.unmount()
+  })
+
+  it('renders without a11y violations', async () => {
+    const wrapper = mount(App, {
+      global: { plugins: [router] },
+      attachTo: document.body,
+    })
+    await router.isReady()
+    await flushPromises()
+
+    const results = await axe(document.body, axeOptions)
+    expect(results).toHaveNoViolations()
+
+    wrapper.unmount()
+  })
+})

--- a/frollz-ui/src/components/__tests__/NavBar.spec.ts
+++ b/frollz-ui/src/components/__tests__/NavBar.spec.ts
@@ -140,6 +140,15 @@ describe('NavBar', () => {
     wrapper.unmount()
   })
 
+  it('root nav has aria-label="Main navigation"', async () => {
+    const wrapper = mountNav()
+    await router.isReady()
+
+    const nav = wrapper.find('nav')
+    expect(nav.attributes('aria-label')).toBe('Main navigation')
+    wrapper.unmount()
+  })
+
   it('all five nav links appear in the drawer', async () => {
     const wrapper = mountNav()
     await router.isReady()

--- a/frollz-ui/src/router/index.ts
+++ b/frollz-ui/src/router/index.ts
@@ -13,17 +13,20 @@ const router = createRouter({
     {
       path: '/',
       name: 'dashboard',
-      component: Dashboard
+      component: Dashboard,
+      meta: { title: 'Dashboard' }
     },
     {
       path: '/stocks',
       name: 'stocks',
-      component: StocksView
+      component: StocksView,
+      meta: { title: 'Stocks' }
     },
     {
       path: '/rolls',
       name: 'rolls',
-      component: RollsView
+      component: RollsView,
+      meta: { title: 'Rolls' }
     },
     {
       path: '/rolls/:key',
@@ -33,19 +36,25 @@ const router = createRouter({
     {
       path: '/formats',
       name: 'formats',
-      component: FilmFormatsView
+      component: FilmFormatsView,
+      meta: { title: 'Film Formats' }
     },
     {
       path: '/tags',
       name: 'tags',
-      component: TagsView
+      component: TagsView,
+      meta: { title: 'Tags' }
     }
   ]
 })
 
-// Move focus to <main> after each navigation so screen reader users land at the top of new content
-router.afterEach(() => {
+// Update page title and move focus to <main> after each navigation (WCAG 2.4.2 Page Titled)
+router.afterEach((to) => {
   nextTick(() => {
+    const metaTitle = typeof to.meta.title === 'string' ? to.meta.title : ''
+    const rollKey = to.name === 'roll-detail' && to.params.key ? String(to.params.key) : ''
+    const pageTitle = rollKey ? `Roll ${rollKey}` : metaTitle
+    document.title = pageTitle ? `${pageTitle} | Frollz` : 'Frollz'
     document.getElementById('main-content')?.focus()
   })
 })


### PR DESCRIPTION
## Summary

- Adds a "Skip to main content" link as the first focusable element on every page — visually hidden until focused (`sr-only focus:not-sr-only`), reveals a styled button anchored to `#main-content` (WCAG 2.4.1 Bypass Blocks)
- Wraps `NavBar` in `<header>` and adds a `<footer>` landmark to `App.vue`, completing the semantic landmark set: `<header>`, `<nav aria-label="Main navigation">`, `<main>`, `<footer>`
- Adds `meta: { title }` to each route and updates `document.title` in `router.afterEach` — e.g. `"Dashboard | Frollz"`, `"Stocks | Frollz"`, `"Roll ABC123 | Frollz"` for roll detail (WCAG 2.4.2 Page Titled)
- All views already had correct `<h1>` headings and no skipped heading levels — no changes needed there

## Test plan

- [x] All 181 Vitest tests pass including 4 new tests
- [x] New `App.spec.ts`: skip link is first focusable element, `<header>`/`<main>`/`<footer>` landmarks present, axe passes on full app shell
- [x] New NavBar test: asserts `aria-label="Main navigation"` on root `<nav>`
- [x] axe-core (`wcag2a`, `wcag2aa`, `wcag21aa`) passes on all views and the app shell

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)