### PR TITLE
feat(a11y): colour contrast audit and fixes for WCAG AA (#205)

### DIFF
--- a/frollz-ui/src/App.vue
+++ b/frollz-ui/src/App.vue
@@ -11,7 +11,7 @@
     <main id="main-content" tabindex="-1" class="max-w-screen-xl mx-auto page-x py-8 focus:outline-none">
       <RouterView />
     </main>
-    <footer class="py-4 text-center text-sm text-gray-400 dark:text-gray-600">
+    <footer class="py-4 text-center text-sm text-gray-600 dark:text-gray-500">
       <p>Frollz &mdash; Film Roll Tracker</p>
     </footer>
     <AppAnnouncer />

--- a/frollz-ui/src/views/Dashboard.vue
+++ b/frollz-ui/src/views/Dashboard.vue
@@ -17,7 +17,7 @@
       <template v-else>
         <StatCard label="Total Rolls" :value="stats.totalRolls" colorClass="text-primary-600 dark:text-primary-400" />
         <StatCard label="Available Stocks" :value="stats.totalStocks" colorClass="text-green-600 dark:text-green-400" />
-        <StatCard label="Currently Loaded" :value="stats.loadedRolls" colorClass="text-yellow-600 dark:text-yellow-400" />
+        <StatCard label="Currently Loaded" :value="stats.loadedRolls" colorClass="text-yellow-700 dark:text-yellow-400" />
         <StatCard label="Developed" :value="stats.developedRolls" colorClass="text-blue-600 dark:text-blue-400" />
       </template>
     </section>

--- a/frollz-ui/src/views/FilmFormatsView.vue
+++ b/frollz-ui/src/views/FilmFormatsView.vue
@@ -12,7 +12,7 @@
 
     <!-- Mobile card list (hidden on md+) -->
     <div class="md:hidden space-y-3" :aria-busy="isLoading" aria-label="Film formats list">
-      <p v-if="filmFormats.length === 0" class="text-center py-8 text-gray-400 dark:text-gray-500 italic">No formats found.</p>
+      <p v-if="filmFormats.length === 0" class="text-center py-8 text-gray-600 dark:text-gray-400 italic">No formats found.</p>
       <div
         v-for="format in filmFormats"
         :key="format._key"
@@ -22,7 +22,7 @@
           <div>
             <p class="font-semibold text-gray-900 dark:text-gray-100">{{ format.format }}</p>
             <p class="text-sm text-gray-500 dark:text-gray-400 mt-0.5">{{ format.formFactor }}</p>
-            <p class="text-xs text-gray-400 dark:text-gray-500 mt-1">{{ formatDate(format.createdAt) }}</p>
+            <p class="text-xs text-gray-600 dark:text-gray-400 mt-1">{{ formatDate(format.createdAt) }}</p>
           </div>
           <button
             @click="deleteFormat(format._key!)"

--- a/frollz-ui/src/views/RollDetailView.vue
+++ b/frollz-ui/src/views/RollDetailView.vue
@@ -7,9 +7,9 @@
       >← Back to Rolls</button>
     </div>
 
-    <div v-if="loading" role="status" aria-label="Loading roll detail" class="text-center py-12 text-gray-400 dark:text-gray-500">Loading...</div>
+    <div v-if="loading" role="status" aria-label="Loading roll detail" class="text-center py-12 text-gray-600 dark:text-gray-400">Loading...</div>
 
-    <div v-else-if="!roll" class="text-center py-12 text-gray-400 dark:text-gray-500">Roll not found.</div>
+    <div v-else-if="!roll" class="text-center py-12 text-gray-600 dark:text-gray-400">Roll not found.</div>
 
     <div v-else class="grid grid-cols-1 md:grid-cols-2 gap-6">
       <!-- Left: Details + Tags + Transitions -->
@@ -248,9 +248,9 @@
         <div v-if="roll.transitionProfile === 'bulk'" class="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6">
           <div class="flex justify-between items-center mb-4">
             <h2 class="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">Child Rolls</h2>
-            <span class="text-xs text-gray-400 dark:text-gray-500">{{ childRolls.length }} roll{{ childRolls.length !== 1 ? 's' : '' }} cut</span>
+            <span class="text-xs text-gray-600 dark:text-gray-400">{{ childRolls.length }} roll{{ childRolls.length !== 1 ? 's' : '' }} cut</span>
           </div>
-          <div v-if="childRolls.length === 0" class="text-sm text-gray-400 dark:text-gray-500 italic">No rolls cut from this canister yet.</div>
+          <div v-if="childRolls.length === 0" class="text-sm text-gray-600 dark:text-gray-400 italic">No rolls cut from this canister yet.</div>
           <ul v-else class="space-y-2">
             <li v-for="child in childRolls" :key="child._key" class="flex items-center justify-between text-sm">
               <button
@@ -281,7 +281,7 @@
                 class="ml-1 leading-none hover:opacity-70 font-bold"
               >&times;</button>
             </span>
-            <span v-if="rollTags.length === 0" class="text-sm text-gray-400 dark:text-gray-500 italic">No tags yet</span>
+            <span v-if="rollTags.length === 0" class="text-sm text-gray-600 dark:text-gray-400 italic">No tags yet</span>
           </div>
           <div class="flex flex-wrap gap-2">
             <button
@@ -300,7 +300,7 @@
       <!-- Right: Transition History -->
       <div class="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6 h-fit">
         <h2 class="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-4">History</h2>
-        <div v-if="annotatedHistory.length === 0" class="text-sm text-gray-400 dark:text-gray-500 py-4 text-center">No history recorded yet.</div>
+        <div v-if="annotatedHistory.length === 0" class="text-sm text-gray-600 dark:text-gray-400 py-4 text-center">No history recorded yet.</div>
         <ol v-else class="relative border-l border-gray-200 dark:border-gray-700 ml-3 space-y-6">
           <li v-for="entry in annotatedHistory" :key="entry.stateId" class="ml-4">
             <div
@@ -312,9 +312,9 @@
                 class="px-2 text-xs leading-5 font-semibold rounded-full"
                 :class="getStateColor(entry.state)"
               >{{ entry.state }}</span>
-              <span v-if="entry.direction === 'backward'" class="text-xs text-orange-600 dark:text-orange-400">{{ entry.isErrorCorrection ? '↩ error correction' : '↩ backward' }}</span>
-              <span v-if="entry.direction === 'initial'" class="text-xs text-gray-400 dark:text-gray-500">initial</span>
-              <time class="text-xs text-gray-400 dark:text-gray-500">{{ formatDate(entry.date) }}</time>
+              <span v-if="entry.direction === 'backward'" class="text-xs text-orange-700 dark:text-orange-400">{{ entry.isErrorCorrection ? '↩ error correction' : '↩ backward' }}</span>
+              <span v-if="entry.direction === 'initial'" class="text-xs text-gray-600 dark:text-gray-400">initial</span>
+              <time class="text-xs text-gray-600 dark:text-gray-400">{{ formatDate(entry.date) }}</time>
             </div>
             <p v-if="entry.notes" class="mt-1 text-sm text-gray-600 dark:text-gray-400">{{ entry.notes }}</p>
             <p v-if="entry.metadata?.temperature != null" class="mt-1 text-xs text-gray-500 dark:text-gray-400">{{ entry.metadata.temperature }}{{ temperatureUnit }}</p>

--- a/frollz-ui/src/views/RollsView.vue
+++ b/frollz-ui/src/views/RollsView.vue
@@ -10,7 +10,7 @@
     <!-- Active Filters -->
     <div class="flex flex-wrap items-center gap-2 mb-4 min-h-[2rem]">
       <span class="text-sm text-gray-500 dark:text-gray-400 font-medium">Filters:</span>
-      <span v-if="activeFilters.length === 0" class="text-sm text-gray-400 dark:text-gray-500 italic">
+      <span v-if="activeFilters.length === 0" class="text-sm text-gray-600 dark:text-gray-400 italic">
         <span class="hidden md:inline">Click any value in the table to filter by that field</span>
         <span class="md:hidden">No active filters</span>
       </span>
@@ -29,7 +29,7 @@
 
     <!-- Mobile card list (hidden on md+) -->
     <div class="md:hidden space-y-3" :aria-busy="isLoading" aria-label="Rolls list">
-      <p v-if="filteredRolls.length === 0" class="text-center py-8 text-gray-400 dark:text-gray-500 italic">No rolls found.</p>
+      <p v-if="filteredRolls.length === 0" class="text-center py-8 text-gray-600 dark:text-gray-400 italic">No rolls found.</p>
       <RouterLink
         v-for="roll in filteredRolls"
         :key="roll._key"
@@ -40,14 +40,14 @@
           <div class="min-w-0">
             <p class="font-semibold text-primary-600 dark:text-primary-400 truncate">{{ roll.rollId }}</p>
             <p class="text-sm text-gray-600 dark:text-gray-300 mt-0.5 truncate">{{ roll.stockName ?? '—' }}</p>
-            <p class="text-xs text-gray-400 dark:text-gray-500 mt-0.5">{{ roll.formatName ?? '—' }}</p>
+            <p class="text-xs text-gray-600 dark:text-gray-400 mt-0.5">{{ roll.formatName ?? '—' }}</p>
           </div>
           <span
             class="shrink-0 px-2 text-xs leading-5 font-semibold rounded-full"
             :class="getStateColor(roll.state)"
           >{{ roll.state }}</span>
         </div>
-        <p class="text-xs text-gray-400 dark:text-gray-500 mt-2">{{ formatDate(roll.dateObtained) }}</p>
+        <p class="text-xs text-gray-600 dark:text-gray-400 mt-2">{{ formatDate(roll.dateObtained) }}</p>
       </RouterLink>
     </div>
 
@@ -145,7 +145,7 @@
                 <input id="roll-bulk-canister" v-model="form.isBulkRoll" type="checkbox" class="rounded" @change="onBulkRollToggle" />
                 <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Bulk canister roll</span>
               </label>
-              <span class="text-xs text-gray-400 dark:text-gray-500">(100ft spool or similar)</span>
+              <span class="text-xs text-gray-600 dark:text-gray-400">(100ft spool or similar)</span>
             </div>
 
             <!-- Parent bulk roll selector (only for non-bulk rolls) -->

--- a/frollz-ui/src/views/StocksView.vue
+++ b/frollz-ui/src/views/StocksView.vue
@@ -10,7 +10,7 @@
     <!-- Active Filters -->
     <div class="flex flex-wrap items-center gap-2 mb-4 min-h-[2rem]">
       <span class="text-sm text-gray-500 dark:text-gray-400 font-medium">Filters:</span>
-      <span v-if="activeFilters.length === 0" class="text-sm text-gray-400 dark:text-gray-500 italic">
+      <span v-if="activeFilters.length === 0" class="text-sm text-gray-600 dark:text-gray-400 italic">
         <span class="hidden md:inline">Click any value in the table to filter by that field</span>
         <span class="md:hidden">No active filters</span>
       </span>
@@ -29,7 +29,7 @@
 
     <!-- Mobile card list (hidden on md+) -->
     <div class="md:hidden space-y-3" :aria-busy="isLoading" aria-label="Stocks list">
-      <p v-if="sortedStocks.length === 0" class="text-center py-8 text-gray-400 dark:text-gray-500 italic">No stocks found.</p>
+      <p v-if="sortedStocks.length === 0" class="text-center py-8 text-gray-600 dark:text-gray-400 italic">No stocks found.</p>
       <div
         v-for="stock in sortedStocks"
         :key="stock._key"
@@ -39,7 +39,7 @@
           <div class="min-w-0">
             <p class="font-semibold text-gray-900 dark:text-gray-100 truncate">{{ stock.brand }}</p>
             <p class="text-sm text-gray-500 dark:text-gray-400 mt-0.5 truncate">{{ stock.manufacturer }}</p>
-            <p class="text-xs text-gray-400 dark:text-gray-500 mt-0.5">{{ stock.format }} · ISO {{ stock.speed }}</p>
+            <p class="text-xs text-gray-600 dark:text-gray-400 mt-0.5">{{ stock.format }} · ISO {{ stock.speed }}</p>
           </div>
           <div class="flex flex-col items-end gap-2 shrink-0">
             <span class="px-2 text-xs leading-5 font-semibold rounded-full bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200">{{ stock.process }}</span>
@@ -193,7 +193,7 @@
             <fieldset>
               <legend class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Formats <span class="text-red-500" aria-hidden="true">*</span></legend>
               <div class="flex flex-wrap gap-2 p-2 border border-gray-300 dark:border-gray-600 rounded-md min-h-[2.5rem] bg-white dark:bg-gray-700">
-                <span v-if="!form.process" class="text-sm text-gray-400 dark:text-gray-500 italic">Select a process first</span>
+                <span v-if="!form.process" class="text-sm text-gray-600 dark:text-gray-400 italic">Select a process first</span>
                 <label
                   v-else
                   v-for="fmt in filteredFormats"

--- a/frollz-ui/src/views/TagsView.vue
+++ b/frollz-ui/src/views/TagsView.vue
@@ -6,7 +6,7 @@
 
     <!-- Mobile card list (hidden on md+) -->
     <div class="md:hidden space-y-3" :aria-busy="isLoading" aria-label="Tags list">
-      <p v-if="tags.length === 0" class="text-center py-8 text-gray-400 dark:text-gray-500 italic">No tags found.</p>
+      <p v-if="tags.length === 0" class="text-center py-8 text-gray-600 dark:text-gray-400 italic">No tags found.</p>
       <div
         v-for="tag in paginatedTags"
         :key="tag._key"
@@ -36,7 +36,7 @@
               >Delete</button>
             </div>
           </div>
-          <div class="flex gap-4 mt-2 text-xs text-gray-400 dark:text-gray-500">
+          <div class="flex gap-4 mt-2 text-xs text-gray-600 dark:text-gray-400">
             <span>Roll scope: {{ tag.isRollScoped ? 'Yes' : 'No' }}</span>
             <span>Stock scope: {{ tag.isStockScoped ? 'Yes' : 'No' }}</span>
             <span>{{ formatDate(tag.createdAt) }}</span>
@@ -175,7 +175,7 @@
               </td>
             </tr>
             <tr v-if="tags.length === 0">
-              <td colspan="6" class="px-6 py-8 text-center text-sm text-gray-400 dark:text-gray-500">No tags found.</td>
+              <td colspan="6" class="px-6 py-8 text-center text-sm text-gray-600 dark:text-gray-400">No tags found.</td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
## Summary

Full colour contrast audit against WCAG AA thresholds with targeted fixes for all failures found.

- **`text-gray-400 dark:text-gray-500` → `text-gray-600 dark:text-gray-400`** across all views and App.vue footer — `gray-400` on white is ~2.54:1 (fails 4.5:1 AA); `dark:gray-500` on `dark:bg-gray-800` is ~2.77:1 (also fails). The replacement pair gives ~5.74:1 light / ~5.28:1 dark — both pass with margin.
- **Dashboard "Currently Loaded" stat: `text-yellow-600` → `text-yellow-700`** — `yellow-600` on white is ~2.94:1, which fails even the 3:1 large-text threshold. `yellow-700` gives ~4.95:1.
- **RollDetailView history backward label: `text-orange-600` → `text-orange-700`** — `orange-600` on white is ~3.56:1, below the 4.5:1 required for normal-weight `text-xs`. `orange-700` gives ~5.18:1.

**Combinations confirmed passing (no changes needed):**
- `text-gray-500` on white: ~4.83:1 ✓ (table headers, detail labels, section headings, nav links)
- All state badge `*-800 on *-100` combos: 8–12:1 ✓
- `text-primary-600` on white: ~4.7:1 ✓
- `text-white` on `bg-primary-600` (skip link, buttons): ~4.7:1 ✓
- Dark mode `dark:text-gray-400` on `dark:bg-gray-800`: ~5.28:1 ✓

**Not addressed (systemic / data-layer):** Tag pills use `text-white` on a user-defined `backgroundColor`. Contrast depends on the colour the user picks — this requires UI guardrails at tag creation time and is out of scope for this issue.

## Test plan

- [x] 181/181 Vitest tests pass
- [x] axe-core (`wcag2a`, `wcag2aa`, `wcag21aa`) passes on all views and app shell
- [x] No `text-gray-400 dark:text-gray-500` patterns remain in `src/`
- [x] No `text-yellow-600` or `text-orange-600` text instances remain

Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)