### PR TITLE
API: Dry-ed up the roll service and calls to get the next roll id

### DIFF
--- a/frollz-api/src/roll/roll.service.ts
+++ b/frollz-api/src/roll/roll.service.ts
@@ -128,10 +128,7 @@ export class RollService implements OnModuleInit {
 
     let rollId = createRollDto.rollId;
     if (!rollId) {
-      const rows = await this.databaseService.query<{ nextval: string }>(
-        `SELECT nextval('roll_id_seq')`,
-      );
-      rollId = String(rows[0].nextval).padStart(5, "0");
+      rollId = await this.getNextId();
     }
 
     const now = new Date();


### PR DESCRIPTION
## What does this PR do?

Gets rid of second call to getNextId with explicit SQL call by using existing call on the database service
Closes #209 

## How was it tested?

- unit test
- manual walk through
- lint

## Checklist

- [x] Tests added or updated
- [x] All tests pass (`npm test` in `frollz-api/` and `frollz-ui/`)
- [x] Lint passes (`npm run lint` in both)
- [x] No `console.log` left in committed code
- [x] PR targets the `development` branch (not `main`)
