### PR TITLE
adding support to search film notes

### DIFF
--- a/frollz-api/src/domain/film/repositories/film.repository.interface.ts
+++ b/frollz-api/src/domain/film/repositories/film.repository.interface.ts
@@ -10,6 +10,7 @@ export interface FilmFilters {
   loadedStateId?: number;
   loadedDateFrom?: Date;
   loadedDateTo?: Date;
+  searchQuery?: string;
 }
 
 export interface IFilmRepository {

--- a/frollz-api/src/infrastructure/persistence/film/film.knex.repository.ts
+++ b/frollz-api/src/infrastructure/persistence/film/film.knex.repository.ts
@@ -63,6 +63,15 @@ export class FilmKnexRepository implements IFilmRepository {
       query = query.whereIn('id', sub);
     }
 
+    if (filters.searchQuery) {
+      const pattern = `%${filters.searchQuery}%`;
+      query = query.where((builder) => {
+        builder
+          .whereILike('name', pattern)
+          .orWhereIn('id', this.knex('film_state').select('film_id').whereILike('note', pattern));
+      });
+    }
+
     const rows = await query.select('*');
     return Promise.all(rows.map((row) => this.hydrate(row)));
   }

--- a/frollz-api/src/modules/film/application/film.service.spec.ts
+++ b/frollz-api/src/modules/film/application/film.service.spec.ts
@@ -257,6 +257,45 @@ describe('FilmService', () => {
         loadedDateTo: new Date('2025-03-31T23:59:59.999Z'),
       });
     });
+
+    it('passes searchQuery when q is provided', async () => {
+      const film = makeFilm();
+      const filmRepo = makeFilmRepo({ findWithFilters: jest.fn().mockResolvedValue([film]) });
+      const service = makeService(filmRepo);
+
+      await service.findAll({ q: 'scotland' });
+
+      expect(filmRepo.findWithFilters).toHaveBeenCalledWith({ searchQuery: 'scotland' });
+    });
+
+    it('trims whitespace from q before passing as searchQuery', async () => {
+      const filmRepo = makeFilmRepo({ findWithFilters: jest.fn().mockResolvedValue([]) });
+      const service = makeService(filmRepo);
+
+      await service.findAll({ q: '  scotland  ' });
+
+      expect(filmRepo.findWithFilters).toHaveBeenCalledWith({ searchQuery: 'scotland' });
+    });
+
+    it('ignores q when it is blank whitespace', async () => {
+      const filmRepo = makeFilmRepo({ findAll: jest.fn().mockResolvedValue([]) });
+      const service = makeService(filmRepo);
+
+      await service.findAll({ q: '   ' });
+
+      expect(filmRepo.findAll).toHaveBeenCalled();
+      expect(filmRepo.findWithFilters).not.toHaveBeenCalled();
+    });
+
+    it('combines q with other filters', async () => {
+      const emulsionId = randomId();
+      const filmRepo = makeFilmRepo({ findWithFilters: jest.fn().mockResolvedValue([]) });
+      const service = makeService(filmRepo);
+
+      await service.findAll({ emulsionId, q: 'paris' });
+
+      expect(filmRepo.findWithFilters).toHaveBeenCalledWith({ emulsionId, searchQuery: 'paris' });
+    });
   });
 
   describe('findById', () => {

--- a/frollz-api/src/modules/film/application/film.service.ts
+++ b/frollz-api/src/modules/film/application/film.service.ts
@@ -18,6 +18,7 @@ export interface FilmFindAllParams {
   tagIds?: number[];
   from?: string;
   to?: string;
+  q?: string;
 }
 
 @Injectable()
@@ -47,6 +48,7 @@ export class FilmService {
     if (params.emulsionId !== undefined) filters.emulsionId = params.emulsionId;
     if (params.formatId !== undefined) filters.formatId = params.formatId;
     if (params.tagIds?.length) filters.tagIds = params.tagIds;
+    if (params.q?.trim()) filters.searchQuery = params.q.trim();
 
     if (params.from || params.to) {
       const loadedState = allStates.find((s) => s.name === 'Loaded');

--- a/frollz-api/src/modules/film/film.controller.ts
+++ b/frollz-api/src/modules/film/film.controller.ts
@@ -31,6 +31,7 @@ export class FilmController {
   @ApiQuery({ name: 'tagId', required: false, isArray: true, type: Number, description: 'Filter by tag ID(s) — OR semantics' })
   @ApiQuery({ name: 'from', required: false, type: String, description: 'Filter by loaded date — start (YYYY-MM-DD, inclusive)' })
   @ApiQuery({ name: 'to', required: false, type: String, description: 'Filter by loaded date — end (YYYY-MM-DD, inclusive)' })
+  @ApiQuery({ name: 'q', required: false, type: String, description: 'Search by film name or state note (case-insensitive partial match)' })
   findAll(
     @Query('state') state?: string | string[],
     @Query('emulsionId') rawEmulsionId?: string,
@@ -38,6 +39,7 @@ export class FilmController {
     @Query('tagId') tagId?: string | string[],
     @Query('from') rawFrom?: string,
     @Query('to') rawTo?: string,
+    @Query('q') rawQ?: string,
   ) {
     const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
     if (rawFrom && !dateRegex.test(rawFrom)) {
@@ -53,7 +55,7 @@ export class FilmController {
     const tagIds = tagId
       ? (Array.isArray(tagId) ? tagId : [tagId]).map((t) => parseInt(t, 10)).filter((n) => !isNaN(n))
       : undefined;
-    return this.filmService.findAll({ stateNames, emulsionId, formatId, tagIds, from: rawFrom, to: rawTo });
+    return this.filmService.findAll({ stateNames, emulsionId, formatId, tagIds, from: rawFrom, to: rawTo, q: rawQ });
   }
 
   @Get(':id')

--- a/frollz-ui/src/services/api-client.ts
+++ b/frollz-ui/src/services/api-client.ts
@@ -61,7 +61,7 @@ export const filmTagApi = {
 
 // Film API (replaces rollApi)
 export const filmApi = {
-  getAll: (params?: { state?: string[]; emulsionId?: number; formatId?: number; tagId?: number[]; from?: string; to?: string }) =>
+  getAll: (params?: { state?: string[]; emulsionId?: number; formatId?: number; tagId?: number[]; from?: string; to?: string; q?: string }) =>
     api.get<Film[]>('/films', {
       params,
       paramsSerializer: { indexes: null },

--- a/frollz-ui/src/views/FilmsView.vue
+++ b/frollz-ui/src/views/FilmsView.vue
@@ -9,7 +9,7 @@
 
     <!-- Search + Filters toggle row -->
     <div class="flex gap-3 mb-3">
-      <!-- Search (wired up in #158) -->
+      <!-- Search -->
       <div class="relative flex-1">
         <svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 dark:text-gray-500 pointer-events-none" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-4.35-4.35M17 11A6 6 0 1 1 5 11a6 6 0 0 1 12 0z" />
@@ -437,6 +437,10 @@ const activeFilterChips = computed((): FilterChip[] => {
   })
   if (selectedFrom.value) chips.push({ key: 'from', label: `From ${selectedFrom.value}`, remove: () => { selectedFrom.value = '' } })
   if (selectedTo.value) chips.push({ key: 'to', label: `To ${selectedTo.value}`, remove: () => { selectedTo.value = '' } })
+  if (searchQuery.value.trim()) {
+    const q = searchQuery.value.trim()
+    chips.push({ key: 'search', label: `"${q}"`, remove: () => { searchQuery.value = '' } })
+  }
   return chips
 })
 
@@ -451,6 +455,7 @@ const clearAllFilters = () => {
   selectedTagIds.value = []
   selectedFrom.value = ''
   selectedTo.value = ''
+  searchQuery.value = ''
 }
 
 const getStateName = (film: Film): string => currentStateName(film)
@@ -534,6 +539,7 @@ const loadFilms = async () => {
     if (selectedTagIds.value.length > 0) params.tagId = selectedTagIds.value
     if (selectedFrom.value) params.from = selectedFrom.value
     if (selectedTo.value) params.to = selectedTo.value
+    if (searchQuery.value.trim()) params.q = searchQuery.value.trim()
     const response = await filmApi.getAll(Object.keys(params).length > 0 ? params : undefined)
     films.value = response.data
   } catch (err) {
@@ -551,6 +557,7 @@ const updateUrlQueryParams = () => {
   if (selectedTagIds.value.length > 0) query.tagId = selectedTagIds.value.map(String)
   if (selectedFrom.value) query.from = selectedFrom.value
   if (selectedTo.value) query.to = selectedTo.value
+  if (searchQuery.value.trim()) query.q = searchQuery.value.trim()
   router.replace({ query })
 }
 
@@ -558,6 +565,15 @@ watch([selectedStates, selectedEmulsionId, selectedFormatId, selectedTagIds, sel
   loadFilms()
   updateUrlQueryParams()
 }, { deep: true })
+
+let searchDebounceTimer: ReturnType<typeof setTimeout> | null = null
+watch(searchQuery, () => {
+  if (searchDebounceTimer !== null) clearTimeout(searchDebounceTimer)
+  searchDebounceTimer = setTimeout(() => {
+    loadFilms()
+    updateUrlQueryParams()
+  }, 300)
+})
 
 const openAddFilm = (emulsionId?: string) => {
   if (emulsionId) form.value.emulsionId = emulsionId
@@ -590,6 +606,8 @@ onMounted(async () => {
   if (fromParam && typeof fromParam === 'string') selectedFrom.value = fromParam
   const toParam = route.query.to
   if (toParam && typeof toParam === 'string') selectedTo.value = toParam
+  const qParam = route.query.q
+  if (qParam && typeof qParam === 'string') searchQuery.value = qParam
 
   await Promise.all([
     loadFilms(),

--- a/frollz-ui/src/views/__tests__/FilmsView.spec.ts
+++ b/frollz-ui/src/views/__tests__/FilmsView.spec.ts
@@ -161,6 +161,82 @@ describe('FilmsView', () => {
     })
   })
 
+  describe('search', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('should call filmApi.getAll with q param after debounce', async () => {
+      const wrapper = mount(FilmsView, { global: { plugins: [router] } })
+      await flushPromises()
+
+      const vm = wrapper.vm as any
+      vm.searchQuery = 'scotland'
+      await wrapper.vm.$nextTick() // let Vue flush the watch
+      vi.advanceTimersByTime(300)
+      await flushPromises()
+
+      expect(filmApi.getAll).toHaveBeenCalledWith({ q: 'scotland' })
+    })
+
+    it('should not fire immediately before debounce delay', async () => {
+      const wrapper = mount(FilmsView, { global: { plugins: [router] } })
+      await flushPromises()
+
+      const callCountBefore = vi.mocked(filmApi.getAll).mock.calls.length
+      const vm = wrapper.vm as any
+      vm.searchQuery = 'scotland'
+      await wrapper.vm.$nextTick() // let Vue flush the watch
+      vi.advanceTimersByTime(100)
+      await flushPromises()
+
+      expect(vi.mocked(filmApi.getAll).mock.calls.length).toBe(callCountBefore)
+    })
+
+    it('should include search chip in activeFilterChips when searchQuery is set', async () => {
+      const wrapper = mount(FilmsView, { global: { plugins: [router] } })
+      await flushPromises()
+
+      const vm = wrapper.vm as any
+      vm.searchQuery = 'scotland'
+      await wrapper.vm.$nextTick()
+
+      const chip = vm.activeFilterChips.find((c: any) => c.key === 'search')
+      expect(chip).toBeDefined()
+      expect(chip.label).toBe('"scotland"')
+    })
+
+    it('should clear searchQuery when search chip is removed', async () => {
+      const wrapper = mount(FilmsView, { global: { plugins: [router] } })
+      await flushPromises()
+
+      const vm = wrapper.vm as any
+      vm.searchQuery = 'scotland'
+      await wrapper.vm.$nextTick()
+
+      const chip = vm.activeFilterChips.find((c: any) => c.key === 'search')
+      chip.remove()
+      await wrapper.vm.$nextTick()
+
+      expect(vm.searchQuery).toBe('')
+    })
+
+    it('should clear searchQuery on clearAllFilters', async () => {
+      const wrapper = mount(FilmsView, { global: { plugins: [router] } })
+      await flushPromises()
+
+      const vm = wrapper.vm as any
+      vm.searchQuery = 'scotland'
+      vm.clearAllFilters()
+      await wrapper.vm.$nextTick()
+
+      expect(vm.searchQuery).toBe('')
+    })
+  })
+
   describe('add film form', () => {
     it('should open modal and set standard profile on openAddFilm', async () => {
       const wrapper = mount(FilmsView, { global: { plugins: [router] } })


### PR DESCRIPTION
## What does this PR do?

  Implements full-text search across film name and state notes (GET /api/films?q=scotland). Closes #158.                                                                             
                                                                                                                                                                                     
  - API: Added q query parameter to GET /api/films. The search is a case-insensitive partial match (ILIKE on PostgreSQL, LIKE on SQLite) against film.name and any film_state.note   
  associated with that film.                                                                                                                                                         
  - UI: Wired the existing search input on the Films screen to the API. Typing debounces at 300 ms before sending the request. An active search term appears as a dismissible chip in
   the filter chip row, is persisted in the URL query string (?q=), and is restored on page load. Clear all also clears the search.                                                  
   
  Search combines with all other active filters (state, emulsion, format, tags, loaded date range).                                                                                  
                                                                                                                                                                                   
## How was it tested?                                                                                                                                                                 
                                                                                                                                                                                   
  - npm test in frollz-api/ — 4 new service-level unit tests: q is passed through as searchQuery, whitespace is trimmed, blank/whitespace-only q is ignored, and q combines correctly
   with other filters (26 tests total, all pass).                                                                                                                                  
  - npm test in frollz-ui/ — 5 new component tests: debounce timing, chip creation, chip removal, and clearAllFilters (137 tests total, all pass).                                   
  - npm run lint and npm run type-check pass in both packages.                                                                                                                       
  - Manual: searched "scotland" in the Films screen, confirmed API call with ?q=scotland, results filtered correctly, chip appeared and could be dismissed. 

## Checklist

- [x] Tests added or updated
- [x] All tests pass (`npm test` in `frollz-api/` and `frollz-ui/`)
- [x] Lint passes (`npm run lint` in both)
- [x] No `console.log` left in committed code
- [x] PR targets the `development` branch (not `main`)
