### PR TITLE
fix: hydrate film.emulsion in FilmKnexRepository

### DIFF
--- a/frollz-api/src/infrastructure/persistence/film/film.knex.repository.ts
+++ b/frollz-api/src/infrastructure/persistence/film/film.knex.repository.ts
@@ -3,8 +3,10 @@ import { Knex } from 'knex';
 import { Film } from '../../../domain/film/entities/film.entity';
 import { FilmFilters, IFilmRepository } from '../../../domain/film/repositories/film.repository.interface';
 import { KNEX_CONNECTION } from '../knex.provider';
-import { FilmRow, FilmTagRow, TagRow } from '../types/db.types';
+import { EmulsionRow, FilmRow, FilmTagRow, TagRow } from '../types/db.types';
 import { FilmMapper } from './film.mapper';
+import { EmulsionMapper } from '../emulsion/emulsion.mapper';
+import { Emulsion } from '../../../domain/emulsion/entities/emulsion.entity';
 import { Tag } from '../../../domain/shared/entities/tag.entity';
 import { FilmState } from '../../../domain/film-state/entities/film-state.entity';
 import { FilmStateMetadata } from '../../../domain/film-state/entities/film-state-metadata.entity';
@@ -135,11 +137,20 @@ export class FilmKnexRepository implements IFilmRepository {
 
   private async hydrate(row: FilmRow): Promise<Film> {
     const film = FilmMapper.toDomain(row);
-    const [tags, states] = await Promise.all([
+    const [tags, states, emulsion] = await Promise.all([
       this.loadTags(row.id),
       this.loadStates(row.id),
+      this.loadEmulsion(row.emulsion_id),
     ]);
-    return Film.create({ ...film, tags, states });
+    return Film.create({ ...film, tags, states, emulsion });
+  }
+
+  private async loadEmulsion(emulsionId: number): Promise<Emulsion | undefined> {
+    const row = await this.knex<EmulsionRow>('emulsion')
+      .select('id', 'parent_id', 'process_id', 'format_id', 'name', 'brand', 'manufacturer', 'speed', 'box_image_mime_type')
+      .where({ id: emulsionId })
+      .first();
+    return row ? EmulsionMapper.toDomain(row) : undefined;
   }
 
   private async loadTags(filmId: number): Promise<Tag[]> {

--- a/frollz-api/test/integration/film-lifecycle.integration.spec.ts
+++ b/frollz-api/test/integration/film-lifecycle.integration.spec.ts
@@ -218,6 +218,9 @@ describe('Film', () => {
     expect(film.transitionProfileId).toBe(standardProfileId);
     expect(film.states).toHaveLength(1);
     expect(film.currentState?.state?.name).toBe('Added');
+    expect(film.emulsion).toBeDefined();
+    expect(film.emulsion?.brand).toBe('Kodak');
+    expect(film.emulsion?.speed).toBe(160);
   });
 
   it('tags a film and verifies the tag is returned', async () => {


### PR DESCRIPTION
## Summary
- `FilmKnexRepository.hydrate()` never queried the emulsion table, leaving `film.emulsion` always `undefined`
- Adds a `loadEmulsion()` private method called in parallel with `loadTags()` and `loadStates()`
- Fixes the film detail view silently hiding emulsion brand and ISO speed behind `v-if="film.emulsion"`

## Test plan
- [x] Integration test updated — asserts `film.emulsion.brand` and `film.emulsion.speed` are populated after create/read
- [x] All 64 unit + integration tests pass
- [x] Lint clean

Closes #261