### PR TITLE
feat: seed Imported transition state and rules

### DIFF
--- a/frollz-api/migrations/20260413000001_imported_transition_state.ts
+++ b/frollz-api/migrations/20260413000001_imported_transition_state.ts
@@ -1,0 +1,65 @@
+import type { Knex } from "knex";
+
+// Adds the "Imported" transition state — an entry-only state used by the CSV
+// import feature. Films created via CSV import land here instead of "Added",
+// making their provenance clear. Rules are added FROM "Imported" to every
+// other existing state for all three profiles so users can transition the film
+// to wherever it actually is after import.
+// No rules point TO "Imported" — it is entry-only.
+
+export async function up(knex: Knex): Promise<void> {
+  await knex("transition_state").insert({ name: "Imported" });
+
+  const allStates = await knex<{ id: number; name: string }>("transition_state").select("id", "name");
+  const stateId = (name: string) => {
+    const row = allStates.find((s) => s.name === name);
+    if (!row) throw new Error(`Seed error: transition_state '${name}' not found`);
+    return row.id;
+  };
+
+  const allProfiles = await knex<{ id: number; name: string }>("transition_profile").select("id", "name");
+  const profileId = (name: string) => {
+    const row = allProfiles.find((p) => p.name === name);
+    if (!row) throw new Error(`Seed error: transition_profile '${name}' not found`);
+    return row.id;
+  };
+
+  const std = profileId("standard");
+  const inst = profileId("instant");
+  const bulk = profileId("bulk");
+
+  const otherStates = [
+    "Added",
+    "Frozen",
+    "Refrigerated",
+    "Shelved",
+    "Loaded",
+    "Finished",
+    "Sent For Development",
+    "Developed",
+    "Received",
+  ];
+
+  type RuleRow = { from_state_id: number; to_state_id: number; profile_id: number };
+
+  const rules: RuleRow[] = [];
+  for (const profile of [std, inst, bulk]) {
+    for (const toState of otherStates) {
+      rules.push({ from_state_id: stateId("Imported"), to_state_id: stateId(toState), profile_id: profile });
+    }
+  }
+
+  await knex("transition_rule").insert(rules);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  const state = await knex<{ id: number }>("transition_state").where({ name: "Imported" }).first();
+  if (!state) return;
+
+  await knex("transition_rule")
+    .where({ from_state_id: state.id })
+    .orWhere({ to_state_id: state.id })
+    .delete();
+
+  await knex("transition_state").where({ name: "Imported" }).delete();
+}

--- a/frollz-api/test/integration/film-lifecycle.integration.spec.ts
+++ b/frollz-api/test/integration/film-lifecycle.integration.spec.ts
@@ -384,3 +384,36 @@ describe('findAll with state filter', () => {
     expect(addedIds).not.toContain(filmB.id);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Imported transition state
+// ---------------------------------------------------------------------------
+
+describe('Imported transition state', () => {
+  it('exists in transition_state', async () => {
+    const row = await knex('transition_state').where({ name: 'Imported' }).first();
+    expect(row).toBeDefined();
+  });
+
+  it('has rules to every other state for each profile', async () => {
+    const importedId = await stateId(knex, 'Imported');
+    const profiles = await knex('transition_profile').select('id', 'name');
+    const otherStates = await knex('transition_state').whereNot({ name: 'Imported' }).select('id');
+
+    for (const profile of profiles) {
+      const rules = await knex('transition_rule')
+        .where({ from_state_id: importedId, profile_id: profile.id })
+        .select('to_state_id');
+      const toIds = rules.map((r: { to_state_id: number }) => r.to_state_id);
+      for (const state of otherStates) {
+        expect(toIds).toContain(state.id);
+      }
+    }
+  });
+
+  it('has no rules pointing TO Imported', async () => {
+    const importedId = await stateId(knex, 'Imported');
+    const count = await knex('transition_rule').where({ to_state_id: importedId }).count('id as n').first();
+    expect(Number(count?.n)).toBe(0);
+  });
+});

--- a/frollz-ui/src/utils/stateColors.ts
+++ b/frollz-ui/src/utils/stateColors.ts
@@ -1,4 +1,5 @@
 const STATE_COLORS: Record<string, string> = {
+  Imported: 'bg-teal-100 text-teal-800 dark:bg-teal-900/50 dark:text-teal-200',
   Added: 'bg-orange-100 text-orange-800 dark:bg-orange-900/50 dark:text-orange-200',
   Frozen: 'bg-blue-100 text-blue-800 dark:bg-blue-900/50 dark:text-blue-200',
   Refrigerated: 'bg-cyan-100 text-cyan-800 dark:bg-cyan-900/50 dark:text-cyan-200',


### PR DESCRIPTION
## Summary
- Adds a new `Imported` transition state — an entry-only state for films created via CSV import (#165)
- Migration seeds the state and 27 transition rules: `Imported` → all 9 existing states × 3 profiles (standard, instant, bulk)
- No rules point TO `Imported` — it cannot be re-entered once left
- Adds teal colour token for `Imported` in the UI state colour map

## Test plan
- [ ] 3 new integration tests verify: state exists, rules to all other states exist for each profile, no rules point TO `Imported`
- [ ] All 20 integration tests pass
- [ ] All 47 unit tests pass
- [ ] Lint clean in both workspaces

Closes #262