### PR TITLE
feat: add ExportImportModule and films JSON export

### DIFF
--- a/frollz-api/src/app.module.ts
+++ b/frollz-api/src/app.module.ts
@@ -7,6 +7,7 @@ import { EmulsionModule } from './modules/emulsion/emulsion.module';
 import { FilmModule } from './modules/film/film.module';
 import { FilmStateModule } from './modules/film-state/film-state.module';
 import { TransitionModule } from './modules/transition/transition.module';
+import { ExportImportModule } from './modules/export-import/export-import.module';
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { TransitionModule } from './modules/transition/transition.module';
     FilmModule,
     FilmStateModule,
     TransitionModule,
+    ExportImportModule,
   ],
   providers: [{ provide: APP_GUARD, useClass: ThrottlerGuard }],
 })

--- a/frollz-api/src/modules/export-import/application/export.service.spec.ts
+++ b/frollz-api/src/modules/export-import/application/export.service.spec.ts
@@ -1,0 +1,80 @@
+import { randomInt } from 'crypto';
+import { ExportService } from './export.service';
+import { IFilmRepository } from '../../../domain/film/repositories/film.repository.interface';
+import { Film } from '../../../domain/film/entities/film.entity';
+
+const randomId = () => randomInt(1, 1_000_000);
+
+const makeFilm = (overrides: Partial<Parameters<typeof Film.create>[0]> = {}): Film =>
+  Film.create({
+    id: randomId(),
+    name: 'Roll 001',
+    emulsionId: randomId(),
+    expirationDate: new Date('2026-12-31'),
+    parentId: null,
+    transitionProfileId: randomId(),
+    ...overrides,
+  });
+
+const makeFilmRepo = (overrides: Partial<IFilmRepository> = {}): IFilmRepository => ({
+  findAll: jest.fn().mockResolvedValue([]),
+  findById: jest.fn().mockResolvedValue(null),
+  findWithFilters: jest.fn().mockResolvedValue([]),
+  findByEmulsionId: jest.fn().mockResolvedValue([]),
+  findChildren: jest.fn().mockResolvedValue([]),
+  findByCurrentStateIds: jest.fn().mockResolvedValue([]),
+  save: jest.fn().mockResolvedValue(randomId()),
+  update: jest.fn().mockResolvedValue(undefined),
+  delete: jest.fn().mockResolvedValue(undefined),
+  ...overrides,
+});
+
+describe('ExportService', () => {
+  let service: ExportService;
+  let filmRepo: jest.Mocked<IFilmRepository>;
+
+  beforeEach(() => {
+    filmRepo = makeFilmRepo() as jest.Mocked<IFilmRepository>;
+    service = new ExportService(filmRepo);
+  });
+
+  describe('exportFilmsJson', () => {
+    it('returns an empty films array when no films exist', async () => {
+      filmRepo.findAll = jest.fn().mockResolvedValue([]);
+      const result = await service.exportFilmsJson();
+      expect(result.films).toEqual([]);
+    });
+
+    it('returns all films from the repository', async () => {
+      const films = [makeFilm({ name: 'Roll 001' }), makeFilm({ name: 'Roll 002' })];
+      filmRepo.findAll = jest.fn().mockResolvedValue(films);
+      const result = await service.exportFilmsJson();
+      expect(result.films).toEqual(films);
+      expect(filmRepo.findAll).toHaveBeenCalledTimes(1);
+    });
+
+    it('includes a version field from APP_VERSION env var', async () => {
+      process.env.APP_VERSION = 'v1.2.3';
+      filmRepo.findAll = jest.fn().mockResolvedValue([]);
+      const result = await service.exportFilmsJson();
+      expect(result.version).toBe('v1.2.3');
+      delete process.env.APP_VERSION;
+    });
+
+    it('falls back to "unknown" when APP_VERSION is not set', async () => {
+      delete process.env.APP_VERSION;
+      filmRepo.findAll = jest.fn().mockResolvedValue([]);
+      const result = await service.exportFilmsJson();
+      expect(result.version).toBe('unknown');
+    });
+
+    it('includes an exportedAt ISO timestamp', async () => {
+      filmRepo.findAll = jest.fn().mockResolvedValue([]);
+      const before = new Date().toISOString();
+      const result = await service.exportFilmsJson();
+      const after = new Date().toISOString();
+      expect(result.exportedAt >= before).toBe(true);
+      expect(result.exportedAt <= after).toBe(true);
+    });
+  });
+});

--- a/frollz-api/src/modules/export-import/application/export.service.ts
+++ b/frollz-api/src/modules/export-import/application/export.service.ts
@@ -1,0 +1,25 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { Film } from '../../../domain/film/entities/film.entity';
+import { IFilmRepository, FILM_REPOSITORY } from '../../../domain/film/repositories/film.repository.interface';
+
+export interface FilmsExportEnvelope {
+  version: string;
+  exportedAt: string;
+  films: Film[];
+}
+
+@Injectable()
+export class ExportService {
+  constructor(
+    @Inject(FILM_REPOSITORY) private readonly filmRepo: IFilmRepository,
+  ) {}
+
+  async exportFilmsJson(): Promise<FilmsExportEnvelope> {
+    const films = await this.filmRepo.findAll();
+    return {
+      version: process.env.APP_VERSION ?? 'unknown',
+      exportedAt: new Date().toISOString(),
+      films,
+    };
+  }
+}

--- a/frollz-api/src/modules/export-import/export-import.controller.ts
+++ b/frollz-api/src/modules/export-import/export-import.controller.ts
@@ -1,0 +1,20 @@
+import { Controller, Get, Res } from '@nestjs/common';
+import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Response } from 'express';
+import { ExportService } from './application/export.service';
+
+@ApiTags('Export')
+@Controller('export')
+export class ExportImportController {
+  constructor(private readonly exportService: ExportService) {}
+
+  @Get('films.json')
+  @ApiOperation({ summary: 'Export all films as JSON' })
+  async exportFilmsJson(@Res() res: Response): Promise<void> {
+    const envelope = await this.exportService.exportFilmsJson();
+    const date = new Date().toISOString().slice(0, 10);
+    res.setHeader('Content-Type', 'application/json');
+    res.setHeader('Content-Disposition', `attachment; filename="films-${date}.json"`);
+    res.json(envelope);
+  }
+}

--- a/frollz-api/src/modules/export-import/export-import.module.ts
+++ b/frollz-api/src/modules/export-import/export-import.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { DatabaseModule } from '../../infrastructure/persistence/database.module';
+import { FILM_REPOSITORY } from '../../domain/film/repositories/film.repository.interface';
+import { FilmKnexRepository } from '../../infrastructure/persistence/film/film.knex.repository';
+import { ExportService } from './application/export.service';
+import { ExportImportController } from './export-import.controller';
+
+@Module({
+  imports: [DatabaseModule],
+  providers: [
+    { provide: FILM_REPOSITORY, useClass: FilmKnexRepository },
+    ExportService,
+  ],
+  controllers: [ExportImportController],
+})
+export class ExportImportModule {}

--- a/frollz-ui/src/services/api-client.ts
+++ b/frollz-ui/src/services/api-client.ts
@@ -90,6 +90,11 @@ export const filmStateApi = {
     api.get<FilmState[]>('/film-states', { params: { filmId } }),
 }
 
+// Export API
+export const exportApi = {
+  filmsJsonPath: '/export/films.json',
+}
+
 // Transition API
 export const transitionApi = {
   getProfiles: () => api.get<TransitionProfile[]>('/transitions/profiles'),

--- a/frollz-ui/src/utils/download.ts
+++ b/frollz-ui/src/utils/download.ts
@@ -1,0 +1,23 @@
+const API_BASE_URL = import.meta.env.VITE_API_URL || '/api'
+
+/**
+ * Fetches a URL and triggers a browser file download.
+ * Reads the filename from the Content-Disposition response header when available,
+ * falling back to the provided fallbackFilename.
+ */
+export async function triggerDownload(path: string, fallbackFilename: string): Promise<void> {
+  const res = await fetch(`${API_BASE_URL}${path}`)
+  if (!res.ok) throw new Error(`HTTP ${res.status}`)
+
+  const disposition = res.headers.get('Content-Disposition') ?? ''
+  const match = disposition.match(/filename="([^"]+)"/)
+  const filename = match?.[1] ?? fallbackFilename
+
+  const blob = await res.blob()
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}

--- a/frollz-ui/src/views/FilmsView.vue
+++ b/frollz-ui/src/views/FilmsView.vue
@@ -2,9 +2,18 @@
   <div>
     <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between mb-4">
       <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100">Films</h1>
-      <button @click="openAddFilm()" class="bg-primary-600 text-white px-4 py-2 min-h-[44px] rounded-md hover:bg-primary-700 font-medium">
-        Add Film
-      </button>
+      <div class="flex flex-wrap gap-2">
+        <button
+          @click="exportFilmsJson"
+          :disabled="exportingJson"
+          class="border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 px-4 py-2 min-h-[44px] rounded-md hover:bg-gray-50 dark:hover:bg-gray-700 font-medium disabled:opacity-50"
+        >
+          {{ exportingJson ? 'Exporting…' : 'Export JSON' }}
+        </button>
+        <button @click="openAddFilm()" class="bg-primary-600 text-white px-4 py-2 min-h-[44px] rounded-md hover:bg-primary-700 font-medium">
+          Add Film
+        </button>
+      </div>
     </div>
 
     <!-- Search + Filters toggle row -->
@@ -440,11 +449,12 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, watch } from 'vue'
 import { RouterLink, useRoute, useRouter } from 'vue-router'
-import { filmApi, emulsionApi, transitionApi, formatApi, tagApi } from '@/services/api-client'
+import { filmApi, emulsionApi, transitionApi, formatApi, tagApi, exportApi } from '@/services/api-client'
 import BaseModal from '@/components/BaseModal.vue'
 import type { Film, Emulsion, TransitionProfile, Format, Tag } from '@/types'
 import { currentStateName, getScanUrls } from '@/types'
 import { getStateColor } from '@/utils/stateColors'
+import { triggerDownload } from '@/utils/download'
 
 const route = useRoute()
 const router = useRouter()
@@ -455,6 +465,7 @@ const formats = ref<Format[]>([])
 const tags = ref<Tag[]>([])
 const transitionProfiles = ref<TransitionProfile[]>([])
 const isLoading = ref(true)
+const exportingJson = ref(false)
 const showModal = ref(false)
 
 const searchQuery = ref('')
@@ -641,6 +652,17 @@ watch(searchQuery, () => {
     updateUrlQueryParams()
   }, 300)
 })
+
+const exportFilmsJson = async () => {
+  exportingJson.value = true
+  try {
+    await triggerDownload(exportApi.filmsJsonPath, 'films.json')
+  } catch (err) {
+    console.error('Export failed:', err)
+  } finally {
+    exportingJson.value = false
+  }
+}
 
 const openAddFilm = (emulsionId?: string) => {
   if (emulsionId) form.value.emulsionId = emulsionId


### PR DESCRIPTION
## Summary
- Adds `ExportImportModule` — the scaffold for all export/import features in the epic (#143)
- `GET /api/export/films.json` returns a versioned envelope with full-fidelity film data
- Envelope shape: `{ version, exportedAt, films: [...] }` — `version` comes from `APP_VERSION` env var (falls back to `"unknown"`) so future import logic can detect schema changes
- Each film includes hydrated emulsion, tags, and full state history with metadata
- UI: "Export JSON" button on the films list page triggers a browser download

## Test plan
- [ ] 5 unit tests on `ExportService`: empty library, populated library, version from env var, unknown fallback, exportedAt timestamp
- [ ] All 52 API unit tests pass
- [ ] All 20 integration tests pass
- [ ] UI lint, type-check, and 143 tests pass

Closes #162