### PR TITLE
feat(#164): export reference data (emulsions, formats, tags) as JSON

### DIFF
--- a/frollz-api/src/modules/export-import/application/export.service.spec.ts
+++ b/frollz-api/src/modules/export-import/application/export.service.spec.ts
@@ -2,6 +2,12 @@ import { randomInt } from 'crypto';
 import { ExportService } from './export.service';
 import { IFilmRepository } from '../../../domain/film/repositories/film.repository.interface';
 import { Film } from '../../../domain/film/entities/film.entity';
+import { IEmulsionRepository } from '../../../domain/emulsion/repositories/emulsion.repository.interface';
+import { Emulsion } from '../../../domain/emulsion/entities/emulsion.entity';
+import { IFormatRepository } from '../../../domain/shared/repositories/format.repository.interface';
+import { Format } from '../../../domain/shared/entities/format.entity';
+import { ITagRepository } from '../../../domain/shared/repositories/tag.repository.interface';
+import { Tag } from '../../../domain/shared/entities/tag.entity';
 
 const randomId = () => randomInt(1, 1_000_000);
 
@@ -29,13 +35,83 @@ const makeFilmRepo = (overrides: Partial<IFilmRepository> = {}): IFilmRepository
   ...overrides,
 });
 
+const makeEmulsion = (overrides: Partial<Parameters<typeof Emulsion.create>[0]> = {}): Emulsion =>
+  Emulsion.create({
+    id: randomId(),
+    name: 'Kodak Gold 200',
+    brand: 'Kodak',
+    manufacturer: 'Kodak',
+    speed: 200,
+    processId: randomId(),
+    formatId: randomId(),
+    ...overrides,
+  });
+
+const makeFormat = (overrides: Partial<Parameters<typeof Format.create>[0]> = {}): Format =>
+  Format.create({
+    id: randomId(),
+    packageId: randomId(),
+    name: '35mm',
+    ...overrides,
+  });
+
+const makeTag = (overrides: Partial<Parameters<typeof Tag.create>[0]> = {}): Tag =>
+  Tag.create({
+    id: randomId(),
+    name: 'Expired',
+    colorCode: '#6B7280',
+    ...overrides,
+  });
+
+const makeEmulsionRepo = (overrides: Partial<IEmulsionRepository> = {}): IEmulsionRepository => ({
+  findAll: jest.fn().mockResolvedValue([]),
+  findById: jest.fn().mockResolvedValue(null),
+  findByProcessId: jest.fn().mockResolvedValue([]),
+  findByFormatId: jest.fn().mockResolvedValue([]),
+  findBrands: jest.fn().mockResolvedValue([]),
+  findManufacturers: jest.fn().mockResolvedValue([]),
+  findSpeeds: jest.fn().mockResolvedValue([]),
+  save: jest.fn().mockResolvedValue(randomId()),
+  update: jest.fn().mockResolvedValue(undefined),
+  delete: jest.fn().mockResolvedValue(undefined),
+  updateBoxImage: jest.fn().mockResolvedValue(undefined),
+  getBoxImage: jest.fn().mockResolvedValue(null),
+  ...overrides,
+});
+
+const makeFormatRepo = (overrides: Partial<IFormatRepository> = {}): IFormatRepository => ({
+  findAll: jest.fn().mockResolvedValue([]),
+  findById: jest.fn().mockResolvedValue(null),
+  findByPackageId: jest.fn().mockResolvedValue([]),
+  save: jest.fn().mockResolvedValue(randomId()),
+  update: jest.fn().mockResolvedValue(undefined),
+  delete: jest.fn().mockResolvedValue(undefined),
+  ...overrides,
+});
+
+const makeTagRepo = (overrides: Partial<ITagRepository> = {}): ITagRepository => ({
+  findAll: jest.fn().mockResolvedValue([]),
+  findById: jest.fn().mockResolvedValue(null),
+  findByName: jest.fn().mockResolvedValue(null),
+  save: jest.fn().mockResolvedValue(randomId()),
+  update: jest.fn().mockResolvedValue(undefined),
+  delete: jest.fn().mockResolvedValue(undefined),
+  ...overrides,
+});
+
 describe('ExportService', () => {
   let service: ExportService;
   let filmRepo: jest.Mocked<IFilmRepository>;
+  let emulsionRepo: jest.Mocked<IEmulsionRepository>;
+  let formatRepo: jest.Mocked<IFormatRepository>;
+  let tagRepo: jest.Mocked<ITagRepository>;
 
   beforeEach(() => {
     filmRepo = makeFilmRepo() as jest.Mocked<IFilmRepository>;
-    service = new ExportService(filmRepo);
+    emulsionRepo = makeEmulsionRepo() as jest.Mocked<IEmulsionRepository>;
+    formatRepo = makeFormatRepo() as jest.Mocked<IFormatRepository>;
+    tagRepo = makeTagRepo() as jest.Mocked<ITagRepository>;
+    service = new ExportService(filmRepo, emulsionRepo, formatRepo, tagRepo);
   });
 
   describe('exportFilmsJson', () => {
@@ -72,6 +148,54 @@ describe('ExportService', () => {
       filmRepo.findAll = jest.fn().mockResolvedValue([]);
       const before = new Date().toISOString();
       const result = await service.exportFilmsJson();
+      const after = new Date().toISOString();
+      expect(result.exportedAt >= before).toBe(true);
+      expect(result.exportedAt <= after).toBe(true);
+    });
+  });
+
+  describe('exportLibraryJson', () => {
+    it('returns empty arrays when no data exists', async () => {
+      const result = await service.exportLibraryJson();
+      expect(result.emulsions).toEqual([]);
+      expect(result.formats).toEqual([]);
+      expect(result.tags).toEqual([]);
+    });
+
+    it('returns all emulsions, formats, and tags from their repositories', async () => {
+      const emulsions = [makeEmulsion({ name: 'Kodak Gold 200' }), makeEmulsion({ name: 'Fuji Superia 400' })];
+      const formats = [makeFormat({ name: '35mm' }), makeFormat({ name: '120' })];
+      const tags = [makeTag({ name: 'Expired' }), makeTag({ name: 'Push +1' })];
+      emulsionRepo.findAll = jest.fn().mockResolvedValue(emulsions);
+      formatRepo.findAll = jest.fn().mockResolvedValue(formats);
+      tagRepo.findAll = jest.fn().mockResolvedValue(tags);
+
+      const result = await service.exportLibraryJson();
+
+      expect(result.emulsions).toEqual(emulsions);
+      expect(result.formats).toEqual(formats);
+      expect(result.tags).toEqual(tags);
+      expect(emulsionRepo.findAll).toHaveBeenCalledTimes(1);
+      expect(formatRepo.findAll).toHaveBeenCalledTimes(1);
+      expect(tagRepo.findAll).toHaveBeenCalledTimes(1);
+    });
+
+    it('includes a version field from APP_VERSION env var', async () => {
+      process.env.APP_VERSION = 'v2.0.0';
+      const result = await service.exportLibraryJson();
+      expect(result.version).toBe('v2.0.0');
+      delete process.env.APP_VERSION;
+    });
+
+    it('falls back to "unknown" when APP_VERSION is not set', async () => {
+      delete process.env.APP_VERSION;
+      const result = await service.exportLibraryJson();
+      expect(result.version).toBe('unknown');
+    });
+
+    it('includes an exportedAt ISO timestamp', async () => {
+      const before = new Date().toISOString();
+      const result = await service.exportLibraryJson();
       const after = new Date().toISOString();
       expect(result.exportedAt >= before).toBe(true);
       expect(result.exportedAt <= after).toBe(true);

--- a/frollz-api/src/modules/export-import/application/export.service.ts
+++ b/frollz-api/src/modules/export-import/application/export.service.ts
@@ -1,6 +1,12 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { Film } from '../../../domain/film/entities/film.entity';
 import { IFilmRepository, FILM_REPOSITORY } from '../../../domain/film/repositories/film.repository.interface';
+import { Emulsion } from '../../../domain/emulsion/entities/emulsion.entity';
+import { IEmulsionRepository, EMULSION_REPOSITORY } from '../../../domain/emulsion/repositories/emulsion.repository.interface';
+import { Format } from '../../../domain/shared/entities/format.entity';
+import { IFormatRepository, FORMAT_REPOSITORY } from '../../../domain/shared/repositories/format.repository.interface';
+import { Tag } from '../../../domain/shared/entities/tag.entity';
+import { ITagRepository, TAG_REPOSITORY } from '../../../domain/shared/repositories/tag.repository.interface';
 
 export interface FilmsExportEnvelope {
   version: string;
@@ -8,10 +14,21 @@ export interface FilmsExportEnvelope {
   films: Film[];
 }
 
+export interface LibraryExportEnvelope {
+  version: string;
+  exportedAt: string;
+  emulsions: Emulsion[];
+  formats: Format[];
+  tags: Tag[];
+}
+
 @Injectable()
 export class ExportService {
   constructor(
     @Inject(FILM_REPOSITORY) private readonly filmRepo: IFilmRepository,
+    @Inject(EMULSION_REPOSITORY) private readonly emulsionRepo: IEmulsionRepository,
+    @Inject(FORMAT_REPOSITORY) private readonly formatRepo: IFormatRepository,
+    @Inject(TAG_REPOSITORY) private readonly tagRepo: ITagRepository,
   ) {}
 
   async exportFilmsJson(): Promise<FilmsExportEnvelope> {
@@ -20,6 +37,21 @@ export class ExportService {
       version: process.env.APP_VERSION ?? 'unknown',
       exportedAt: new Date().toISOString(),
       films,
+    };
+  }
+
+  async exportLibraryJson(): Promise<LibraryExportEnvelope> {
+    const [emulsions, formats, tags] = await Promise.all([
+      this.emulsionRepo.findAll(),
+      this.formatRepo.findAll(),
+      this.tagRepo.findAll(),
+    ]);
+    return {
+      version: process.env.APP_VERSION ?? 'unknown',
+      exportedAt: new Date().toISOString(),
+      emulsions,
+      formats,
+      tags,
     };
   }
 }

--- a/frollz-api/src/modules/export-import/export-import.controller.ts
+++ b/frollz-api/src/modules/export-import/export-import.controller.ts
@@ -17,4 +17,14 @@ export class ExportImportController {
     res.setHeader('Content-Disposition', `attachment; filename="films-${date}.json"`);
     res.json(envelope);
   }
+
+  @Get('library.json')
+  @ApiOperation({ summary: 'Export reference data (emulsions, formats, tags) as JSON' })
+  async exportLibraryJson(@Res() res: Response): Promise<void> {
+    const envelope = await this.exportService.exportLibraryJson();
+    const date = new Date().toISOString().slice(0, 10);
+    res.setHeader('Content-Type', 'application/json');
+    res.setHeader('Content-Disposition', `attachment; filename="library-${date}.json"`);
+    res.json(envelope);
+  }
 }

--- a/frollz-api/src/modules/export-import/export-import.module.ts
+++ b/frollz-api/src/modules/export-import/export-import.module.ts
@@ -2,6 +2,12 @@ import { Module } from '@nestjs/common';
 import { DatabaseModule } from '../../infrastructure/persistence/database.module';
 import { FILM_REPOSITORY } from '../../domain/film/repositories/film.repository.interface';
 import { FilmKnexRepository } from '../../infrastructure/persistence/film/film.knex.repository';
+import { EMULSION_REPOSITORY } from '../../domain/emulsion/repositories/emulsion.repository.interface';
+import { EmulsionKnexRepository } from '../../infrastructure/persistence/emulsion/emulsion.knex.repository';
+import { FORMAT_REPOSITORY } from '../../domain/shared/repositories/format.repository.interface';
+import { FormatKnexRepository } from '../../infrastructure/persistence/shared/format.knex.repository';
+import { TAG_REPOSITORY } from '../../domain/shared/repositories/tag.repository.interface';
+import { TagKnexRepository } from '../../infrastructure/persistence/shared/tag.knex.repository';
 import { ExportService } from './application/export.service';
 import { ExportImportController } from './export-import.controller';
 
@@ -9,6 +15,9 @@ import { ExportImportController } from './export-import.controller';
   imports: [DatabaseModule],
   providers: [
     { provide: FILM_REPOSITORY, useClass: FilmKnexRepository },
+    { provide: EMULSION_REPOSITORY, useClass: EmulsionKnexRepository },
+    { provide: FORMAT_REPOSITORY, useClass: FormatKnexRepository },
+    { provide: TAG_REPOSITORY, useClass: TagKnexRepository },
     ExportService,
   ],
   controllers: [ExportImportController],

--- a/frollz-ui/src/services/api-client.ts
+++ b/frollz-ui/src/services/api-client.ts
@@ -93,6 +93,7 @@ export const filmStateApi = {
 // Export API
 export const exportApi = {
   filmsJsonPath: '/export/films.json',
+  libraryJsonPath: '/export/library.json',
 }
 
 // Transition API

--- a/frollz-ui/src/views/FilmsView.vue
+++ b/frollz-ui/src/views/FilmsView.vue
@@ -10,6 +10,13 @@
         >
           {{ exportingJson ? 'Exporting…' : 'Export JSON' }}
         </button>
+        <button
+          @click="exportLibraryJson"
+          :disabled="exportingLibrary"
+          class="border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 px-4 py-2 min-h-[44px] rounded-md hover:bg-gray-50 dark:hover:bg-gray-700 font-medium disabled:opacity-50"
+        >
+          {{ exportingLibrary ? 'Exporting…' : 'Export Library' }}
+        </button>
         <button @click="openAddFilm()" class="bg-primary-600 text-white px-4 py-2 min-h-[44px] rounded-md hover:bg-primary-700 font-medium">
           Add Film
         </button>
@@ -466,6 +473,7 @@ const tags = ref<Tag[]>([])
 const transitionProfiles = ref<TransitionProfile[]>([])
 const isLoading = ref(true)
 const exportingJson = ref(false)
+const exportingLibrary = ref(false)
 const showModal = ref(false)
 
 const searchQuery = ref('')
@@ -661,6 +669,17 @@ const exportFilmsJson = async () => {
     console.error('Export failed:', err)
   } finally {
     exportingJson.value = false
+  }
+}
+
+const exportLibraryJson = async () => {
+  exportingLibrary.value = true
+  try {
+    await triggerDownload(exportApi.libraryJsonPath, 'library.json')
+  } catch (err) {
+    console.error('Export failed:', err)
+  } finally {
+    exportingLibrary.value = false
   }
 }
 


### PR DESCRIPTION
Closes #164

## Summary
- `GET /api/export/library.json` returns `{ version, exportedAt, emulsions, formats, tags }` (same versioned envelope as films export)
- `Content-Disposition: attachment; filename="library-{YYYY-MM-DD}.json"` set via manual `@Res()` response
- `ExportImportModule` now binds `EMULSION_REPOSITORY`, `FORMAT_REPOSITORY`, and `TAG_REPOSITORY` tokens alongside the existing `FILM_REPOSITORY`
- `ExportService.exportLibraryJson()` fetches all three collections in parallel via `Promise.all`
- "Export Library" button added to FilmsView alongside "Export JSON" with matching loading state
- 5 new unit tests for `exportLibraryJson` (empty, populated, version env var, unknown fallback, timestamp)
- All 57 API tests + 143 UI tests pass; lint and type-check clean

## Test plan
- [x] `GET /api/export/library.json` downloads a `library-YYYY-MM-DD.json` file
- [x] Downloaded JSON contains `version`, `exportedAt`, `emulsions`, `formats`, and `tags` arrays
- [x] "Export Library" button shows "Exporting…" while in-flight and is disabled
- [x] "Export JSON" button still works unchanged