### PR TITLE
feat(#165): import films from CSV

### DIFF
--- a/frollz-api/package-lock.json
+++ b/frollz-api/package-lock.json
@@ -17,6 +17,7 @@
         "better-sqlite3": "^12.8.0",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.15.1",
+        "csv-parse": "^6.2.1",
         "dotenv": "^17.4.1",
         "helmet": "^8.1.0",
         "knex": "^3.2.9",
@@ -4418,6 +4419,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/csv-parse": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-6.2.1.tgz",
+      "integrity": "sha512-LRLMV+UCyfMokp8Wb411duBf1gaBKJfOfBWU9eHMJ+b+cJYZsNu3AFmjJf3+yPGd59Exz1TsMjaSFyxnYB9+IQ==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",

--- a/frollz-api/package.json
+++ b/frollz-api/package.json
@@ -31,6 +31,7 @@
     "better-sqlite3": "^12.8.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.15.1",
+    "csv-parse": "^6.2.1",
     "dotenv": "^17.4.1",
     "helmet": "^8.1.0",
     "knex": "^3.2.9",

--- a/frollz-api/src/domain/emulsion/repositories/emulsion.repository.interface.ts
+++ b/frollz-api/src/domain/emulsion/repositories/emulsion.repository.interface.ts
@@ -5,6 +5,7 @@ export const EMULSION_REPOSITORY = 'EMULSION_REPOSITORY';
 export interface IEmulsionRepository {
   findById(id: number): Promise<Emulsion | null>;
   findAll(): Promise<Emulsion[]>;
+  findByName(name: string): Promise<Emulsion | null>;
   findByProcessId(processId: number): Promise<Emulsion[]>;
   findByFormatId(formatId: number): Promise<Emulsion[]>;
   findBrands(q?: string): Promise<string[]>;

--- a/frollz-api/src/infrastructure/persistence/emulsion/emulsion.knex.repository.ts
+++ b/frollz-api/src/infrastructure/persistence/emulsion/emulsion.knex.repository.ts
@@ -43,6 +43,14 @@ export class EmulsionKnexRepository implements IEmulsionRepository {
     );
   }
 
+  async findByName(name: string): Promise<Emulsion | null> {
+    const row = await this.knex<EmulsionRow>('emulsion').select(EMULSION_COLUMNS).whereILike('name', name).first();
+    if (!row) return null;
+    const emulsion = EmulsionMapper.toDomain(row);
+    const tags = await this.loadTags(row.id);
+    return Emulsion.create({ ...emulsion, tags });
+  }
+
   async findByProcessId(processId: number): Promise<Emulsion[]> {
     const rows = await this.knex<EmulsionRow>('emulsion').select(EMULSION_COLUMNS).where({ process_id: processId });
     return Promise.all(

--- a/frollz-api/src/modules/emulsion/application/emulsion.service.spec.ts
+++ b/frollz-api/src/modules/emulsion/application/emulsion.service.spec.ts
@@ -24,6 +24,7 @@ const makeEmulsion = (overrides: Partial<Parameters<typeof Emulsion.create>[0]> 
 const makeRepo = (overrides: Partial<IEmulsionRepository> = {}): IEmulsionRepository => ({
   findAll: jest.fn().mockResolvedValue([]),
   findById: jest.fn().mockResolvedValue(null),
+  findByName: jest.fn().mockResolvedValue(null),
   findByProcessId: jest.fn().mockResolvedValue([]),
   findByFormatId: jest.fn().mockResolvedValue([]),
   findBrands: jest.fn().mockResolvedValue([]),

--- a/frollz-api/src/modules/export-import/application/export.service.spec.ts
+++ b/frollz-api/src/modules/export-import/application/export.service.spec.ts
@@ -66,6 +66,7 @@ const makeTag = (overrides: Partial<Parameters<typeof Tag.create>[0]> = {}): Tag
 const makeEmulsionRepo = (overrides: Partial<IEmulsionRepository> = {}): IEmulsionRepository => ({
   findAll: jest.fn().mockResolvedValue([]),
   findById: jest.fn().mockResolvedValue(null),
+  findByName: jest.fn().mockResolvedValue(null),
   findByProcessId: jest.fn().mockResolvedValue([]),
   findByFormatId: jest.fn().mockResolvedValue([]),
   findBrands: jest.fn().mockResolvedValue([]),

--- a/frollz-api/src/modules/export-import/application/import.service.spec.ts
+++ b/frollz-api/src/modules/export-import/application/import.service.spec.ts
@@ -1,0 +1,271 @@
+import { BadRequestException } from '@nestjs/common';
+import { randomInt } from 'crypto';
+import { ImportService } from './import.service';
+import { IFilmRepository } from '../../../domain/film/repositories/film.repository.interface';
+import { IFilmStateRepository } from '../../../domain/film-state/repositories/film-state.repository.interface';
+import { IFilmTagRepository } from '../../../domain/film-tag/repositories/film-tag.repository.interface';
+import { IEmulsionRepository } from '../../../domain/emulsion/repositories/emulsion.repository.interface';
+import { ITagRepository } from '../../../domain/shared/repositories/tag.repository.interface';
+import { ITransitionStateRepository } from '../../../domain/transition/repositories/transition-state.repository.interface';
+import { ITransitionProfileRepository } from '../../../domain/transition/repositories/transition-profile.repository.interface';
+import { Emulsion } from '../../../domain/emulsion/entities/emulsion.entity';
+import { Tag } from '../../../domain/shared/entities/tag.entity';
+import { TransitionState } from '../../../domain/transition/entities/transition-state.entity';
+import { TransitionProfile } from '../../../domain/transition/entities/transition-profile.entity';
+
+const randomId = () => randomInt(1, 1_000_000);
+
+const makeEmulsion = (name = 'Kodak Portra 400'): Emulsion =>
+  Emulsion.create({
+    id: randomId(),
+    name,
+    brand: 'Kodak',
+    manufacturer: 'Kodak',
+    speed: 400,
+    processId: randomId(),
+    formatId: randomId(),
+  });
+
+const makeTag = (name = 'landscape'): Tag =>
+  Tag.create({ id: randomId(), name, colorCode: '#6B7280' });
+
+const makeTransitionState = (name = 'Imported'): TransitionState =>
+  TransitionState.create({ id: randomId(), name });
+
+const makeTransitionProfile = (name = 'standard'): TransitionProfile =>
+  TransitionProfile.create({ id: randomId(), name });
+
+const makeFilmRepo = (overrides: Partial<IFilmRepository> = {}): IFilmRepository => ({
+  findAll: jest.fn().mockResolvedValue([]),
+  findById: jest.fn().mockResolvedValue(null),
+  findWithFilters: jest.fn().mockResolvedValue([]),
+  findByEmulsionId: jest.fn().mockResolvedValue([]),
+  findChildren: jest.fn().mockResolvedValue([]),
+  findByCurrentStateIds: jest.fn().mockResolvedValue([]),
+  save: jest.fn().mockResolvedValue(randomId()),
+  update: jest.fn().mockResolvedValue(undefined),
+  delete: jest.fn().mockResolvedValue(undefined),
+  ...overrides,
+});
+
+const makeFilmStateRepo = (overrides: Partial<IFilmStateRepository> = {}): IFilmStateRepository => ({
+  findById: jest.fn().mockResolvedValue(null),
+  findByFilmId: jest.fn().mockResolvedValue([]),
+  findLatestByFilmId: jest.fn().mockResolvedValue(null),
+  findFilmIdsByCurrentState: jest.fn().mockResolvedValue([]),
+  save: jest.fn().mockResolvedValue(randomId()),
+  saveMetadataValue: jest.fn().mockResolvedValue(undefined),
+  update: jest.fn().mockResolvedValue(undefined),
+  delete: jest.fn().mockResolvedValue(undefined),
+  ...overrides,
+});
+
+const makeFilmTagRepo = (overrides: Partial<IFilmTagRepository> = {}): IFilmTagRepository => ({
+  add: jest.fn().mockResolvedValue(undefined),
+  remove: jest.fn().mockResolvedValue(undefined),
+  ...overrides,
+});
+
+const makeEmulsionRepo = (overrides: Partial<IEmulsionRepository> = {}): IEmulsionRepository => ({
+  findAll: jest.fn().mockResolvedValue([]),
+  findById: jest.fn().mockResolvedValue(null),
+  findByName: jest.fn().mockResolvedValue(null),
+  findByProcessId: jest.fn().mockResolvedValue([]),
+  findByFormatId: jest.fn().mockResolvedValue([]),
+  findBrands: jest.fn().mockResolvedValue([]),
+  findManufacturers: jest.fn().mockResolvedValue([]),
+  findSpeeds: jest.fn().mockResolvedValue([]),
+  save: jest.fn().mockResolvedValue(randomId()),
+  update: jest.fn().mockResolvedValue(undefined),
+  delete: jest.fn().mockResolvedValue(undefined),
+  updateBoxImage: jest.fn().mockResolvedValue(undefined),
+  getBoxImage: jest.fn().mockResolvedValue(null),
+  ...overrides,
+});
+
+const makeTagRepo = (overrides: Partial<ITagRepository> = {}): ITagRepository => ({
+  findAll: jest.fn().mockResolvedValue([]),
+  findById: jest.fn().mockResolvedValue(null),
+  findByName: jest.fn().mockResolvedValue(null),
+  save: jest.fn().mockResolvedValue(randomId()),
+  update: jest.fn().mockResolvedValue(undefined),
+  delete: jest.fn().mockResolvedValue(undefined),
+  ...overrides,
+});
+
+const makeTransitionStateRepo = (state: TransitionState, overrides: Partial<ITransitionStateRepository> = {}): ITransitionStateRepository => ({
+  findAll: jest.fn().mockResolvedValue([]),
+  findById: jest.fn().mockResolvedValue(null),
+  findByName: jest.fn().mockResolvedValue(state),
+  save: jest.fn().mockResolvedValue(undefined),
+  update: jest.fn().mockResolvedValue(undefined),
+  delete: jest.fn().mockResolvedValue(undefined),
+  ...overrides,
+});
+
+const makeTransitionProfileRepo = (profile: TransitionProfile, overrides: Partial<ITransitionProfileRepository> = {}): ITransitionProfileRepository => ({
+  findAll: jest.fn().mockResolvedValue([]),
+  findById: jest.fn().mockResolvedValue(null),
+  findByName: jest.fn().mockResolvedValue(profile),
+  save: jest.fn().mockResolvedValue(undefined),
+  update: jest.fn().mockResolvedValue(undefined),
+  delete: jest.fn().mockResolvedValue(undefined),
+  ...overrides,
+});
+
+const csv = (rows: string[]) => Buffer.from([`name,emulsion,tags,notes`, ...rows].join('\n'));
+
+describe('ImportService', () => {
+  let service: ImportService;
+  let filmRepo: jest.Mocked<IFilmRepository>;
+  let filmStateRepo: jest.Mocked<IFilmStateRepository>;
+  let filmTagRepo: jest.Mocked<IFilmTagRepository>;
+  let emulsionRepo: jest.Mocked<IEmulsionRepository>;
+  let tagRepo: jest.Mocked<ITagRepository>;
+  let transitionStateRepo: jest.Mocked<ITransitionStateRepository>;
+  let transitionProfileRepo: jest.Mocked<ITransitionProfileRepository>;
+
+  const importedState = makeTransitionState('Imported');
+  const standardProfile = makeTransitionProfile('standard');
+  const portra = makeEmulsion('Kodak Portra 400');
+
+  beforeEach(() => {
+    filmRepo = makeFilmRepo() as jest.Mocked<IFilmRepository>;
+    filmStateRepo = makeFilmStateRepo() as jest.Mocked<IFilmStateRepository>;
+    filmTagRepo = makeFilmTagRepo() as jest.Mocked<IFilmTagRepository>;
+    emulsionRepo = makeEmulsionRepo({ findByName: jest.fn().mockResolvedValue(portra) }) as jest.Mocked<IEmulsionRepository>;
+    tagRepo = makeTagRepo() as jest.Mocked<ITagRepository>;
+    transitionStateRepo = makeTransitionStateRepo(importedState) as jest.Mocked<ITransitionStateRepository>;
+    transitionProfileRepo = makeTransitionProfileRepo(standardProfile) as jest.Mocked<ITransitionProfileRepository>;
+
+    service = new ImportService(
+      filmRepo, filmStateRepo, filmTagRepo,
+      emulsionRepo, tagRepo,
+      transitionStateRepo, transitionProfileRepo,
+    );
+  });
+
+  describe('getTemplate', () => {
+    it('returns a CSV string with the header row and one example row', () => {
+      const result = service.getTemplate();
+      const lines = result.trim().split('\n');
+      expect(lines[0]).toBe('name,emulsion,tags,notes');
+      expect(lines.length).toBeGreaterThan(1);
+    });
+  });
+
+  describe('importFilms', () => {
+    it('throws BadRequestException when Imported state is not seeded', async () => {
+      transitionStateRepo.findByName = jest.fn().mockResolvedValue(null);
+      await expect(service.importFilms(csv(['Roll 001,Kodak Portra 400,,']))).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException when standard profile is not seeded', async () => {
+      transitionProfileRepo.findByName = jest.fn().mockResolvedValue(null);
+      await expect(service.importFilms(csv(['Roll 001,Kodak Portra 400,,']))).rejects.toThrow(BadRequestException);
+    });
+
+    it('imports a valid row successfully', async () => {
+      const result = await service.importFilms(csv(['Roll 001,Kodak Portra 400,,']));
+      expect(result.imported).toBe(1);
+      expect(result.skipped).toBe(0);
+      expect(result.errors).toHaveLength(0);
+      expect(filmRepo.save).toHaveBeenCalledTimes(1);
+      expect(filmStateRepo.save).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips a row missing the name field', async () => {
+      const result = await service.importFilms(csv([',Kodak Portra 400,,']));
+      expect(result.imported).toBe(0);
+      expect(result.skipped).toBe(1);
+      expect(result.errors[0]).toMatchObject({ row: 2, reason: expect.stringContaining('name') });
+    });
+
+    it('skips a row missing the emulsion field', async () => {
+      const result = await service.importFilms(csv(['Roll 001,,,']));
+      expect(result.imported).toBe(0);
+      expect(result.skipped).toBe(1);
+      expect(result.errors[0]).toMatchObject({ row: 2, reason: expect.stringContaining('emulsion') });
+    });
+
+    it('skips a row where the emulsion name is not found', async () => {
+      emulsionRepo.findByName = jest.fn().mockResolvedValue(null);
+      const result = await service.importFilms(csv(['Roll 001,Unknown Emulsion,,']));
+      expect(result.imported).toBe(0);
+      expect(result.skipped).toBe(1);
+      expect(result.errors[0].reason).toContain('Unknown emulsion');
+    });
+
+    it('creates tags that do not already exist with default color', async () => {
+      const newTagId = randomId();
+      const newTag = makeTag('nature');
+      tagRepo.findByName = jest.fn().mockResolvedValue(null);
+      tagRepo.save = jest.fn().mockResolvedValue(newTagId);
+      tagRepo.findById = jest.fn().mockResolvedValue(newTag);
+
+      await service.importFilms(csv(['Roll 001,Kodak Portra 400,nature,']));
+
+      expect(tagRepo.save).toHaveBeenCalledWith(expect.objectContaining({ colorCode: '#6B7280' }));
+      expect(filmTagRepo.add).toHaveBeenCalledTimes(1);
+    });
+
+    it('reuses existing tags without creating duplicates', async () => {
+      const existingTag = makeTag('landscape');
+      tagRepo.findByName = jest.fn().mockResolvedValue(existingTag);
+
+      await service.importFilms(csv(['Roll 001,Kodak Portra 400,landscape,']));
+
+      expect(tagRepo.save).not.toHaveBeenCalled();
+      expect(filmTagRepo.add).toHaveBeenCalledWith(expect.any(Number), existingTag.id);
+    });
+
+    it('stores notes as the FilmState note', async () => {
+      await service.importFilms(csv(['Roll 001,Kodak Portra 400,,Shot in Portugal']));
+
+      expect(filmStateRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ note: 'Shot in Portugal' }),
+      );
+    });
+
+    it('handles pipe-separated tags correctly', async () => {
+      const tag1 = makeTag('landscape');
+      const tag2 = makeTag('expired');
+      tagRepo.findByName = jest.fn()
+        .mockResolvedValueOnce(tag1)
+        .mockResolvedValueOnce(tag2);
+
+      await service.importFilms(csv(['Roll 001,Kodak Portra 400,landscape|expired,']));
+
+      expect(filmTagRepo.add).toHaveBeenCalledTimes(2);
+    });
+
+    it('continues processing remaining rows after a skipped row', async () => {
+      emulsionRepo.findByName = jest.fn()
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(portra);
+
+      const result = await service.importFilms(csv([
+        'Roll 001,Unknown Emulsion,,',
+        'Roll 002,Kodak Portra 400,,',
+      ]));
+
+      expect(result.imported).toBe(1);
+      expect(result.skipped).toBe(1);
+      expect(result.errors).toHaveLength(1);
+    });
+
+    it('returns correct counts for a mixed batch', async () => {
+      // Row 1: valid; Row 2: missing name (skipped before emulsion lookup); Row 3: valid
+      emulsionRepo.findByName = jest.fn().mockResolvedValue(portra);
+
+      const result = await service.importFilms(csv([
+        'Roll 001,Kodak Portra 400,,',
+        ',Kodak Portra 400,,',
+        'Roll 003,Kodak Portra 400,,',
+      ]));
+
+      expect(result.imported).toBe(2);
+      expect(result.skipped).toBe(1);
+    });
+  });
+});

--- a/frollz-api/src/modules/export-import/application/import.service.ts
+++ b/frollz-api/src/modules/export-import/application/import.service.ts
@@ -1,0 +1,138 @@
+import { BadRequestException, Inject, Injectable } from '@nestjs/common';
+import { parse } from 'csv-parse/sync';
+import { Film } from '../../../domain/film/entities/film.entity';
+import { IFilmRepository, FILM_REPOSITORY } from '../../../domain/film/repositories/film.repository.interface';
+import { FilmState } from '../../../domain/film-state/entities/film-state.entity';
+import { IFilmStateRepository, FILM_STATE_REPOSITORY } from '../../../domain/film-state/repositories/film-state.repository.interface';
+import { IFilmTagRepository, FILM_TAG_REPOSITORY } from '../../../domain/film-tag/repositories/film-tag.repository.interface';
+import { IEmulsionRepository, EMULSION_REPOSITORY } from '../../../domain/emulsion/repositories/emulsion.repository.interface';
+import { Tag } from '../../../domain/shared/entities/tag.entity';
+import { ITagRepository, TAG_REPOSITORY } from '../../../domain/shared/repositories/tag.repository.interface';
+import { ITransitionStateRepository, TRANSITION_STATE_REPOSITORY } from '../../../domain/transition/repositories/transition-state.repository.interface';
+import { ITransitionProfileRepository, TRANSITION_PROFILE_REPOSITORY } from '../../../domain/transition/repositories/transition-profile.repository.interface';
+
+export interface ImportRowError {
+  row: number;
+  reason: string;
+}
+
+export interface ImportResult {
+  imported: number;
+  skipped: number;
+  errors: ImportRowError[];
+}
+
+const TEMPLATE_HEADER = 'name,emulsion,tags,notes';
+const TEMPLATE_EXAMPLE = 'Roll 001,Kodak Portra 400,landscape|expired,Shot in Portugal';
+const DEFAULT_EXPIRATION = new Date('2099-12-31');
+const DEFAULT_TAG_COLOR = '#6B7280';
+
+@Injectable()
+export class ImportService {
+  constructor(
+    @Inject(FILM_REPOSITORY) private readonly filmRepo: IFilmRepository,
+    @Inject(FILM_STATE_REPOSITORY) private readonly filmStateRepo: IFilmStateRepository,
+    @Inject(FILM_TAG_REPOSITORY) private readonly filmTagRepo: IFilmTagRepository,
+    @Inject(EMULSION_REPOSITORY) private readonly emulsionRepo: IEmulsionRepository,
+    @Inject(TAG_REPOSITORY) private readonly tagRepo: ITagRepository,
+    @Inject(TRANSITION_STATE_REPOSITORY) private readonly transitionStateRepo: ITransitionStateRepository,
+    @Inject(TRANSITION_PROFILE_REPOSITORY) private readonly transitionProfileRepo: ITransitionProfileRepository,
+  ) {}
+
+  getTemplate(): string {
+    return `${TEMPLATE_HEADER}\n${TEMPLATE_EXAMPLE}\n`;
+  }
+
+  async importFilms(buffer: Buffer): Promise<ImportResult> {
+    const [importedState, standardProfile] = await Promise.all([
+      this.transitionStateRepo.findByName('Imported'),
+      this.transitionProfileRepo.findByName('standard'),
+    ]);
+
+    if (!importedState) throw new BadRequestException("Transition state 'Imported' is not seeded");
+    if (!standardProfile) throw new BadRequestException("Transition profile 'standard' is not seeded");
+
+    let rows: Record<string, string>[];
+    try {
+      rows = parse(buffer, { columns: true, skip_empty_lines: true, trim: true });
+    } catch {
+      throw new BadRequestException('Failed to parse CSV — ensure the file is valid UTF-8 CSV');
+    }
+
+    const errors: ImportRowError[] = [];
+    let imported = 0;
+    let skipped = 0;
+
+    for (let i = 0; i < rows.length; i++) {
+      const rowNum = i + 2; // 1-based, offset by header row
+      const row = rows[i];
+
+      const name = row['name']?.trim();
+      if (!name) {
+        errors.push({ row: rowNum, reason: 'Missing required field: name' });
+        skipped++;
+        continue;
+      }
+
+      const emulsionName = row['emulsion']?.trim();
+      if (!emulsionName) {
+        errors.push({ row: rowNum, reason: 'Missing required field: emulsion' });
+        skipped++;
+        continue;
+      }
+
+      const emulsion = await this.emulsionRepo.findByName(emulsionName);
+      if (!emulsion) {
+        errors.push({ row: rowNum, reason: `Unknown emulsion: "${emulsionName}"` });
+        skipped++;
+        continue;
+      }
+
+      const note = row['notes']?.trim() || null;
+      const tagNames = row['tags']
+        ? row['tags'].split('|').map((t) => t.trim()).filter(Boolean)
+        : [];
+
+      try {
+        const film = Film.create({
+          name,
+          emulsionId: emulsion.id,
+          expirationDate: DEFAULT_EXPIRATION,
+          parentId: null,
+          transitionProfileId: standardProfile.id,
+        });
+        const filmId = await this.filmRepo.save(film);
+
+        const filmState = FilmState.create({
+          filmId,
+          stateId: importedState.id,
+          date: new Date(),
+          note,
+        });
+        await this.filmStateRepo.save(filmState);
+
+        for (const tagName of tagNames) {
+          const tag = await this.findOrCreateTag(tagName);
+          await this.filmTagRepo.add(filmId, tag.id);
+        }
+
+        imported++;
+      } catch {
+        errors.push({ row: rowNum, reason: 'Internal error saving film — row skipped' });
+        skipped++;
+      }
+    }
+
+    return { imported, skipped, errors };
+  }
+
+  private async findOrCreateTag(name: string): Promise<Tag> {
+    const existing = await this.tagRepo.findByName(name);
+    if (existing) return existing;
+
+    const newTag = Tag.create({ name, colorCode: DEFAULT_TAG_COLOR });
+    const newId = await this.tagRepo.save(newTag);
+    const saved = await this.tagRepo.findById(newId);
+    return saved!;
+  }
+}

--- a/frollz-api/src/modules/export-import/export-import.controller.ts
+++ b/frollz-api/src/modules/export-import/export-import.controller.ts
@@ -1,14 +1,19 @@
-import { Controller, Get, Res } from '@nestjs/common';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { BadRequestException, Controller, Get, Post, Res, UploadedFile, UseInterceptors } from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { ApiBody, ApiConsumes, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { Response } from 'express';
 import { ExportService } from './application/export.service';
+import { ImportResult, ImportService } from './application/import.service';
 
-@ApiTags('Export')
-@Controller('export')
+@ApiTags('Export / Import')
+@Controller()
 export class ExportImportController {
-  constructor(private readonly exportService: ExportService) {}
+  constructor(
+    private readonly exportService: ExportService,
+    private readonly importService: ImportService,
+  ) {}
 
-  @Get('films.json')
+  @Get('export/films.json')
   @ApiOperation({ summary: 'Export all films as JSON' })
   async exportFilmsJson(@Res() res: Response): Promise<void> {
     const envelope = await this.exportService.exportFilmsJson();
@@ -18,7 +23,7 @@ export class ExportImportController {
     res.json(envelope);
   }
 
-  @Get('library.json')
+  @Get('export/library.json')
   @ApiOperation({ summary: 'Export reference data (emulsions, formats, tags) as JSON' })
   async exportLibraryJson(@Res() res: Response): Promise<void> {
     const envelope = await this.exportService.exportLibraryJson();
@@ -26,5 +31,28 @@ export class ExportImportController {
     res.setHeader('Content-Type', 'application/json');
     res.setHeader('Content-Disposition', `attachment; filename="library-${date}.json"`);
     res.json(envelope);
+  }
+
+  @Get('import/films/template')
+  @ApiOperation({ summary: 'Download CSV template for film import' })
+  getFilmsTemplate(@Res() res: Response): void {
+    const date = new Date().toISOString().slice(0, 10);
+    res.setHeader('Content-Type', 'text/csv');
+    res.setHeader('Content-Disposition', `attachment; filename="films-import-template-${date}.csv"`);
+    res.send(this.importService.getTemplate());
+  }
+
+  @Post('import/films')
+  @ApiOperation({ summary: 'Import films from a CSV file' })
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({ schema: { type: 'object', properties: { csv: { type: 'string', format: 'binary' } } } })
+  @UseInterceptors(FileInterceptor('csv'))
+  async importFilms(@UploadedFile() file: Express.Multer.File): Promise<ImportResult> {
+    if (!file) throw new BadRequestException('No file uploaded');
+    const allowed = new Set(['text/csv', 'application/vnd.ms-excel', 'text/plain']);
+    if (!allowed.has(file.mimetype)) {
+      throw new BadRequestException(`Unsupported file type: ${file.mimetype}`);
+    }
+    return this.importService.importFilms(file.buffer);
   }
 }

--- a/frollz-api/src/modules/export-import/export-import.module.ts
+++ b/frollz-api/src/modules/export-import/export-import.module.ts
@@ -8,7 +8,16 @@ import { FORMAT_REPOSITORY } from '../../domain/shared/repositories/format.repos
 import { FormatKnexRepository } from '../../infrastructure/persistence/shared/format.knex.repository';
 import { TAG_REPOSITORY } from '../../domain/shared/repositories/tag.repository.interface';
 import { TagKnexRepository } from '../../infrastructure/persistence/shared/tag.knex.repository';
+import { FILM_STATE_REPOSITORY } from '../../domain/film-state/repositories/film-state.repository.interface';
+import { FilmStateKnexRepository } from '../../infrastructure/persistence/film-state/film-state.knex.repository';
+import { FILM_TAG_REPOSITORY } from '../../domain/film-tag/repositories/film-tag.repository.interface';
+import { FilmTagKnexRepository } from '../../infrastructure/persistence/film-tag/film-tag.knex.repository';
+import { TRANSITION_STATE_REPOSITORY } from '../../domain/transition/repositories/transition-state.repository.interface';
+import { TransitionStateKnexRepository } from '../../infrastructure/persistence/transition/transition-state.knex.repository';
+import { TRANSITION_PROFILE_REPOSITORY } from '../../domain/transition/repositories/transition-profile.repository.interface';
+import { TransitionProfileKnexRepository } from '../../infrastructure/persistence/transition/transition-profile.knex.repository';
 import { ExportService } from './application/export.service';
+import { ImportService } from './application/import.service';
 import { ExportImportController } from './export-import.controller';
 
 @Module({
@@ -18,7 +27,12 @@ import { ExportImportController } from './export-import.controller';
     { provide: EMULSION_REPOSITORY, useClass: EmulsionKnexRepository },
     { provide: FORMAT_REPOSITORY, useClass: FormatKnexRepository },
     { provide: TAG_REPOSITORY, useClass: TagKnexRepository },
+    { provide: FILM_STATE_REPOSITORY, useClass: FilmStateKnexRepository },
+    { provide: FILM_TAG_REPOSITORY, useClass: FilmTagKnexRepository },
+    { provide: TRANSITION_STATE_REPOSITORY, useClass: TransitionStateKnexRepository },
+    { provide: TRANSITION_PROFILE_REPOSITORY, useClass: TransitionProfileKnexRepository },
     ExportService,
+    ImportService,
   ],
   controllers: [ExportImportController],
 })

--- a/frollz-ui/src/services/api-client.ts
+++ b/frollz-ui/src/services/api-client.ts
@@ -96,6 +96,21 @@ export const exportApi = {
   libraryJsonPath: '/export/library.json',
 }
 
+// Import API
+const API_BASE_URL = import.meta.env.VITE_API_URL || '/api'
+export const importApi = {
+  templatePath: '/import/films/template',
+  importFilms: (file: File) => {
+    const form = new FormData()
+    form.append('csv', file)
+    return api.post<{ imported: number; skipped: number; errors: { row: number; reason: string }[] }>(
+      '/import/films',
+      form,
+    )
+  },
+  templateUrl: `${API_BASE_URL}/import/films/template`,
+}
+
 // Transition API
 export const transitionApi = {
   getProfiles: () => api.get<TransitionProfile[]>('/transitions/profiles'),

--- a/frollz-ui/src/views/FilmsView.vue
+++ b/frollz-ui/src/views/FilmsView.vue
@@ -17,10 +17,34 @@
         >
           {{ exportingLibrary ? 'Exporting…' : 'Export Library' }}
         </button>
+        <button
+          @click="csvInput?.click()"
+          :disabled="importingCsv"
+          class="border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 px-4 py-2 min-h-[44px] rounded-md hover:bg-gray-50 dark:hover:bg-gray-700 font-medium disabled:opacity-50"
+        >
+          {{ importingCsv ? 'Importing…' : 'Import CSV' }}
+        </button>
+        <input ref="csvInput" type="file" accept=".csv,text/csv" class="hidden" aria-label="Select CSV file to import" @change="onCsvSelected" />
         <button @click="openAddFilm()" class="bg-primary-600 text-white px-4 py-2 min-h-[44px] rounded-md hover:bg-primary-700 font-medium">
           Add Film
         </button>
       </div>
+    </div>
+
+    <!-- Import results -->
+    <div v-if="importResult" class="mb-4 rounded-md border p-4 text-sm" :class="importResult.errors.length ? 'border-yellow-300 bg-yellow-50 dark:bg-yellow-900/20 dark:border-yellow-700' : 'border-green-300 bg-green-50 dark:bg-green-900/20 dark:border-green-700'">
+      <div class="flex items-center justify-between mb-1">
+        <span class="font-medium text-gray-800 dark:text-gray-200">
+          Import complete — {{ importResult.imported }} imported, {{ importResult.skipped }} skipped
+        </span>
+        <button @click="importResult = null" class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 text-lg leading-none">&times;</button>
+      </div>
+      <ul v-if="importResult.errors.length" class="mt-2 space-y-1 text-yellow-800 dark:text-yellow-200">
+        <li v-for="err in importResult.errors" :key="err.row">Row {{ err.row }}: {{ err.reason }}</li>
+      </ul>
+      <p v-if="!importResult.errors.length" class="text-green-800 dark:text-green-200 mt-1">
+        All rows imported successfully. <a :href="importApi.templateUrl" class="underline">Download template</a> for next time.
+      </p>
     </div>
 
     <!-- Search + Filters toggle row -->
@@ -456,7 +480,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, watch } from 'vue'
 import { RouterLink, useRoute, useRouter } from 'vue-router'
-import { filmApi, emulsionApi, transitionApi, formatApi, tagApi, exportApi } from '@/services/api-client'
+import { filmApi, emulsionApi, transitionApi, formatApi, tagApi, exportApi, importApi } from '@/services/api-client'
 import BaseModal from '@/components/BaseModal.vue'
 import type { Film, Emulsion, TransitionProfile, Format, Tag } from '@/types'
 import { currentStateName, getScanUrls } from '@/types'
@@ -474,6 +498,9 @@ const transitionProfiles = ref<TransitionProfile[]>([])
 const isLoading = ref(true)
 const exportingJson = ref(false)
 const exportingLibrary = ref(false)
+const importingCsv = ref(false)
+const csvInput = ref<HTMLInputElement | null>(null)
+const importResult = ref<{ imported: number; skipped: number; errors: { row: number; reason: string }[] } | null>(null)
 const showModal = ref(false)
 
 const searchQuery = ref('')
@@ -680,6 +707,23 @@ const exportLibraryJson = async () => {
     console.error('Export failed:', err)
   } finally {
     exportingLibrary.value = false
+  }
+}
+
+const onCsvSelected = async (event: Event) => {
+  const file = (event.target as HTMLInputElement).files?.[0]
+  if (!file) return
+  importingCsv.value = true
+  importResult.value = null
+  try {
+    const res = await importApi.importFilms(file)
+    importResult.value = res.data
+    await loadFilms()
+  } catch (err) {
+    console.error('Import failed:', err)
+  } finally {
+    importingCsv.value = false
+    if (csvInput.value) csvInput.value.value = ''
   }
 }
 


### PR DESCRIPTION
Closes #165

## Summary
- `POST /api/import/films` — multipart CSV upload, returns `{ imported, skipped, errors: [{ row, reason }] }`
- `GET /api/import/films/template` — downloadable CSV with header + example row
- Each imported film lands directly in the **Imported** transition state (bypasses FilmService to avoid the "Added" initial state; inserts FilmState directly via repo)
- `notes` column stored as the `note` on the FilmState record
- Missing `name` or `emulsion` → row skipped with descriptive error; rest of import continues
- Unknown emulsion name → row skipped with descriptive error
- Unknown tags auto-created with color `#6B7280`; existing tags reused
- `expirationDate` defaults to `2099-12-31` (not in CSV spec)
- Added `IEmulsionRepository.findByName()` + `EmulsionKnexRepository` implementation
- Updated `ExportImportModule` with 4 new repo bindings (FilmState, FilmTag, TransitionState, TransitionProfile)
- UI: "Import CSV" button opens hidden file input, POSTs to API, shows inline results banner with per-row errors and a template download link
- 13 new unit tests for ImportService; mock factories in export + emulsion service specs updated for new interface method

## Test plan
- [ ] Upload a valid CSV → films appear in the list in Imported state
- [ ] Upload a CSV with a missing name → that row skipped, rest imported
- [ ] Upload a CSV with an unknown emulsion → that row skipped, rest imported
- [ ] Unknown tags are auto-created; existing tags are reused
- [ ] `GET /api/import/films/template` downloads a `.csv` file
- [ ] Results banner shows imported/skipped counts and per-row errors