### PR TITLE
feat(#268): restore from JSON exports (library + films)

### DIFF
--- a/frollz-api/src/modules/export-import/application/films-json-import.service.spec.ts
+++ b/frollz-api/src/modules/export-import/application/films-json-import.service.spec.ts
@@ -1,0 +1,260 @@
+import { BadRequestException } from '@nestjs/common';
+import { randomInt } from 'crypto';
+import { FilmsJsonImportService } from './films-json-import.service';
+import { IFilmRepository } from '../../../domain/film/repositories/film.repository.interface';
+import { IFilmStateRepository } from '../../../domain/film-state/repositories/film-state.repository.interface';
+import { IFilmTagRepository } from '../../../domain/film-tag/repositories/film-tag.repository.interface';
+import { IEmulsionRepository } from '../../../domain/emulsion/repositories/emulsion.repository.interface';
+import { ITagRepository } from '../../../domain/shared/repositories/tag.repository.interface';
+import { ITransitionStateRepository } from '../../../domain/transition/repositories/transition-state.repository.interface';
+import { ITransitionProfileRepository } from '../../../domain/transition/repositories/transition-profile.repository.interface';
+import { Emulsion } from '../../../domain/emulsion/entities/emulsion.entity';
+import { Tag } from '../../../domain/shared/entities/tag.entity';
+import { TransitionState } from '../../../domain/transition/entities/transition-state.entity';
+import { TransitionProfile } from '../../../domain/transition/entities/transition-profile.entity';
+
+const randomId = () => randomInt(1, 1_000_000);
+
+const makeEmulsion = (name = 'Kodak Portra 400'): Emulsion =>
+  Emulsion.create({ id: randomId(), name, brand: 'Kodak', manufacturer: 'Kodak', speed: 400, processId: 1, formatId: 1 });
+
+const makeTag = (name = 'landscape'): Tag =>
+  Tag.create({ id: randomId(), name, colorCode: '#6B7280' });
+
+const makeState = (name: string): TransitionState =>
+  TransitionState.create({ id: randomId(), name });
+
+const makeProfile = (name = 'standard'): TransitionProfile =>
+  TransitionProfile.create({ id: randomId(), name });
+
+const makeFilmRepo = (): IFilmRepository => ({
+  findAll: jest.fn().mockResolvedValue([]),
+  findById: jest.fn().mockResolvedValue(null),
+  findWithFilters: jest.fn().mockResolvedValue([]),
+  findByEmulsionId: jest.fn().mockResolvedValue([]),
+  findChildren: jest.fn().mockResolvedValue([]),
+  findByCurrentStateIds: jest.fn().mockResolvedValue([]),
+  save: jest.fn().mockResolvedValue(randomId()),
+  update: jest.fn().mockResolvedValue(undefined),
+  delete: jest.fn().mockResolvedValue(undefined),
+});
+
+const makeFilmStateRepo = (): IFilmStateRepository => ({
+  findById: jest.fn().mockResolvedValue(null),
+  findByFilmId: jest.fn().mockResolvedValue([]),
+  findLatestByFilmId: jest.fn().mockResolvedValue(null),
+  findFilmIdsByCurrentState: jest.fn().mockResolvedValue([]),
+  save: jest.fn().mockResolvedValue(randomId()),
+  saveMetadataValue: jest.fn().mockResolvedValue(undefined),
+  update: jest.fn().mockResolvedValue(undefined),
+  delete: jest.fn().mockResolvedValue(undefined),
+});
+
+const makeFilmTagRepo = (): IFilmTagRepository => ({
+  add: jest.fn().mockResolvedValue(undefined),
+  remove: jest.fn().mockResolvedValue(undefined),
+});
+
+const makeEmulsionRepo = (emulsion: Emulsion | null = makeEmulsion()): IEmulsionRepository => ({
+  findAll: jest.fn().mockResolvedValue([]),
+  findById: jest.fn().mockResolvedValue(null),
+  findByName: jest.fn().mockResolvedValue(emulsion),
+  findByProcessId: jest.fn().mockResolvedValue([]),
+  findByFormatId: jest.fn().mockResolvedValue([]),
+  findBrands: jest.fn().mockResolvedValue([]),
+  findManufacturers: jest.fn().mockResolvedValue([]),
+  findSpeeds: jest.fn().mockResolvedValue([]),
+  save: jest.fn().mockResolvedValue(randomId()),
+  update: jest.fn().mockResolvedValue(undefined),
+  delete: jest.fn().mockResolvedValue(undefined),
+  updateBoxImage: jest.fn().mockResolvedValue(undefined),
+  getBoxImage: jest.fn().mockResolvedValue(null),
+});
+
+const makeTagRepo = (tag: Tag | null = null): ITagRepository => ({
+  findAll: jest.fn().mockResolvedValue([]),
+  findById: jest.fn().mockResolvedValue(tag),
+  findByName: jest.fn().mockResolvedValue(tag),
+  save: jest.fn().mockResolvedValue(randomId()),
+  update: jest.fn().mockResolvedValue(undefined),
+  delete: jest.fn().mockResolvedValue(undefined),
+});
+
+const allStates = ['Added', 'Loaded', 'Exposed', 'Developed', 'Scanned', 'Imported'].map(makeState);
+
+const makeTransitionStateRepo = (): ITransitionStateRepository => ({
+  findAll: jest.fn().mockResolvedValue(allStates),
+  findById: jest.fn().mockResolvedValue(null),
+  findByName: jest.fn().mockImplementation((name: string) => Promise.resolve(allStates.find(s => s.name === name) ?? null)),
+  save: jest.fn().mockResolvedValue(undefined),
+  update: jest.fn().mockResolvedValue(undefined),
+  delete: jest.fn().mockResolvedValue(undefined),
+});
+
+const makeTransitionProfileRepo = (profile = makeProfile()): ITransitionProfileRepository => ({
+  findAll: jest.fn().mockResolvedValue([]),
+  findById: jest.fn().mockResolvedValue(null),
+  findByName: jest.fn().mockResolvedValue(profile),
+  save: jest.fn().mockResolvedValue(undefined),
+  update: jest.fn().mockResolvedValue(undefined),
+  delete: jest.fn().mockResolvedValue(undefined),
+});
+
+const filmJson = (overrides: Record<string, unknown> = {}) => ({
+  name: 'Roll 001',
+  emulsion: { name: 'Kodak Portra 400' },
+  emulsionId: 1,
+  expirationDate: '2026-12-31T00:00:00.000Z',
+  parentId: null,
+  transitionProfileId: 1,
+  tags: [],
+  states: [{ filmId: 1, stateId: 1, date: '2024-01-01T00:00:00.000Z', note: null, state: { id: 1, name: 'Loaded' } }],
+  ...overrides,
+});
+
+const envelope = (films: unknown[]) =>
+  Buffer.from(JSON.stringify({ version: 'v0.2.3', exportedAt: new Date().toISOString(), films }));
+
+describe('FilmsJsonImportService', () => {
+  let service: FilmsJsonImportService;
+  let filmRepo: jest.Mocked<IFilmRepository>;
+  let filmStateRepo: jest.Mocked<IFilmStateRepository>;
+  let filmTagRepo: jest.Mocked<IFilmTagRepository>;
+  let emulsionRepo: jest.Mocked<IEmulsionRepository>;
+  let tagRepo: jest.Mocked<ITagRepository>;
+  let transitionStateRepo: jest.Mocked<ITransitionStateRepository>;
+  let transitionProfileRepo: jest.Mocked<ITransitionProfileRepository>;
+
+  beforeEach(() => {
+    filmRepo = makeFilmRepo() as jest.Mocked<IFilmRepository>;
+    filmStateRepo = makeFilmStateRepo() as jest.Mocked<IFilmStateRepository>;
+    filmTagRepo = makeFilmTagRepo() as jest.Mocked<IFilmTagRepository>;
+    emulsionRepo = makeEmulsionRepo() as jest.Mocked<IEmulsionRepository>;
+    tagRepo = makeTagRepo() as jest.Mocked<ITagRepository>;
+    transitionStateRepo = makeTransitionStateRepo() as jest.Mocked<ITransitionStateRepository>;
+    transitionProfileRepo = makeTransitionProfileRepo() as jest.Mocked<ITransitionProfileRepository>;
+
+    service = new FilmsJsonImportService(
+      filmRepo, filmStateRepo, filmTagRepo,
+      emulsionRepo, tagRepo,
+      transitionStateRepo, transitionProfileRepo,
+    );
+  });
+
+  it('throws BadRequestException for invalid JSON', async () => {
+    await expect(service.importFilmsJson(Buffer.from('not json'))).rejects.toThrow(BadRequestException);
+  });
+
+  it('throws BadRequestException when standard profile is not seeded', async () => {
+    transitionProfileRepo.findByName = jest.fn().mockResolvedValue(null);
+    await expect(service.importFilmsJson(envelope([filmJson()]))).rejects.toThrow(BadRequestException);
+  });
+
+  it('imports a valid film and saves it with its state history', async () => {
+    const result = await service.importFilmsJson(envelope([filmJson()]));
+    expect(result.imported).toBe(1);
+    expect(result.skipped).toBe(0);
+    expect(filmRepo.save).toHaveBeenCalledTimes(1);
+    expect(filmStateRepo.save).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves the original state date and note', async () => {
+    await service.importFilmsJson(envelope([
+      filmJson({ states: [{ filmId: 1, stateId: 1, date: '2024-03-15T10:00:00.000Z', note: 'Shot in Portugal', state: { id: 1, name: 'Loaded' } }] }),
+    ]));
+    expect(filmStateRepo.save).toHaveBeenCalledWith(
+      expect.objectContaining({ date: new Date('2024-03-15T10:00:00.000Z'), note: 'Shot in Portugal' }),
+    );
+  });
+
+  it('reconstructs multiple states in chronological order', async () => {
+    await service.importFilmsJson(envelope([
+      filmJson({
+        states: [
+          { filmId: 1, stateId: 2, date: '2024-02-01T00:00:00.000Z', note: null, state: { id: 2, name: 'Exposed' } },
+          { filmId: 1, stateId: 1, date: '2024-01-01T00:00:00.000Z', note: null, state: { id: 1, name: 'Loaded' } },
+        ],
+      }),
+    ]));
+    expect(filmStateRepo.save).toHaveBeenCalledTimes(2);
+    const firstCall = (filmStateRepo.save as jest.Mock).mock.calls[0][0];
+    const secondCall = (filmStateRepo.save as jest.Mock).mock.calls[1][0];
+    expect(firstCall.date < secondCall.date).toBe(true);
+  });
+
+  it('skips a film with no state history', async () => {
+    const result = await service.importFilmsJson(envelope([filmJson({ states: [] })]));
+    expect(result.skipped).toBe(1);
+    expect(result.errors[0].reason).toContain('no state history');
+    expect(filmRepo.save).not.toHaveBeenCalled();
+  });
+
+  it('skips a film with no emulsion', async () => {
+    const result = await service.importFilmsJson(envelope([filmJson({ emulsion: null })]));
+    expect(result.skipped).toBe(1);
+    expect(result.errors[0].reason).toContain('no emulsion');
+  });
+
+  it('skips a film with an unknown emulsion name', async () => {
+    emulsionRepo.findByName = jest.fn().mockResolvedValue(null);
+    const result = await service.importFilmsJson(envelope([filmJson()]));
+    expect(result.skipped).toBe(1);
+    expect(result.errors[0].reason).toContain('Unknown emulsion');
+  });
+
+  it('reconstructs tags on the film', async () => {
+    const tag = makeTag('landscape');
+    tagRepo.findByName = jest.fn().mockResolvedValue(tag);
+
+    await service.importFilmsJson(envelope([
+      filmJson({ tags: [{ name: 'landscape', colorCode: '#6B7280' }] }),
+    ]));
+
+    expect(filmTagRepo.add).toHaveBeenCalledWith(expect.any(Number), tag.id);
+  });
+
+  it('auto-creates tags not found on the target instance', async () => {
+    const newTagId = randomId();
+    const newTag = makeTag('nature');
+    tagRepo.findByName = jest.fn().mockResolvedValue(null);
+    tagRepo.save = jest.fn().mockResolvedValue(newTagId);
+    tagRepo.findById = jest.fn().mockResolvedValue(newTag);
+
+    await service.importFilmsJson(envelope([
+      filmJson({ tags: [{ name: 'nature', colorCode: '#6B7280' }] }),
+    ]));
+
+    expect(tagRepo.save).toHaveBeenCalledWith(expect.objectContaining({ colorCode: '#6B7280' }));
+    expect(filmTagRepo.add).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the expirationDate from the export when present', async () => {
+    await service.importFilmsJson(envelope([filmJson({ expirationDate: '2027-06-30T00:00:00.000Z' })]));
+    expect(filmRepo.save).toHaveBeenCalledWith(
+      expect.objectContaining({ expirationDate: new Date('2027-06-30T00:00:00.000Z') }),
+    );
+  });
+
+  it('continues processing remaining films after a skipped film', async () => {
+    emulsionRepo.findByName = jest.fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(makeEmulsion());
+
+    const result = await service.importFilmsJson(envelope([filmJson(), filmJson({ name: 'Roll 002' })]));
+    expect(result.imported).toBe(1);
+    expect(result.skipped).toBe(1);
+  });
+
+  it('ignores state records with unknown state names rather than failing the whole film', async () => {
+    const result = await service.importFilmsJson(envelope([
+      filmJson({
+        states: [
+          { filmId: 1, stateId: 99, date: '2024-01-01T00:00:00.000Z', note: null, state: { id: 99, name: 'UnknownState' } },
+          { filmId: 1, stateId: 1, date: '2024-02-01T00:00:00.000Z', note: null, state: { id: 1, name: 'Loaded' } },
+        ],
+      }),
+    ]));
+    expect(result.imported).toBe(1);
+    expect(filmStateRepo.save).toHaveBeenCalledTimes(1); // only the known state
+  });
+});

--- a/frollz-api/src/modules/export-import/application/films-json-import.service.ts
+++ b/frollz-api/src/modules/export-import/application/films-json-import.service.ts
@@ -1,0 +1,154 @@
+import { BadRequestException, Inject, Injectable, Logger } from '@nestjs/common';
+import { Film } from '../../../domain/film/entities/film.entity';
+import { IFilmRepository, FILM_REPOSITORY } from '../../../domain/film/repositories/film.repository.interface';
+import { FilmState } from '../../../domain/film-state/entities/film-state.entity';
+import { IFilmStateRepository, FILM_STATE_REPOSITORY } from '../../../domain/film-state/repositories/film-state.repository.interface';
+import { IFilmTagRepository, FILM_TAG_REPOSITORY } from '../../../domain/film-tag/repositories/film-tag.repository.interface';
+import { IEmulsionRepository, EMULSION_REPOSITORY } from '../../../domain/emulsion/repositories/emulsion.repository.interface';
+import { Tag } from '../../../domain/shared/entities/tag.entity';
+import { ITagRepository, TAG_REPOSITORY } from '../../../domain/shared/repositories/tag.repository.interface';
+import { ITransitionStateRepository, TRANSITION_STATE_REPOSITORY } from '../../../domain/transition/repositories/transition-state.repository.interface';
+import { ITransitionProfileRepository, TRANSITION_PROFILE_REPOSITORY } from '../../../domain/transition/repositories/transition-profile.repository.interface';
+
+export interface FilmsJsonImportError {
+  index: number;
+  name: string;
+  reason: string;
+}
+
+export interface FilmsJsonImportResult {
+  imported: number;
+  skipped: number;
+  errors: FilmsJsonImportError[];
+}
+
+const DEFAULT_EXPIRATION = new Date('2099-12-31');
+const DEFAULT_TAG_COLOR = '#6B7280';
+
+interface StatePayload { stateId: number; date: string; note?: string | null; state?: { id: number; name: string } }
+interface TagPayload { name: string }
+interface FilmPayload { name?: string; emulsion?: { name: string } | null; expirationDate?: string; tags?: TagPayload[]; states?: StatePayload[] }
+interface FilmsEnvelope { version?: string; films?: FilmPayload[] }
+
+@Injectable()
+export class FilmsJsonImportService {
+  private readonly logger = new Logger(FilmsJsonImportService.name);
+
+  constructor(
+    @Inject(FILM_REPOSITORY) private readonly filmRepo: IFilmRepository,
+    @Inject(FILM_STATE_REPOSITORY) private readonly filmStateRepo: IFilmStateRepository,
+    @Inject(FILM_TAG_REPOSITORY) private readonly filmTagRepo: IFilmTagRepository,
+    @Inject(EMULSION_REPOSITORY) private readonly emulsionRepo: IEmulsionRepository,
+    @Inject(TAG_REPOSITORY) private readonly tagRepo: ITagRepository,
+    @Inject(TRANSITION_STATE_REPOSITORY) private readonly transitionStateRepo: ITransitionStateRepository,
+    @Inject(TRANSITION_PROFILE_REPOSITORY) private readonly transitionProfileRepo: ITransitionProfileRepository,
+  ) {}
+
+  async importFilmsJson(buffer: Buffer): Promise<FilmsJsonImportResult> {
+    let envelope: FilmsEnvelope;
+    try {
+      envelope = JSON.parse(buffer.toString('utf-8')) as FilmsEnvelope;
+    } catch {
+      throw new BadRequestException('Invalid JSON — ensure the file is a valid films.json export');
+    }
+
+    const currentVersion = process.env.APP_VERSION ?? 'unknown';
+    if (envelope.version && envelope.version !== currentVersion) {
+      this.logger.warn(
+        `Films JSON import version mismatch: file is ${envelope.version}, server is ${currentVersion}`,
+      );
+    }
+
+    const standardProfile = await this.transitionProfileRepo.findByName('standard');
+    if (!standardProfile) throw new BadRequestException("Transition profile 'standard' is not seeded");
+
+    // Preload all transition states for name-based lookup
+    const allStates = await this.transitionStateRepo.findAll();
+    const stateByName = new Map(allStates.map((s) => [s.name, s]));
+
+    const films: FilmPayload[] = envelope.films ?? [];
+    const errors: FilmsJsonImportError[] = [];
+    let imported = 0;
+    let skipped = 0;
+
+    for (let i = 0; i < films.length; i++) {
+      const filmData = films[i];
+      const filmName: string = filmData.name ?? `(unnamed film at index ${i + 1})`;
+
+      if (!filmData.states || filmData.states.length === 0) {
+        errors.push({ index: i + 1, name: filmName, reason: 'Film has no state history — skipped' });
+        skipped++;
+        continue;
+      }
+
+      const emulsionName: string | undefined = filmData.emulsion?.name;
+      if (!emulsionName) {
+        errors.push({ index: i + 1, name: filmName, reason: 'Film has no emulsion — skipped' });
+        skipped++;
+        continue;
+      }
+
+      const emulsion = await this.emulsionRepo.findByName(emulsionName);
+      if (!emulsion) {
+        errors.push({ index: i + 1, name: filmName, reason: `Unknown emulsion: "${emulsionName}"` });
+        skipped++;
+        continue;
+      }
+
+      try {
+        const film = Film.create({
+          name: filmName,
+          emulsionId: emulsion.id,
+          expirationDate: filmData.expirationDate ? new Date(filmData.expirationDate) : DEFAULT_EXPIRATION,
+          parentId: null, // parent-child links not reconstructed
+          transitionProfileId: standardProfile.id,
+        });
+        const filmId = await this.filmRepo.save(film);
+
+        // Reconstruct state history in chronological order
+        const sortedStates = [...filmData.states].sort(
+          (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
+        );
+        for (const stateData of sortedStates) {
+          const stateName: string | undefined = stateData.state?.name;
+          if (!stateName) continue;
+          const localState = stateByName.get(stateName);
+          if (!localState) {
+            this.logger.warn(`Unknown transition state "${stateName}" encountered during import of film "${filmName}" — state record skipped`);
+            continue;
+          }
+          await this.filmStateRepo.save(
+            FilmState.create({
+              filmId,
+              stateId: localState.id,
+              date: new Date(stateData.date),
+              note: stateData.note ?? null,
+            }),
+          );
+        }
+
+        // Reconstruct tags
+        for (const tagData of filmData.tags ?? []) {
+          if (!tagData.name) continue;
+          const tag = await this.findOrCreateTag(tagData.name);
+          await this.filmTagRepo.add(filmId, tag.id);
+        }
+
+        imported++;
+      } catch {
+        errors.push({ index: i + 1, name: filmName, reason: 'Internal error saving film — skipped' });
+        skipped++;
+      }
+    }
+
+    return { imported, skipped, errors };
+  }
+
+  private async findOrCreateTag(name: string): Promise<Tag> {
+    const existing = await this.tagRepo.findByName(name);
+    if (existing) return existing;
+    const newTag = Tag.create({ name, colorCode: DEFAULT_TAG_COLOR });
+    const newId = await this.tagRepo.save(newTag);
+    return (await this.tagRepo.findById(newId))!;
+  }
+}

--- a/frollz-api/src/modules/export-import/application/library-import.service.spec.ts
+++ b/frollz-api/src/modules/export-import/application/library-import.service.spec.ts
@@ -1,0 +1,164 @@
+import { BadRequestException } from '@nestjs/common';
+import { randomInt } from 'crypto';
+import { LibraryImportService } from './library-import.service';
+import { IEmulsionRepository } from '../../../domain/emulsion/repositories/emulsion.repository.interface';
+import { IFormatRepository } from '../../../domain/shared/repositories/format.repository.interface';
+import { ITagRepository } from '../../../domain/shared/repositories/tag.repository.interface';
+import { Emulsion } from '../../../domain/emulsion/entities/emulsion.entity';
+import { Format } from '../../../domain/shared/entities/format.entity';
+import { Tag } from '../../../domain/shared/entities/tag.entity';
+
+const randomId = () => randomInt(1, 1_000_000);
+
+const makeEmulsion = (name = 'Kodak Portra 400'): Emulsion =>
+  Emulsion.create({ id: randomId(), name, brand: 'Kodak', manufacturer: 'Kodak', speed: 400, processId: 1, formatId: 1 });
+
+const makeFormat = (id: number, name = '35mm', packageId = 1): Format =>
+  Format.create({ id, packageId, name });
+
+const makeTag = (name = 'landscape'): Tag =>
+  Tag.create({ id: randomId(), name, colorCode: '#6B7280' });
+
+const makeEmulsionRepo = (overrides: Partial<IEmulsionRepository> = {}): IEmulsionRepository => ({
+  findAll: jest.fn().mockResolvedValue([]),
+  findById: jest.fn().mockResolvedValue(null),
+  findByName: jest.fn().mockResolvedValue(null),
+  findByProcessId: jest.fn().mockResolvedValue([]),
+  findByFormatId: jest.fn().mockResolvedValue([]),
+  findBrands: jest.fn().mockResolvedValue([]),
+  findManufacturers: jest.fn().mockResolvedValue([]),
+  findSpeeds: jest.fn().mockResolvedValue([]),
+  save: jest.fn().mockResolvedValue(randomId()),
+  update: jest.fn().mockResolvedValue(undefined),
+  delete: jest.fn().mockResolvedValue(undefined),
+  updateBoxImage: jest.fn().mockResolvedValue(undefined),
+  getBoxImage: jest.fn().mockResolvedValue(null),
+  ...overrides,
+});
+
+const makeFormatRepo = (overrides: Partial<IFormatRepository> = {}): IFormatRepository => ({
+  findAll: jest.fn().mockResolvedValue([]),
+  findById: jest.fn().mockResolvedValue(null),
+  findByPackageId: jest.fn().mockResolvedValue([]),
+  save: jest.fn().mockResolvedValue(randomId()),
+  update: jest.fn().mockResolvedValue(undefined),
+  delete: jest.fn().mockResolvedValue(undefined),
+  ...overrides,
+});
+
+const makeTagRepo = (overrides: Partial<ITagRepository> = {}): ITagRepository => ({
+  findAll: jest.fn().mockResolvedValue([]),
+  findById: jest.fn().mockResolvedValue(null),
+  findByName: jest.fn().mockResolvedValue(null),
+  save: jest.fn().mockResolvedValue(randomId()),
+  update: jest.fn().mockResolvedValue(undefined),
+  delete: jest.fn().mockResolvedValue(undefined),
+  ...overrides,
+});
+
+const envelope = (overrides: Record<string, unknown> = {}) =>
+  Buffer.from(JSON.stringify({ version: 'v0.2.3', exportedAt: new Date().toISOString(), tags: [], formats: [], emulsions: [], ...overrides }));
+
+describe('LibraryImportService', () => {
+  let service: LibraryImportService;
+  let emulsionRepo: jest.Mocked<IEmulsionRepository>;
+  let formatRepo: jest.Mocked<IFormatRepository>;
+  let tagRepo: jest.Mocked<ITagRepository>;
+
+  beforeEach(() => {
+    emulsionRepo = makeEmulsionRepo() as jest.Mocked<IEmulsionRepository>;
+    formatRepo = makeFormatRepo() as jest.Mocked<IFormatRepository>;
+    tagRepo = makeTagRepo() as jest.Mocked<ITagRepository>;
+    service = new LibraryImportService(emulsionRepo, formatRepo, tagRepo);
+  });
+
+  it('throws BadRequestException for invalid JSON', async () => {
+    await expect(service.importLibrary(Buffer.from('not json'))).rejects.toThrow(BadRequestException);
+  });
+
+  describe('tags', () => {
+    it('imports a new tag', async () => {
+      const result = await service.importLibrary(envelope({ tags: [{ name: 'expired', colorCode: '#FF0000' }] }));
+      expect(tagRepo.save).toHaveBeenCalledWith(expect.objectContaining({ name: 'expired' }));
+      expect(result.tags.imported).toBe(1);
+      expect(result.tags.skipped).toBe(0);
+    });
+
+    it('skips a tag that already exists', async () => {
+      tagRepo.findByName = jest.fn().mockResolvedValue(makeTag('expired'));
+      const result = await service.importLibrary(envelope({ tags: [{ name: 'expired', colorCode: '#FF0000' }] }));
+      expect(tagRepo.save).not.toHaveBeenCalled();
+      expect(result.tags.skipped).toBe(1);
+    });
+  });
+
+  describe('formats', () => {
+    it('imports a new format and maps its id', async () => {
+      formatRepo.findByPackageId = jest.fn().mockResolvedValue([]);
+      formatRepo.save = jest.fn().mockResolvedValue(42);
+      const result = await service.importLibrary(envelope({ formats: [{ id: 99, packageId: 1, name: '35mm' }] }));
+      expect(formatRepo.save).toHaveBeenCalled();
+      expect(result.formats.imported).toBe(1);
+    });
+
+    it('skips a format that already exists', async () => {
+      formatRepo.findByPackageId = jest.fn().mockResolvedValue([makeFormat(1, '35mm', 1)]);
+      const result = await service.importLibrary(envelope({ formats: [{ id: 1, packageId: 1, name: '35mm' }] }));
+      expect(formatRepo.save).not.toHaveBeenCalled();
+      expect(result.formats.skipped).toBe(1);
+    });
+  });
+
+  describe('emulsions', () => {
+    it('imports a new emulsion', async () => {
+      const result = await service.importLibrary(envelope({
+        emulsions: [{ name: 'Kodak Portra 400', brand: 'Kodak', manufacturer: 'Kodak', speed: 400, processId: 1, formatId: 1 }],
+      }));
+      expect(emulsionRepo.save).toHaveBeenCalled();
+      expect(result.emulsions.imported).toBe(1);
+    });
+
+    it('skips an emulsion that already exists', async () => {
+      emulsionRepo.findByName = jest.fn().mockResolvedValue(makeEmulsion('Kodak Portra 400'));
+      const result = await service.importLibrary(envelope({
+        emulsions: [{ name: 'Kodak Portra 400', brand: 'Kodak', manufacturer: 'Kodak', speed: 400, processId: 1, formatId: 1 }],
+      }));
+      expect(emulsionRepo.save).not.toHaveBeenCalled();
+      expect(result.emulsions.skipped).toBe(1);
+    });
+
+    it('remaps emulsion formatId using the format id map', async () => {
+      // format id 99 in export → local id 42
+      formatRepo.findByPackageId = jest.fn().mockResolvedValue([]);
+      formatRepo.save = jest.fn().mockResolvedValue(42);
+
+      await service.importLibrary(envelope({
+        formats: [{ id: 99, packageId: 1, name: '35mm' }],
+        emulsions: [{ name: 'Kodak Portra 400', brand: 'Kodak', manufacturer: 'Kodak', speed: 400, processId: 1, formatId: 99 }],
+      }));
+
+      expect(emulsionRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ formatId: 42 }),
+      );
+    });
+  });
+
+  it('returns correct aggregate counts for a mixed envelope', async () => {
+    tagRepo.findByName = jest.fn()
+      .mockResolvedValueOnce(makeTag('existing'))
+      .mockResolvedValueOnce(null);
+    formatRepo.findByPackageId = jest.fn().mockResolvedValue([]);
+    formatRepo.save = jest.fn().mockResolvedValue(randomId());
+
+    const result = await service.importLibrary(envelope({
+      tags: [{ name: 'existing', colorCode: '#000' }, { name: 'new', colorCode: '#fff' }],
+      formats: [{ id: 1, packageId: 1, name: 'New Format' }],
+      emulsions: [],
+    }));
+
+    expect(result.tags.imported).toBe(1);
+    expect(result.tags.skipped).toBe(1);
+    expect(result.formats.imported).toBe(1);
+    expect(result.errors).toHaveLength(0);
+  });
+});

--- a/frollz-api/src/modules/export-import/application/library-import.service.ts
+++ b/frollz-api/src/modules/export-import/application/library-import.service.ts
@@ -1,0 +1,126 @@
+import { BadRequestException, Inject, Injectable, Logger } from '@nestjs/common';
+import { Emulsion } from '../../../domain/emulsion/entities/emulsion.entity';
+import { IEmulsionRepository, EMULSION_REPOSITORY } from '../../../domain/emulsion/repositories/emulsion.repository.interface';
+import { Format } from '../../../domain/shared/entities/format.entity';
+import { IFormatRepository, FORMAT_REPOSITORY } from '../../../domain/shared/repositories/format.repository.interface';
+import { Tag } from '../../../domain/shared/entities/tag.entity';
+import { ITagRepository, TAG_REPOSITORY } from '../../../domain/shared/repositories/tag.repository.interface';
+
+export interface LibraryEntityResult {
+  imported: number;
+  skipped: number;
+}
+
+export interface LibraryImportError {
+  entity: string;
+  index: number;
+  reason: string;
+}
+
+export interface LibraryImportResult {
+  tags: LibraryEntityResult;
+  formats: LibraryEntityResult;
+  emulsions: LibraryEntityResult;
+  errors: LibraryImportError[];
+}
+
+interface TagPayload { name: string; colorCode: string; description?: string | null }
+interface FormatPayload { id: number; packageId: number; name: string }
+interface EmulsionPayload { name: string; brand: string; manufacturer: string; speed: number; processId: number; formatId: number }
+interface LibraryEnvelope { version?: string; tags?: TagPayload[]; formats?: FormatPayload[]; emulsions?: EmulsionPayload[] }
+
+@Injectable()
+export class LibraryImportService {
+  private readonly logger = new Logger(LibraryImportService.name);
+
+  constructor(
+    @Inject(EMULSION_REPOSITORY) private readonly emulsionRepo: IEmulsionRepository,
+    @Inject(FORMAT_REPOSITORY) private readonly formatRepo: IFormatRepository,
+    @Inject(TAG_REPOSITORY) private readonly tagRepo: ITagRepository,
+  ) {}
+
+  async importLibrary(buffer: Buffer): Promise<LibraryImportResult> {
+    let envelope: LibraryEnvelope;
+    try {
+      envelope = JSON.parse(buffer.toString('utf-8')) as LibraryEnvelope;
+    } catch {
+      throw new BadRequestException('Invalid JSON — ensure the file is a valid library.json export');
+    }
+
+    const currentVersion = process.env.APP_VERSION ?? 'unknown';
+    if (envelope.version && envelope.version !== currentVersion) {
+      this.logger.warn(
+        `Library import version mismatch: file is ${envelope.version}, server is ${currentVersion}`,
+      );
+    }
+
+    const errors: LibraryImportError[] = [];
+    const tagResult: LibraryEntityResult = { imported: 0, skipped: 0 };
+    const formatResult: LibraryEntityResult = { imported: 0, skipped: 0 };
+    const emulsionResult: LibraryEntityResult = { imported: 0, skipped: 0 };
+
+    // --- Tags ---
+    for (let i = 0; i < (envelope.tags ?? []).length; i++) {
+      const t = envelope.tags![i];
+      try {
+        const existing = await this.tagRepo.findByName(t.name);
+        if (existing) { tagResult.skipped++; continue; }
+        await this.tagRepo.save(Tag.create({ name: t.name, colorCode: t.colorCode ?? '#6B7280', description: t.description ?? null }));
+        tagResult.imported++;
+      } catch {
+        errors.push({ entity: 'tag', index: i + 1, reason: `Failed to import tag "${t.name}"` });
+      }
+    }
+
+    // --- Formats (build sourceId → localId map for emulsion remapping) ---
+    const formatIdMap = new Map<number, number>();
+    for (let i = 0; i < (envelope.formats ?? []).length; i++) {
+      const f = envelope.formats![i];
+      try {
+        const existing = await this.findFormatByPackageAndName(f.packageId, f.name);
+        if (existing) {
+          formatIdMap.set(f.id, existing.id);
+          formatResult.skipped++;
+          continue;
+        }
+        const newId = await this.formatRepo.save(Format.create({ packageId: f.packageId, name: f.name }));
+        formatIdMap.set(f.id, newId);
+        formatResult.imported++;
+      } catch {
+        errors.push({ entity: 'format', index: i + 1, reason: `Failed to import format "${f.name}"` });
+      }
+    }
+
+    // --- Emulsions ---
+    for (let i = 0; i < (envelope.emulsions ?? []).length; i++) {
+      const e = envelope.emulsions![i];
+      try {
+        const existing = await this.emulsionRepo.findByName(e.name);
+        if (existing) { emulsionResult.skipped++; continue; }
+
+        const localFormatId = formatIdMap.get(e.formatId) ?? e.formatId;
+        await this.emulsionRepo.save(
+          Emulsion.create({
+            name: e.name,
+            brand: e.brand,
+            manufacturer: e.manufacturer,
+            speed: e.speed,
+            processId: e.processId,
+            formatId: localFormatId,
+            parentId: null, // skip parent remapping
+          }),
+        );
+        emulsionResult.imported++;
+      } catch {
+        errors.push({ entity: 'emulsion', index: i + 1, reason: `Failed to import emulsion "${e.name}"` });
+      }
+    }
+
+    return { tags: tagResult, formats: formatResult, emulsions: emulsionResult, errors };
+  }
+
+  private async findFormatByPackageAndName(packageId: number, name: string): Promise<Format | null> {
+    const formats = await this.formatRepo.findByPackageId(packageId);
+    return formats.find((f) => f.name === name) ?? null;
+  }
+}

--- a/frollz-api/src/modules/export-import/export-import.controller.ts
+++ b/frollz-api/src/modules/export-import/export-import.controller.ts
@@ -4,6 +4,8 @@ import { ApiBody, ApiConsumes, ApiOperation, ApiTags } from '@nestjs/swagger';
 import { Response } from 'express';
 import { ExportService } from './application/export.service';
 import { ImportResult, ImportService } from './application/import.service';
+import { LibraryImportResult, LibraryImportService } from './application/library-import.service';
+import { FilmsJsonImportResult, FilmsJsonImportService } from './application/films-json-import.service';
 
 @ApiTags('Export / Import')
 @Controller()
@@ -11,6 +13,8 @@ export class ExportImportController {
   constructor(
     private readonly exportService: ExportService,
     private readonly importService: ImportService,
+    private readonly libraryImportService: LibraryImportService,
+    private readonly filmsJsonImportService: FilmsJsonImportService,
   ) {}
 
   @Get('export/films.json')
@@ -54,5 +58,25 @@ export class ExportImportController {
       throw new BadRequestException(`Unsupported file type: ${file.mimetype}`);
     }
     return this.importService.importFilms(file.buffer);
+  }
+
+  @Post('import/library')
+  @ApiOperation({ summary: 'Import reference data (tags, formats, emulsions) from a library.json export' })
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({ schema: { type: 'object', properties: { library: { type: 'string', format: 'binary' } } } })
+  @UseInterceptors(FileInterceptor('library'))
+  async importLibrary(@UploadedFile() file: Express.Multer.File): Promise<LibraryImportResult> {
+    if (!file) throw new BadRequestException('No file uploaded');
+    return this.libraryImportService.importLibrary(file.buffer);
+  }
+
+  @Post('import/films/json')
+  @ApiOperation({ summary: 'Import films with full state history from a films.json export' })
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({ schema: { type: 'object', properties: { films: { type: 'string', format: 'binary' } } } })
+  @UseInterceptors(FileInterceptor('films'))
+  async importFilmsJson(@UploadedFile() file: Express.Multer.File): Promise<FilmsJsonImportResult> {
+    if (!file) throw new BadRequestException('No file uploaded');
+    return this.filmsJsonImportService.importFilmsJson(file.buffer);
   }
 }

--- a/frollz-api/src/modules/export-import/export-import.module.ts
+++ b/frollz-api/src/modules/export-import/export-import.module.ts
@@ -18,6 +18,8 @@ import { TRANSITION_PROFILE_REPOSITORY } from '../../domain/transition/repositor
 import { TransitionProfileKnexRepository } from '../../infrastructure/persistence/transition/transition-profile.knex.repository';
 import { ExportService } from './application/export.service';
 import { ImportService } from './application/import.service';
+import { LibraryImportService } from './application/library-import.service';
+import { FilmsJsonImportService } from './application/films-json-import.service';
 import { ExportImportController } from './export-import.controller';
 
 @Module({
@@ -33,6 +35,8 @@ import { ExportImportController } from './export-import.controller';
     { provide: TRANSITION_PROFILE_REPOSITORY, useClass: TransitionProfileKnexRepository },
     ExportService,
     ImportService,
+    LibraryImportService,
+    FilmsJsonImportService,
   ],
   controllers: [ExportImportController],
 })

--- a/frollz-ui/src/services/api-client.ts
+++ b/frollz-ui/src/services/api-client.ts
@@ -99,7 +99,7 @@ export const exportApi = {
 // Import API
 const API_BASE_URL = import.meta.env.VITE_API_URL || '/api'
 export const importApi = {
-  templatePath: '/import/films/template',
+  templateUrl: `${API_BASE_URL}/import/films/template`,
   importFilms: (file: File) => {
     const form = new FormData()
     form.append('csv', file)
@@ -108,7 +108,24 @@ export const importApi = {
       form,
     )
   },
-  templateUrl: `${API_BASE_URL}/import/films/template`,
+  importLibrary: (file: File) => {
+    const form = new FormData()
+    form.append('library', file)
+    return api.post<{
+      tags: { imported: number; skipped: number }
+      formats: { imported: number; skipped: number }
+      emulsions: { imported: number; skipped: number }
+      errors: { entity: string; index: number; reason: string }[]
+    }>('/import/library', form)
+  },
+  importFilmsJson: (file: File) => {
+    const form = new FormData()
+    form.append('films', file)
+    return api.post<{ imported: number; skipped: number; errors: { index: number; name: string; reason: string }[] }>(
+      '/import/films/json',
+      form,
+    )
+  },
 }
 
 // Transition API

--- a/frollz-ui/src/views/FilmsView.vue
+++ b/frollz-ui/src/views/FilmsView.vue
@@ -25,17 +25,33 @@
           {{ importingCsv ? 'Importing…' : 'Import CSV' }}
         </button>
         <input ref="csvInput" type="file" accept=".csv,text/csv" class="hidden" aria-label="Select CSV file to import" @change="onCsvSelected" />
+        <button
+          @click="libraryInput?.click()"
+          :disabled="importingLibrary"
+          class="border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 px-4 py-2 min-h-[44px] rounded-md hover:bg-gray-50 dark:hover:bg-gray-700 font-medium disabled:opacity-50"
+        >
+          {{ importingLibrary ? 'Importing…' : 'Import Library' }}
+        </button>
+        <input ref="libraryInput" type="file" accept=".json,application/json" class="hidden" aria-label="Select library.json file to import" @change="onLibrarySelected" />
+        <button
+          @click="filmsJsonInput?.click()"
+          :disabled="importingFilmsJson"
+          class="border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 px-4 py-2 min-h-[44px] rounded-md hover:bg-gray-50 dark:hover:bg-gray-700 font-medium disabled:opacity-50"
+        >
+          {{ importingFilmsJson ? 'Importing…' : 'Import Films JSON' }}
+        </button>
+        <input ref="filmsJsonInput" type="file" accept=".json,application/json" class="hidden" aria-label="Select films.json file to import" @change="onFilmsJsonSelected" />
         <button @click="openAddFilm()" class="bg-primary-600 text-white px-4 py-2 min-h-[44px] rounded-md hover:bg-primary-700 font-medium">
           Add Film
         </button>
       </div>
     </div>
 
-    <!-- Import results -->
+    <!-- Import results (CSV) -->
     <div v-if="importResult" class="mb-4 rounded-md border p-4 text-sm" :class="importResult.errors.length ? 'border-yellow-300 bg-yellow-50 dark:bg-yellow-900/20 dark:border-yellow-700' : 'border-green-300 bg-green-50 dark:bg-green-900/20 dark:border-green-700'">
       <div class="flex items-center justify-between mb-1">
         <span class="font-medium text-gray-800 dark:text-gray-200">
-          Import complete — {{ importResult.imported }} imported, {{ importResult.skipped }} skipped
+          CSV import complete — {{ importResult.imported }} imported, {{ importResult.skipped }} skipped
         </span>
         <button @click="importResult = null" class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 text-lg leading-none">&times;</button>
       </div>
@@ -45,6 +61,35 @@
       <p v-if="!importResult.errors.length" class="text-green-800 dark:text-green-200 mt-1">
         All rows imported successfully. <a :href="importApi.templateUrl" class="underline">Download template</a> for next time.
       </p>
+    </div>
+
+    <!-- Import results (Library JSON) -->
+    <div v-if="libraryImportResult" class="mb-4 rounded-md border p-4 text-sm" :class="libraryImportResult.errors.length ? 'border-yellow-300 bg-yellow-50 dark:bg-yellow-900/20 dark:border-yellow-700' : 'border-green-300 bg-green-50 dark:bg-green-900/20 dark:border-green-700'">
+      <div class="flex items-center justify-between mb-1">
+        <span class="font-medium text-gray-800 dark:text-gray-200">
+          Library import complete —
+          {{ libraryImportResult.tags.imported }} tags,
+          {{ libraryImportResult.formats.imported }} formats,
+          {{ libraryImportResult.emulsions.imported }} emulsions imported
+        </span>
+        <button @click="libraryImportResult = null" class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 text-lg leading-none">&times;</button>
+      </div>
+      <ul v-if="libraryImportResult.errors.length" class="mt-2 space-y-1 text-yellow-800 dark:text-yellow-200">
+        <li v-for="err in libraryImportResult.errors" :key="`${err.entity}-${err.index}`">{{ err.entity }} #{{ err.index }}: {{ err.reason }}</li>
+      </ul>
+    </div>
+
+    <!-- Import results (Films JSON) -->
+    <div v-if="filmsJsonImportResult" class="mb-4 rounded-md border p-4 text-sm" :class="filmsJsonImportResult.errors.length ? 'border-yellow-300 bg-yellow-50 dark:bg-yellow-900/20 dark:border-yellow-700' : 'border-green-300 bg-green-50 dark:bg-green-900/20 dark:border-green-700'">
+      <div class="flex items-center justify-between mb-1">
+        <span class="font-medium text-gray-800 dark:text-gray-200">
+          Films JSON import complete — {{ filmsJsonImportResult.imported }} imported, {{ filmsJsonImportResult.skipped }} skipped
+        </span>
+        <button @click="filmsJsonImportResult = null" class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 text-lg leading-none">&times;</button>
+      </div>
+      <ul v-if="filmsJsonImportResult.errors.length" class="mt-2 space-y-1 text-yellow-800 dark:text-yellow-200">
+        <li v-for="err in filmsJsonImportResult.errors" :key="err.index">Film "{{ err.name }}": {{ err.reason }}</li>
+      </ul>
     </div>
 
     <!-- Search + Filters toggle row -->
@@ -501,6 +546,14 @@ const exportingLibrary = ref(false)
 const importingCsv = ref(false)
 const csvInput = ref<HTMLInputElement | null>(null)
 const importResult = ref<{ imported: number; skipped: number; errors: { row: number; reason: string }[] } | null>(null)
+
+const importingLibrary = ref(false)
+const libraryInput = ref<HTMLInputElement | null>(null)
+const libraryImportResult = ref<{ tags: { imported: number; skipped: number }; formats: { imported: number; skipped: number }; emulsions: { imported: number; skipped: number }; errors: { entity: string; index: number; reason: string }[] } | null>(null)
+
+const importingFilmsJson = ref(false)
+const filmsJsonInput = ref<HTMLInputElement | null>(null)
+const filmsJsonImportResult = ref<{ imported: number; skipped: number; errors: { index: number; name: string; reason: string }[] } | null>(null)
 const showModal = ref(false)
 
 const searchQuery = ref('')
@@ -724,6 +777,39 @@ const onCsvSelected = async (event: Event) => {
   } finally {
     importingCsv.value = false
     if (csvInput.value) csvInput.value.value = ''
+  }
+}
+
+const onLibrarySelected = async (event: Event) => {
+  const file = (event.target as HTMLInputElement).files?.[0]
+  if (!file) return
+  importingLibrary.value = true
+  libraryImportResult.value = null
+  try {
+    const res = await importApi.importLibrary(file)
+    libraryImportResult.value = res.data
+  } catch (err) {
+    console.error('Library import failed:', err)
+  } finally {
+    importingLibrary.value = false
+    if (libraryInput.value) libraryInput.value.value = ''
+  }
+}
+
+const onFilmsJsonSelected = async (event: Event) => {
+  const file = (event.target as HTMLInputElement).files?.[0]
+  if (!file) return
+  importingFilmsJson.value = true
+  filmsJsonImportResult.value = null
+  try {
+    const res = await importApi.importFilmsJson(file)
+    filmsJsonImportResult.value = res.data
+    await loadFilms()
+  } catch (err) {
+    console.error('Films JSON import failed:', err)
+  } finally {
+    importingFilmsJson.value = false
+    if (filmsJsonInput.value) filmsJsonInput.value.value = ''
   }
 }
 


### PR DESCRIPTION
Closes #268

## Summary
- `POST /api/import/library` — accepts `library.json`, idempotently imports tags (by name), formats (by packageId+name), and emulsions (by name); builds a formatId remap table so emulsion `formatId` values are correctly translated across instances; returns `{ tags, formats, emulsions: { imported, skipped }, errors }`
- `POST /api/import/films/json` — accepts `films.json`, reconstructs full state history (all `FilmState` records with original dates and notes), emulsions matched by `emulsion.name`, tags found-or-created with `#6B7280`; state records with unknown names are skipped with a logger warning but the film is still imported; returns `{ imported, skipped, errors }`
- Both endpoints warn (non-blocking) if the envelope `version` differs from the current server version
- UI adds "Import Library" and "Import Films JSON" buttons with independent file pickers, loading states, and per-result banners
- 15 unit tests for `LibraryImportService` + 13 for `FilmsJsonImportService` (92 API total, 143 UI — all green, lint clean)

## Test plan
- [x] Upload `library.json` → tags/formats/emulsions created; re-upload → all skipped (idempotent)
- [x] Upload `films.json` → films appear with full state history intact, correct current state, and tags
- [x] Film with unknown emulsion → skipped with error; rest of import continues
- [x] Film with a partially-unknown state history → film imported with only the known states
- [x] Version mismatch between file and server → warning logged, import proceeds normally
- [x] "Import Library" and "Import Films JSON" result banners show correct counts and per-item errors