### PR TITLE
feat(#139): Statistics & Reporting

### DIFF
--- a/frollz-api/src/app.module.ts
+++ b/frollz-api/src/app.module.ts
@@ -8,6 +8,7 @@ import { FilmModule } from './modules/film/film.module';
 import { FilmStateModule } from './modules/film-state/film-state.module';
 import { TransitionModule } from './modules/transition/transition.module';
 import { ExportImportModule } from './modules/export-import/export-import.module';
+import { FilmStatsModule } from './modules/film-stats/film-stats.module';
 
 @Module({
   imports: [
@@ -19,6 +20,7 @@ import { ExportImportModule } from './modules/export-import/export-import.module
     FilmStateModule,
     TransitionModule,
     ExportImportModule,
+    FilmStatsModule,
   ],
   providers: [{ provide: APP_GUARD, useClass: ThrottlerGuard }],
 })

--- a/frollz-api/src/domain/film-stats/repositories/film-stats.repository.interface.ts
+++ b/frollz-api/src/domain/film-stats/repositories/film-stats.repository.interface.ts
@@ -1,0 +1,28 @@
+export interface StateCount {
+  state: string;
+  count: number;
+}
+
+export interface MonthCount {
+  month: string;
+  count: number;
+}
+
+export interface EmulsionCount {
+  emulsionName: string;
+  count: number;
+}
+
+export interface TransitionDuration {
+  transition: string;
+  avgDays: number | null;
+}
+
+export const FILM_STATS_REPOSITORY = 'FILM_STATS_REPOSITORY';
+
+export interface IFilmStatsRepository {
+  countByCurrentState(): Promise<StateCount[]>;
+  countByFirstStateMonth(months: number): Promise<MonthCount[]>;
+  countByEmulsion(): Promise<EmulsionCount[]>;
+  avgTransitionDurations(): Promise<TransitionDuration[]>;
+}

--- a/frollz-api/src/infrastructure/persistence/film-stats/film-stats.knex.repository.ts
+++ b/frollz-api/src/infrastructure/persistence/film-stats/film-stats.knex.repository.ts
@@ -1,0 +1,114 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { Knex } from 'knex';
+import {
+  EmulsionCount,
+  IFilmStatsRepository,
+  MonthCount,
+  StateCount,
+  TransitionDuration,
+} from '../../../domain/film-stats/repositories/film-stats.repository.interface';
+import { KNEX_CONNECTION } from '../knex.provider';
+
+@Injectable()
+export class FilmStatsKnexRepository implements IFilmStatsRepository {
+  constructor(@Inject(KNEX_CONNECTION) private readonly knex: Knex) {}
+
+  async countByCurrentState(): Promise<StateCount[]> {
+    const rows = await this.knex('transition_state as ts')
+      .leftJoin(
+        this.knex('film_state as fs')
+          .select('fs.film_id', 'fs.state_id')
+          .whereRaw('fs.id = (SELECT MAX(id) FROM film_state fs2 WHERE fs2.film_id = fs.film_id)')
+          .as('sub'),
+        'sub.state_id',
+        'ts.id',
+      )
+      .groupBy('ts.id', 'ts.name')
+      .orderBy('ts.name')
+      .select('ts.name as state', this.knex.raw('COUNT(sub.film_id) as count'));
+
+    return rows.map((r: { state: string; count: string | number }) => ({
+      state: r.state,
+      count: Number(r.count),
+    }));
+  }
+
+  async countByFirstStateMonth(months: number): Promise<MonthCount[]> {
+    const isPostgres = this.isPostgres();
+    const monthExpr = isPostgres ? `to_char(first_date, 'YYYY-MM')` : `strftime('%Y-%m', first_date)`;
+    const cutoff = isPostgres
+      ? this.knex.raw(`NOW() - INTERVAL '${months} months'`)
+      : this.knex.raw(`datetime('now', '-${months} months')`);
+
+    const rows = await this.knex
+      .from(
+        this.knex('film_state').select('film_id').min('date as first_date').groupBy('film_id').as('first_states'),
+      )
+      .where('first_date', '>=', cutoff)
+      .groupByRaw(monthExpr)
+      .orderBy('month')
+      .select(this.knex.raw(`${monthExpr} as month`), this.knex.raw('COUNT(*) as count'));
+
+    return rows.map((r: { month: string; count: string | number }) => ({
+      month: r.month,
+      count: Number(r.count),
+    }));
+  }
+
+  async countByEmulsion(): Promise<EmulsionCount[]> {
+    const rows = await this.knex('film as f')
+      .join('emulsion as e', 'e.id', 'f.emulsion_id')
+      .groupBy('e.id', 'e.brand', 'e.name')
+      .orderByRaw('COUNT(f.id) DESC')
+      .select(this.knex.raw(`e.brand || ' ' || e.name as emulsion_name`), this.knex.raw('COUNT(f.id) as count'));
+
+    return rows.map((r: { emulsion_name: string; count: string | number }) => ({
+      emulsionName: r.emulsion_name,
+      count: Number(r.count),
+    }));
+  }
+
+  async avgTransitionDurations(): Promise<TransitionDuration[]> {
+    const dayDiff = this.isPostgres()
+      ? `EXTRACT(EPOCH FROM (CAST(fs2.date AS TIMESTAMP) - CAST(fs1.date AS TIMESTAMP))) / 86400`
+      : `(julianday(fs2.date) - julianday(fs1.date))`;
+
+    const raw = await this.knex.raw<{ rows?: RawDurationRow[]; [0]: RawDurationRow[] }>(`
+      SELECT
+        ts1.name || ' → ' || ts2.name AS transition,
+        CASE WHEN COUNT(*) >= 2 THEN AVG(day_diff) ELSE NULL END AS avg_days
+      FROM (
+        SELECT
+          fs1.state_id AS from_state_id,
+          fs2.state_id AS to_state_id,
+          ${dayDiff} AS day_diff
+        FROM film_state fs1
+        JOIN film_state fs2
+          ON fs2.film_id = fs1.film_id
+          AND fs2.id = (
+            SELECT MIN(id) FROM film_state
+            WHERE film_id = fs1.film_id AND id > fs1.id
+          )
+      ) pairs
+      JOIN transition_state ts1 ON ts1.id = pairs.from_state_id
+      JOIN transition_state ts2 ON ts2.id = pairs.to_state_id
+      GROUP BY pairs.from_state_id, pairs.to_state_id, ts1.name, ts2.name
+      ORDER BY ts1.name, ts2.name
+    `);
+
+    const rows: RawDurationRow[] = this.isPostgres() ? (raw as any).rows : (raw as any);
+    return rows.map((r) => ({
+      transition: r.transition,
+      avgDays: r.avg_days !== null && r.avg_days !== undefined ? Number(r.avg_days) : null,
+    }));
+  }
+
+  private isPostgres(): boolean {
+    return (this.knex as any).client?.config?.client === 'pg';
+  }
+}
+
+interface RawDurationRow {
+  transition: string;
+  avg_days: number | null;
+}

--- a/frollz-api/src/modules/film-stats/application/film-stats.service.ts
+++ b/frollz-api/src/modules/film-stats/application/film-stats.service.ts
@@ -1,0 +1,30 @@
+import { Inject, Injectable } from '@nestjs/common';
+import {
+  EmulsionCount,
+  FILM_STATS_REPOSITORY,
+  IFilmStatsRepository,
+  MonthCount,
+  StateCount,
+  TransitionDuration,
+} from '../../../domain/film-stats/repositories/film-stats.repository.interface';
+
+@Injectable()
+export class FilmStatsService {
+  constructor(@Inject(FILM_STATS_REPOSITORY) private readonly statsRepo: IFilmStatsRepository) {}
+
+  countByCurrentState(): Promise<StateCount[]> {
+    return this.statsRepo.countByCurrentState();
+  }
+
+  countByFirstStateMonth(months: number): Promise<MonthCount[]> {
+    return this.statsRepo.countByFirstStateMonth(months);
+  }
+
+  countByEmulsion(): Promise<EmulsionCount[]> {
+    return this.statsRepo.countByEmulsion();
+  }
+
+  avgTransitionDurations(): Promise<TransitionDuration[]> {
+    return this.statsRepo.avgTransitionDurations();
+  }
+}

--- a/frollz-api/src/modules/film-stats/film-stats.controller.ts
+++ b/frollz-api/src/modules/film-stats/film-stats.controller.ts
@@ -1,0 +1,38 @@
+import { BadRequestException, Controller, Get, Query } from '@nestjs/common';
+import { ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { FilmStatsService } from './application/film-stats.service';
+
+@ApiTags('Film Stats')
+@Controller('films/stats')
+export class FilmStatsController {
+  constructor(private readonly filmStatsService: FilmStatsService) {}
+
+  @Get('by-state')
+  @ApiOperation({ summary: 'Film count grouped by current transition state' })
+  byState() {
+    return this.filmStatsService.countByCurrentState();
+  }
+
+  @Get('by-month')
+  @ApiOperation({ summary: 'Film count grouped by month of first state transition' })
+  @ApiQuery({ name: 'months', required: false, type: Number, description: 'Number of months to look back (default 12)' })
+  byMonth(@Query('months') rawMonths?: string) {
+    const months = rawMonths !== undefined ? parseInt(rawMonths, 10) : 12;
+    if (isNaN(months) || months < 1 || months > 120) {
+      throw new BadRequestException('months must be a number between 1 and 120');
+    }
+    return this.filmStatsService.countByFirstStateMonth(months);
+  }
+
+  @Get('by-emulsion')
+  @ApiOperation({ summary: 'Film count grouped by emulsion' })
+  byEmulsion() {
+    return this.filmStatsService.countByEmulsion();
+  }
+
+  @Get('lifecycle-durations')
+  @ApiOperation({ summary: 'Average days between consecutive state transitions' })
+  lifecycleDurations() {
+    return this.filmStatsService.avgTransitionDurations();
+  }
+}

--- a/frollz-api/src/modules/film-stats/film-stats.module.ts
+++ b/frollz-api/src/modules/film-stats/film-stats.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { DatabaseModule } from '../../infrastructure/persistence/database.module';
+import { FILM_STATS_REPOSITORY } from '../../domain/film-stats/repositories/film-stats.repository.interface';
+import { FilmStatsKnexRepository } from '../../infrastructure/persistence/film-stats/film-stats.knex.repository';
+import { FilmStatsService } from './application/film-stats.service';
+import { FilmStatsController } from './film-stats.controller';
+
+@Module({
+  imports: [DatabaseModule],
+  providers: [
+    { provide: FILM_STATS_REPOSITORY, useClass: FilmStatsKnexRepository },
+    FilmStatsService,
+  ],
+  controllers: [FilmStatsController],
+})
+export class FilmStatsModule {}

--- a/frollz-ui/src/components/NavBar.vue
+++ b/frollz-ui/src/components/NavBar.vue
@@ -117,6 +117,7 @@ const navLinks = [
   { to: '/emulsions', name: 'emulsions', label: 'Emulsions' },
   { to: '/films', name: 'films', label: 'Films' },
   { to: '/tags', name: 'tags', label: 'Tags' },
+  { to: '/stats', name: 'stats', label: 'Statistics' },
 ] as const
 
 const menuOpen = ref(false)

--- a/frollz-ui/src/router/index.ts
+++ b/frollz-ui/src/router/index.ts
@@ -38,6 +38,12 @@ const router = createRouter({
       name: 'tags',
       component: () => import('@/views/TagsView.vue'),
       meta: { title: 'Tags' }
+    },
+    {
+      path: '/stats',
+      name: 'stats',
+      component: () => import('@/views/StatsView.vue'),
+      meta: { title: 'Statistics' }
     }
   ]
 })

--- a/frollz-ui/src/services/api-client.ts
+++ b/frollz-ui/src/services/api-client.ts
@@ -1,5 +1,5 @@
 import { api } from './api'
-import type { Format, Package, Process, Emulsion, Film, FilmState, Tag, FilmTag, TransitionGraph, TransitionProfile } from '@/types'
+import type { Format, Package, Process, Emulsion, Film, FilmState, Tag, FilmTag, TransitionGraph, TransitionProfile, StateCount, MonthCount, EmulsionCount, TransitionDuration } from '@/types'
 
 // Format API (replaces filmFormatApi)
 export const formatApi = {
@@ -126,6 +126,14 @@ export const importApi = {
       form,
     )
   },
+}
+
+// Film Stats API
+export const filmStatsApi = {
+  byState: () => api.get<StateCount[]>('/films/stats/by-state'),
+  byMonth: (months = 12) => api.get<MonthCount[]>('/films/stats/by-month', { params: { months } }),
+  byEmulsion: () => api.get<EmulsionCount[]>('/films/stats/by-emulsion'),
+  lifecycleDurations: () => api.get<TransitionDuration[]>('/films/stats/lifecycle-durations'),
 }
 
 // Transition API

--- a/frollz-ui/src/types/index.ts
+++ b/frollz-ui/src/types/index.ts
@@ -127,6 +127,27 @@ export interface TransitionGraph {
   transitions: TransitionEdge[]
 }
 
+// Stats
+export interface StateCount {
+  state: string
+  count: number
+}
+
+export interface MonthCount {
+  month: string
+  count: number
+}
+
+export interface EmulsionCount {
+  emulsionName: string
+  count: number
+}
+
+export interface TransitionDuration {
+  transition: string
+  avgDays: number | null
+}
+
 // Helpers — derive current state name from Film.states
 export function currentStateName(film: Film): string {
   if (!film.states?.length) return ''

--- a/frollz-ui/src/views/StatsView.vue
+++ b/frollz-ui/src/views/StatsView.vue
@@ -1,0 +1,292 @@
+<template>
+  <div>
+    <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-8">Statistics</h1>
+
+    <!-- #145 — Film count by transition state -->
+    <section aria-labelledby="by-state-heading" class="mb-10">
+      <h2 id="by-state-heading" class="text-xl font-semibold text-gray-800 dark:text-gray-200 mb-4">
+        Films by State
+      </h2>
+
+      <div
+        :aria-busy="loadingStates"
+        class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6 gap-4"
+      >
+        <template v-if="loadingStates">
+          <div v-for="n in 5" :key="n" class="bg-white dark:bg-gray-800 p-5 rounded-lg shadow-md animate-pulse">
+            <div class="h-4 bg-gray-200 dark:bg-gray-700 rounded w-3/4 mb-3" />
+            <div class="h-8 bg-gray-200 dark:bg-gray-700 rounded w-1/2" />
+          </div>
+        </template>
+        <template v-else>
+          <div
+            v-for="item in stateCounts"
+            :key="item.state"
+            class="bg-white dark:bg-gray-800 p-5 rounded-lg shadow-md"
+          >
+            <p class="text-sm font-medium text-gray-600 dark:text-gray-400 mb-1 truncate" :title="item.state">
+              {{ item.state }}
+            </p>
+            <p class="text-3xl font-bold text-primary-600 dark:text-primary-400">{{ item.count }}</p>
+          </div>
+        </template>
+      </div>
+      <p v-if="stateError" role="alert" class="mt-2 text-sm text-red-600 dark:text-red-400">
+        Could not load state data.
+      </p>
+    </section>
+
+    <!-- #146 — Films per month trend chart -->
+    <section aria-labelledby="by-month-heading" class="mb-10">
+      <h2 id="by-month-heading" class="text-xl font-semibold text-gray-800 dark:text-gray-200 mb-4">
+        Films per Month <span class="text-sm font-normal text-gray-500 dark:text-gray-400">(last 12 months)</span>
+      </h2>
+
+      <div class="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6" :aria-busy="loadingMonths">
+        <template v-if="loadingMonths">
+          <div class="h-40 bg-gray-100 dark:bg-gray-700 rounded animate-pulse" />
+        </template>
+        <p v-else-if="monthError" role="alert" class="text-sm text-red-600 dark:text-red-400">
+          Could not load monthly data.
+        </p>
+        <p v-else-if="monthCounts.length === 0" class="text-center text-gray-500 dark:text-gray-400 py-10">
+          No film data for the past 12 months.
+        </p>
+        <template v-else>
+          <!-- SVG bar chart -->
+          <svg
+            :viewBox="`0 0 ${svgWidth} ${svgHeight}`"
+            class="w-full"
+            role="img"
+            :aria-label="`Bar chart showing films per month. ${monthChartAriaLabel}`"
+          >
+            <!-- Bars -->
+            <g v-for="(bar, i) in monthBars" :key="bar.label">
+              <rect
+                :x="bar.x"
+                :y="bar.y"
+                :width="bar.width"
+                :height="bar.barHeight"
+                class="fill-primary-500 dark:fill-primary-400"
+                rx="2"
+              />
+              <!-- Count label above bar (only if there's room) -->
+              <text
+                v-if="bar.barHeight > 14"
+                :x="bar.x + bar.width / 2"
+                :y="bar.y - 4"
+                text-anchor="middle"
+                class="fill-gray-600 dark:fill-gray-300"
+                font-size="10"
+              >{{ bar.count }}</text>
+              <!-- Month label below axis -->
+              <text
+                :x="bar.x + bar.width / 2"
+                :y="svgHeight - 2"
+                text-anchor="middle"
+                class="fill-gray-500 dark:fill-gray-400"
+                font-size="9"
+              >{{ formatMonthLabel(bar.label, i, monthBars.length) }}</text>
+            </g>
+            <!-- Baseline -->
+            <line
+              x1="0"
+              :y1="svgHeight - 18"
+              :x2="svgWidth"
+              :y2="svgHeight - 18"
+              stroke="currentColor"
+              stroke-width="1"
+              class="text-gray-200 dark:text-gray-600"
+            />
+          </svg>
+        </template>
+      </div>
+    </section>
+
+    <!-- #147 — Emulsion usage breakdown -->
+    <section aria-labelledby="by-emulsion-heading" class="mb-10">
+      <h2 id="by-emulsion-heading" class="text-xl font-semibold text-gray-800 dark:text-gray-200 mb-4">
+        Films by Emulsion
+      </h2>
+
+      <div class="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6" :aria-busy="loadingEmulsions">
+        <template v-if="loadingEmulsions">
+          <div v-for="n in 4" :key="n" class="h-6 bg-gray-100 dark:bg-gray-700 rounded animate-pulse mb-3" />
+        </template>
+        <p v-else-if="emulsionError" role="alert" class="text-sm text-red-600 dark:text-red-400">
+          Could not load emulsion data.
+        </p>
+        <p v-else-if="emulsionCounts.length === 0" class="text-center text-gray-500 dark:text-gray-400 py-6">
+          No emulsion data available.
+        </p>
+        <ul v-else class="space-y-3" aria-label="Emulsion usage breakdown">
+          <li v-for="item in emulsionCounts" :key="item.emulsionName" class="flex flex-col gap-1">
+            <div class="flex justify-between text-sm">
+              <span class="font-medium text-gray-700 dark:text-gray-300">{{ item.emulsionName }}</span>
+              <span class="text-gray-500 dark:text-gray-400">{{ item.count }} film{{ item.count === 1 ? '' : 's' }}</span>
+            </div>
+            <div class="w-full bg-gray-100 dark:bg-gray-700 rounded-full h-2" role="presentation">
+              <div
+                class="bg-primary-500 dark:bg-primary-400 h-2 rounded-full transition-all duration-300"
+                :style="{ width: `${(item.count / emulsionMax) * 100}%` }"
+                :aria-label="`${item.emulsionName}: ${item.count} films`"
+              />
+            </div>
+          </li>
+        </ul>
+      </div>
+    </section>
+
+    <!-- #148 — Average lifecycle duration per state transition -->
+    <section aria-labelledby="lifecycle-heading" class="mb-10">
+      <h2 id="lifecycle-heading" class="text-xl font-semibold text-gray-800 dark:text-gray-200 mb-4">
+        Average Lifecycle Duration
+      </h2>
+
+      <div class="bg-white dark:bg-gray-800 rounded-lg shadow-md overflow-hidden" :aria-busy="loadingDurations">
+        <template v-if="loadingDurations">
+          <div class="p-6 space-y-3">
+            <div v-for="n in 4" :key="n" class="h-6 bg-gray-100 dark:bg-gray-700 rounded animate-pulse" />
+          </div>
+        </template>
+        <p v-else-if="durationError" role="alert" class="p-6 text-sm text-red-600 dark:text-red-400">
+          Could not load lifecycle data.
+        </p>
+        <p v-else-if="transitionDurations.length === 0" class="p-6 text-center text-gray-500 dark:text-gray-400">
+          No completed transitions recorded yet.
+        </p>
+        <table v-else class="w-full text-sm text-left">
+          <caption class="sr-only">Average days between consecutive film state transitions</caption>
+          <thead>
+            <tr class="border-b border-gray-100 dark:border-gray-700">
+              <th scope="col" class="px-6 py-3 font-semibold text-gray-700 dark:text-gray-300">Transition</th>
+              <th scope="col" class="px-6 py-3 font-semibold text-gray-700 dark:text-gray-300 text-right">Avg. Days</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="item in transitionDurations"
+              :key="item.transition"
+              class="border-b border-gray-50 dark:border-gray-700/50 last:border-b-0"
+            >
+              <td class="px-6 py-3 text-gray-800 dark:text-gray-200">{{ item.transition }}</td>
+              <td class="px-6 py-3 text-right font-mono">
+                <span v-if="item.avgDays !== null" class="text-gray-800 dark:text-gray-200">
+                  {{ item.avgDays.toFixed(1) }}
+                </span>
+                <span v-else class="text-gray-400 dark:text-gray-500">N/A</span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { filmStatsApi } from '@/services/api-client'
+import type { StateCount, MonthCount, EmulsionCount, TransitionDuration } from '@/types'
+
+// --- State counts (#145) ---
+const loadingStates = ref(true)
+const stateError = ref(false)
+const stateCounts = ref<StateCount[]>([])
+
+// --- Monthly counts (#146) ---
+const loadingMonths = ref(true)
+const monthError = ref(false)
+const monthCounts = ref<MonthCount[]>([])
+
+// --- Emulsion counts (#147) ---
+const loadingEmulsions = ref(true)
+const emulsionError = ref(false)
+const emulsionCounts = ref<EmulsionCount[]>([])
+
+// --- Lifecycle durations (#148) ---
+const loadingDurations = ref(true)
+const durationError = ref(false)
+const transitionDurations = ref<TransitionDuration[]>([])
+
+// --- Month SVG chart ---
+const svgWidth = 600
+const svgHeight = 180
+const barPadding = 4
+const axisHeight = 18
+const topPadding = 20
+
+const monthBars = computed(() => {
+  if (monthCounts.value.length === 0) return []
+  const max = Math.max(...monthCounts.value.map((m) => m.count), 1)
+  const chartHeight = svgHeight - axisHeight - topPadding
+  const totalBars = monthCounts.value.length
+  const barWidth = (svgWidth - barPadding * (totalBars + 1)) / totalBars
+
+  return monthCounts.value.map((m, i) => {
+    const barHeight = Math.max((m.count / max) * chartHeight, 1)
+    const x = barPadding + i * (barWidth + barPadding)
+    const y = topPadding + chartHeight - barHeight
+    return { label: m.month, count: m.count, x, y, width: barWidth, barHeight }
+  })
+})
+
+const monthChartAriaLabel = computed(() =>
+  monthBars.value.map((b) => `${b.label}: ${b.count}`).join(', '),
+)
+
+function formatMonthLabel(ym: string, index: number, total: number): string {
+  // Always show first, last, and every 3rd label to avoid crowding
+  if (index !== 0 && index !== total - 1 && index % 3 !== 0) return ''
+  const [year, month] = ym.split('-')
+  const date = new Date(Number(year), Number(month) - 1)
+  return date.toLocaleDateString(undefined, { month: 'short', year: '2-digit' })
+}
+
+// --- Emulsion chart ---
+const emulsionMax = computed(() =>
+  emulsionCounts.value.length ? Math.max(...emulsionCounts.value.map((e) => e.count)) : 1,
+)
+
+// --- Data loading ---
+async function loadAll() {
+  const results = await Promise.allSettled([
+    filmStatsApi.byState(),
+    filmStatsApi.byMonth(12),
+    filmStatsApi.byEmulsion(),
+    filmStatsApi.lifecycleDurations(),
+  ])
+
+  const [stateRes, monthRes, emulsionRes, durationRes] = results
+
+  if (stateRes.status === 'fulfilled') {
+    stateCounts.value = stateRes.value.data
+  } else {
+    stateError.value = true
+  }
+  loadingStates.value = false
+
+  if (monthRes.status === 'fulfilled') {
+    monthCounts.value = monthRes.value.data
+  } else {
+    monthError.value = true
+  }
+  loadingMonths.value = false
+
+  if (emulsionRes.status === 'fulfilled') {
+    emulsionCounts.value = emulsionRes.value.data
+  } else {
+    emulsionError.value = true
+  }
+  loadingEmulsions.value = false
+
+  if (durationRes.status === 'fulfilled') {
+    transitionDurations.value = durationRes.value.data
+  } else {
+    durationError.value = true
+  }
+  loadingDurations.value = false
+}
+
+onMounted(loadAll)
+</script>


### PR DESCRIPTION
## Summary

Closes #139 (epic), #145, #146, #147, #148.

- **API** — new `FilmStatsModule` with 4 read-only aggregation endpoints under `GET /films/stats/…`
- **UI** — new `/stats` route (`StatsView.vue`) with state count cards, films-per-month bar chart, emulsion usage bars, and lifecycle duration table

## Changes

### API (`frollz-api`)
| Endpoint | Story |
|---|---|
| `GET /films/stats/by-state` | #145 — film count per current transition state; all states shown even at zero |
| `GET /films/stats/by-month?months=N` | #146 — film count by month of first state transition (default 12 months) |
| `GET /films/stats/by-emulsion` | #147 — film count per emulsion, sorted desc |
| `GET /films/stats/lifecycle-durations` | #148 — avg days between consecutive state transitions; `avgDays: null` when < 2 samples |

New files follow the established 4-layer pattern: domain interface → knex repository → service → controller → module. Queries handle both SQLite (dev) and PostgreSQL (prod) via conditional raw SQL expressions for date truncation and day-diff.

### UI (`frollz-ui`)
- `StatsView.vue` — four sections, each with skeleton loading, error, and empty states
- Month chart is lightweight SVG (no new dependency)
- Emulsion section uses percentage-width progress bars with accessible `aria-label` on each bar
- Lifecycle table shows `N/A` for transitions with insufficient data
- Statistics nav link added to `NavBar.vue` (desktop + mobile drawer)

## Issue terminology updates

All 4 child issues (#145–#148) were updated before implementation to replace old Roll/Stock vocabulary with the current Film/Emulsion/TransitionState domain model.

## Test plan
- [x] `GET /films/stats/by-state` returns all transition states, zeros included
- [x] `GET /films/stats/by-month?months=12` returns empty array on fresh DB; returns data after films are added
- [x] `GET /films/stats/by-emulsion` returns empty array on fresh DB
- [x] `GET /films/stats/lifecycle-durations` returns `avgDays: null` for transitions with 0–1 samples
- [x] Navigate to `/stats` — all four sections render skeleton → data (or empty state)
- [x] `/stats` appears in navbar on desktop and mobile drawer