### PR TITLE
feat(film): add camera selection on loaded state transition

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -8,8 +8,8 @@ ROOT="$(git rev-parse --show-toplevel)"
 echo "▶ pre-commit: UI lint"
 (cd "$ROOT/apps/frollz-ui" && pnpm lint)
 
-echo "▶ pre-commit: UI type-check"
-(cd "$ROOT/apps/frollz-ui" && pnpm type-check)
+echo "▶ pre-commit: UI check-types"
+(cd "$ROOT/apps/frollz-ui" && pnpm check-types)
 
 echo "▶ pre-commit: UI tests"
 (cd "$ROOT/apps/frollz-ui" && pnpm test -- --run)

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -66,8 +66,8 @@ jobs:
       - name: Lint UI
         run: pnpm --filter @frollz/frollz-ui run lint
 
-      - name: Type-check UI
-        run: pnpm --filter @frollz/frollz-ui run type-check
+      - name: Check-types UI
+        run: pnpm --filter @frollz/frollz-ui run check-types
 
       - name: Test UI
         run: pnpm --filter @frollz/frollz-ui test

--- a/apps/frollz-api/migrations/20260418000000_add_camera_metadata_to_loaded_state.ts
+++ b/apps/frollz-api/migrations/20260418000000_add_camera_metadata_to_loaded_state.ts
@@ -1,0 +1,31 @@
+import type { Knex } from "knex";
+
+export async function up(knex: Knex): Promise<void> {
+  await knex("transition_metadata_field").insert([
+    { name: "cameraId", field_type: "camera", allow_multiple: false },
+  ]);
+
+  const loadedState = await knex<{ id: number }>("transition_state")
+    .where({ name: "Loaded" })
+    .first();
+  if (!loadedState) throw new Error("Migration error: 'Loaded' transition_state not found");
+
+  const field = await knex<{ id: number }>("transition_metadata_field")
+    .where({ name: "cameraId" })
+    .first();
+  if (!field) throw new Error("Migration error: 'cameraId' transition_metadata_field not found");
+
+  await knex("transition_state_metadata").insert([
+    { field_id: field.id, transition_state_id: loadedState.id, default_value: null },
+  ]);
+}
+
+export async function down(knex: Knex): Promise<void> {
+  const field = await knex<{ id: number }>("transition_metadata_field")
+    .where({ name: "cameraId" })
+    .first();
+  if (!field) return;
+
+  await knex("transition_state_metadata").where({ field_id: field.id }).delete();
+  await knex("transition_metadata_field").where({ name: "cameraId" }).delete();
+}

--- a/apps/frollz-ui/package.json
+++ b/apps/frollz-ui/package.json
@@ -9,7 +9,7 @@
     "build": "vite build",
     "dev": "vite --host 0.0.0.0",
     "preview": "vite preview",
-    "type-check": "vue-tsc --build --force",
+    "check-types": "vue-tsc --build --force",
     "lint": "eslint . --fix",
     "format": "prettier --write src/",
     "test": "vitest run"

--- a/apps/frollz-ui/src/views/FilmDetailView.vue
+++ b/apps/frollz-ui/src/views/FilmDetailView.vue
@@ -78,6 +78,12 @@
                 >
               </dd>
             </div>
+            <div v-if="loadedCamera" class="flex justify-between text-sm">
+              <dt class="text-gray-500 dark:text-gray-400">Camera</dt>
+              <dd class="text-gray-900 dark:text-gray-100">
+                {{ loadedCamera.brand }} {{ loadedCamera.model }}
+              </dd>
+            </div>
             <div
               v-if="film.expirationDate"
               class="flex justify-between text-sm"
@@ -195,6 +201,32 @@
                     + Add URL
                   </button>
                 </div>
+                <template v-else-if="field.fieldType === 'camera'">
+                  <div v-if="cameras.length === 0" class="mb-2 text-xs text-gray-500 dark:text-gray-400">
+                    Camera — <RouterLink to="/cameras" class="text-primary-600 dark:text-primary-400 hover:underline">add a camera first</RouterLink>
+                  </div>
+                  <label
+                    v-else
+                    :for="`meta-${field.field}`"
+                    class="block text-xs text-gray-600 dark:text-gray-400 mb-2"
+                  >
+                    Camera — optional
+                    <select
+                      :id="`meta-${field.field}`"
+                      v-model="metadataValues[field.field] as string"
+                      class="mt-1 w-full border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-base sm:text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+                    >
+                      <option value="">None</option>
+                      <option
+                        v-for="camera in cameras"
+                        :key="camera.id"
+                        :value="String(camera.id)"
+                      >
+                        {{ camera.brand }} {{ camera.model }}
+                      </option>
+                    </select>
+                  </label>
+                </template>
                 <label
                   v-else
                   :for="`meta-${field.field}`"
@@ -450,22 +482,44 @@
                       }}:</span
                     >
                     <template v-if="Array.isArray(m.value)">
-                      <span v-if="m.value.length === 0" class="ml-1 italic"
-                        >none</span
-                      >
-                      <span v-else class="ml-1 space-x-1">
-                        <a
-                          v-for="(url, i) in m.value"
-                          :key="i"
-                          :href="url"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          class="text-primary-600 dark:text-primary-400 hover:underline"
-                          >Scan {{ i + 1 }}</a
+                      <template v-if="isCameraMetadataField(m)">
+                        <span v-if="m.value.length === 0" class="ml-1 italic"
+                          >none</span
                         >
-                      </span>
+                        <span v-else class="ml-1 space-x-1">
+                          <span
+                            v-for="(value, i) in resolveMetadataValue(m)"
+                            :key="i"
+                            class="text-primary-600 dark:text-primary-400"
+                          >
+                            {{ value }}
+                          </span>
+                        </span>
+                      </template>
+                      <template v-else>
+                        <span v-if="m.value.length === 0" class="ml-1 italic"
+                          >none</span
+                        >
+                        <span v-else class="ml-1 space-x-1">
+                          <a
+                            v-for="(url, i) in m.value"
+                            :key="i"
+                            :href="url"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="text-primary-600 dark:text-primary-400 hover:underline"
+                            >Scan {{ i + 1 }}</a
+                          >
+                        </span>
+                      </template>
                     </template>
-                    <span v-else class="ml-1">{{ m.value ?? "—" }}</span>
+                    <span v-else class="ml-1">
+                      {{
+                        isCameraMetadataField(m)
+                          ? resolveMetadataValue(m)
+                          : m.value ?? "—"
+                      }}
+                    </span>
                   </li>
                 </ul>
               </div>
@@ -479,8 +533,8 @@
 
 <script setup lang="ts">
 import { ref, computed, onMounted, watch } from "vue";
-import { useRoute, useRouter } from "vue-router";
-import { filmApi, tagApi, transitionApi } from "@/services/api-client";
+import { RouterLink, useRoute, useRouter } from "vue-router";
+import { filmApi, tagApi, transitionApi, cameraApi } from "@/services/api-client";
 import type {
   Film,
   FilmTag,
@@ -488,6 +542,7 @@ import type {
   TransitionGraph,
   TransitionProfile,
   TransitionMetadataField,
+  Camera,
 } from "@frollz/shared";
 import { currentStateName } from "@/types";
 import { useNotificationStore } from "@/stores/notification";
@@ -513,10 +568,23 @@ const transitionNote = ref("");
 const metadataValues = ref<Record<string, string | string[]>>({});
 
 const transitionGraph = ref<TransitionGraph>({ states: [], transitions: [] });
+const cameras = ref<Camera[]>([]);
 
 const stateName = computed(() =>
   film.value ? currentStateName(film.value) : "",
 );
+
+const loadedCamera = computed((): Camera | null => {
+  if (!film.value) return null;
+  const loadedState = film.value.states.find((s) => s.state?.name === "Loaded");
+  const meta = loadedState?.metadata.find(
+    (m) => m.transitionStateMetadata?.field?.name === "cameraId",
+  );
+  const val = meta?.value;
+  if (!val || Array.isArray(val)) return null;
+  const id = parseInt(val, 10);
+  return cameras.value.find((c) => c.id === id) ?? null;
+});
 
 const getChildStateName = (child: Film): string => currentStateName(child);
 
@@ -579,6 +647,34 @@ const formatFieldLabel = (fieldName: string): string =>
     .replace(/([A-Z])/g, " $1")
     .replace(/^./, (s) => s.toUpperCase())
     .trim();
+
+const isCameraMetadataField = (
+  metadata: {
+    transitionStateMetadata?: { field?: { name?: string } };
+  },
+): boolean => metadata.transitionStateMetadata?.field?.name === "cameraId";
+
+const resolveMetadataValue = (
+  metadata: {
+    value: string | string[] | null;
+    transitionStateMetadata?: { field?: { name?: string } };
+  },
+): string | string[] | null => {
+  if (!isCameraMetadataField(metadata)) return metadata.value;
+
+  const resolveId = (value: string): string => {
+    const id = parseInt(value, 10);
+    const camera = cameras.value.find((c) => c.id === id);
+    return camera ? `${camera.brand} ${camera.model}` : value;
+  };
+
+  if (Array.isArray(metadata.value)) {
+    return metadata.value.map((value) => resolveId(value));
+  }
+
+  if (!metadata.value) return metadata.value;
+  return resolveId(metadata.value);
+};
 
 const handleTransition = (targetState: string) => {
   pendingTransition.value = targetState;
@@ -726,6 +822,9 @@ const reload = async () => {
       loadData(),
       transitionApi.getProfiles().then((r) => {
         transitionProfiles.value = r.data;
+      }),
+      cameraApi.getAll().then((r) => {
+        cameras.value = r.data;
       }),
     ]);
     const profileName =

--- a/apps/frollz-ui/src/views/FilmsView.vue
+++ b/apps/frollz-ui/src/views/FilmsView.vue
@@ -505,6 +505,12 @@
               >
                 {{ film.emulsion?.brand ?? "—" }}
               </p>
+              <p
+                v-if="getLoadedCamera(film)"
+                class="text-xs text-gray-500 dark:text-gray-400 mt-0.5 truncate"
+              >
+                {{ getLoadedCamera(film)!.brand }} {{ getLoadedCamera(film)!.model }}
+              </p>
             </div>
             <div class="shrink-0 flex items-center gap-2">
               <!-- Scan link indicator -->
@@ -609,6 +615,11 @@
               <th
                 class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider select-none"
               >
+                Camera
+              </th>
+              <th
+                class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider select-none"
+              >
                 Scans
               </th>
               <th class="px-6 py-3"></th>
@@ -635,6 +646,11 @@
                     class="h-5 bg-gray-200 dark:bg-gray-700 rounded-full w-20"
                   ></div>
                 </td>
+                <td class="px-6 py-4">
+                  <div
+                    class="h-4 bg-gray-200 dark:bg-gray-700 rounded w-24"
+                  ></div>
+                </td>
                 <td class="px-6 py-4"></td>
                 <td class="px-6 py-4"></td>
               </tr>
@@ -642,7 +658,7 @@
             <template v-else>
               <tr v-if="filteredFilms.length === 0">
                 <td
-                  colspan="5"
+                  colspan="6"
                   class="px-6 py-8 text-center text-sm text-gray-600 dark:text-gray-400 italic"
                 >
                   No films found.
@@ -675,6 +691,15 @@
                     :class="getStateColor(getStateName(film))"
                     >{{ getStateName(film) || "No state" }}</span
                   >
+                </td>
+                <td
+                  class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400"
+                >
+                  {{
+                    getLoadedCamera(film)
+                      ? `${getLoadedCamera(film)!.brand} ${getLoadedCamera(film)!.model}`
+                      : "—"
+                  }}
                 </td>
                 <td class="px-6 py-4 whitespace-nowrap">
                   <template v-if="getScanUrls(film).length > 0">
@@ -944,9 +969,11 @@ import {
   tagApi,
   exportApi,
   importApi,
+  cameraApi,
 } from "@/services/api-client";
 import BaseModal from "@/components/BaseModal.vue";
 import type { Film, Emulsion, TransitionProfile, Format, Tag } from "@/types";
+import type { Camera } from "@frollz/shared";
 import { currentStateName, getScanUrls } from "@/types";
 import { getStateColor } from "@/utils/stateColors";
 import { triggerDownload } from "@/utils/download";
@@ -958,6 +985,7 @@ const films = ref<Film[]>([]);
 const emulsions = ref<Emulsion[]>([]);
 const formats = ref<Format[]>([]);
 const tags = ref<Tag[]>([]);
+const cameras = ref<Camera[]>([]);
 const transitionProfiles = ref<TransitionProfile[]>([]);
 const isLoading = ref(true);
 const exportingJson = ref(false);
@@ -1117,6 +1145,17 @@ const clearAllFilters = () => {
 };
 
 const getStateName = (film: Film): string => currentStateName(film);
+
+const getLoadedCamera = (film: Film): Camera | null => {
+  const loadedState = film.states.find((s) => s.state?.name === "Loaded");
+  const meta = loadedState?.metadata.find(
+    (m) => m.transitionStateMetadata?.field?.name === "cameraId",
+  );
+  const val = meta?.value;
+  if (!val || Array.isArray(val)) return null;
+  const id = parseInt(val, 10);
+  return cameras.value.find((c) => c.id === id) ?? null;
+};
 
 const emptyForm = () => ({
   name: "",
@@ -1386,6 +1425,9 @@ onMounted(async () => {
     }),
     transitionApi.getProfiles().then((r) => {
       transitionProfiles.value = r.data;
+    }),
+    cameraApi.getAll().then((r) => {
+      cameras.value = r.data;
     }),
   ]);
 

--- a/apps/frollz-ui/src/views/__tests__/FilmDetailView.spec.ts
+++ b/apps/frollz-ui/src/views/__tests__/FilmDetailView.spec.ts
@@ -5,7 +5,7 @@ import { createPinia, setActivePinia } from "pinia";
 import { createRouter, createMemoryHistory } from "vue-router";
 import { axe } from "vitest-axe";
 import FilmDetailView from "@/views/FilmDetailView.vue";
-import { filmApi, tagApi, transitionApi } from "@/services/api-client";
+import { filmApi, tagApi, transitionApi, cameraApi } from "@/services/api-client";
 import type {
   Film,
   Tag,
@@ -35,6 +35,9 @@ vi.mock("@/services/api-client", () => ({
   transitionApi: {
     getGraph: vi.fn(),
     getProfiles: vi.fn(),
+  },
+  cameraApi: {
+    getAll: vi.fn(),
   },
 }));
 
@@ -125,6 +128,7 @@ describe("RollDetailView", () => {
     vi.mocked(transitionApi.getProfiles).mockResolvedValue({
       data: mockProfiles,
     } as any);
+    vi.mocked(cameraApi.getAll).mockResolvedValue({ data: [] } as any);
   });
 
   describe("accessibility", () => {

--- a/apps/frollz-ui/src/views/__tests__/FilmsView.spec.ts
+++ b/apps/frollz-ui/src/views/__tests__/FilmsView.spec.ts
@@ -11,6 +11,7 @@ import {
   transitionApi,
   formatApi,
   tagApi,
+  cameraApi,
 } from "@/services/api-client";
 import type { Film } from "@/types";
 import { randomInt } from "crypto";
@@ -37,6 +38,9 @@ vi.mock("@/services/api-client", () => ({
   },
   transitionApi: {
     getProfiles: vi.fn(),
+  },
+  cameraApi: {
+    getAll: vi.fn(),
   },
 }));
 
@@ -81,6 +85,7 @@ describe("FilmsView", () => {
     vi.mocked(transitionApi.getProfiles).mockResolvedValue({
       data: mockProfiles,
     } as any);
+    vi.mocked(cameraApi.getAll).mockResolvedValue({ data: [] } as any);
   });
 
   describe("accessibility", () => {

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -42,7 +42,7 @@ Pushing the tag triggers the CI/CD pipeline automatically.
 
 - [ ] Open **Actions** tab: `https://github.com/joshholl/frollz/actions`
 - [ ] Confirm `CI / CD` triggered on the tag push
-- [ ] Wait for **API — Lint & Test** and **UI — Lint, Type-check & Test** to go green
+- [ ] Wait for **API — Lint & Test** and **UI — Lint, Check-Types & Test** to go green
 - [ ] Wait for **Build & Push Images** to complete
 - [ ] If any job fails — fix on the release branch, re-merge, re-tag
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -49,7 +49,7 @@ export const Emulsion = z.strictObject({
   speed: z.int().nonnegative(),
   formatId: z.int().nonnegative(),
   processId: z.int().nonnegative(),
-  parentId: z.int().nonnegative().optional(),
+  parentId: z.int().nonnegative().optional().nullable(),
   boxImageMimeType: z.string().nonempty().optional(),
   tags: z.array(Tag),
 })
@@ -111,6 +111,7 @@ export const FilmState = z.strictObject({
   state: z.strictObject({
     id: z.int().nonnegative(),
     name: z.string().nonempty(),
+    metadata: FilmStateMetadata.array().optional(),
   }).optional(),
 })
 export type FilmState = z.infer<typeof FilmState>
@@ -233,7 +234,7 @@ export type TransitionDuration = z.infer<typeof TransitionDuration>
 export const CreateFilmInput = z.strictObject({
   name: z.string().nonempty(),
   emulsionId: z.int().positive(),
-  expirationDate: z.iso.date().nullable().optional(),
+  expirationDate: z.iso.datetime().nullable().optional(),
   parentId: z.int().positive().optional(),
   transitionProfileId: z.int().positive(),
   metadata: z.record(z.string(), z.union([z.string(), z.array(z.string())])).optional(),


### PR DESCRIPTION
## Changes

### ✨ Features
- feat(film): add camera selection on loaded state transition

## Summary

- Adds a `cameraId` metadata field (fieldType `camera`) to the "Loaded" transition state via migration — no schema changes to the `film` table; camera association lives in the existing metadata system
- Transition form on the film detail view now renders a camera `<select>` dropdown when transitioning to "Loaded"; shows an "add a camera first" prompt if no cameras exist
- Film list (desktop table + mobile card) and film detail view both resolve and display the camera from the Loaded state's metadata
- `CreateFilmInput.expirationDate` updated to accept ISO datetime (aligns with what the UI sends)
- Pre-commit hook and UI `package.json` script renamed `type-check` → `check-types` for turbo pipeline consistency
- Test mocks for `FilmDetailView` and `FilmsView` updated to include `cameraApi`

## Checklist
- [x] Types defined in `@frollz/shared` before API/UI code
- [x] Migration added for schema change (`cameraId` metadata field on Loaded state)
- [x] `pnpm check-types` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes
- [ ] ADR updated if this is an architectural change

Closes #152