### PR TITLE
feat(camera): Added camera load state tracking and history

### DIFF
--- a/apps/frollz-api/src/domain/film/repositories/film.repository.interface.ts
+++ b/apps/frollz-api/src/domain/film/repositories/film.repository.interface.ts
@@ -11,6 +11,7 @@ export interface FilmFilters {
   loadedDateFrom?: Date;
   loadedDateTo?: Date;
   searchQuery?: string;
+  cameraId?: number;
 }
 
 export interface IFilmRepository {

--- a/apps/frollz-api/src/infrastructure/persistence/film/film.knex.repository.ts
+++ b/apps/frollz-api/src/infrastructure/persistence/film/film.knex.repository.ts
@@ -93,6 +93,27 @@ export class FilmKnexRepository
       query = query.whereIn("id", sub);
     }
 
+    if (filters.cameraId !== undefined) {
+      query = query.whereIn(
+        "id",
+        this.db("film_state as fsc")
+          .select("fsc.film_id")
+          .join("film_state_metadata as fsm", "fsm.film_state_id", "fsc.id")
+          .join(
+            "transition_state_metadata as tsm",
+            "tsm.id",
+            "fsm.transition_state_metadata_id",
+          )
+          .join(
+            "transition_metadata_field as tmf",
+            "tmf.id",
+            "tsm.field_id",
+          )
+          .where("tmf.name", "cameraId")
+          .where("fsm.value", String(filters.cameraId)),
+      );
+    }
+
     if (filters.searchQuery) {
       const pattern = `%${filters.searchQuery}%`;
       query = query.where((builder) => {

--- a/apps/frollz-api/src/modules/film/application/film.service.ts
+++ b/apps/frollz-api/src/modules/film/application/film.service.ts
@@ -54,6 +54,7 @@ export interface FilmFindAllParams {
   from?: string;
   to?: string;
   q?: string;
+  cameraId?: number;
 }
 
 @Injectable()
@@ -95,6 +96,7 @@ export class FilmService {
     if (params.formatId !== undefined) filters.formatId = params.formatId;
     if (params.tagIds?.length) filters.tagIds = params.tagIds;
     if (params.q?.trim()) filters.searchQuery = params.q.trim();
+    if (params.cameraId !== undefined) filters.cameraId = params.cameraId;
 
     if (params.from || params.to) {
       const loadedState = allStates.find((s) => s.name === "Loaded");

--- a/apps/frollz-api/src/modules/film/film.controller.ts
+++ b/apps/frollz-api/src/modules/film/film.controller.ts
@@ -75,6 +75,12 @@ export class FilmController {
     description:
       "Search by film name or state note (case-insensitive partial match)",
   })
+  @ApiQuery({
+    name: "cameraId",
+    required: false,
+    type: Number,
+    description: "Filter by camera ID (films loaded with this camera)",
+  })
   findAll(
     @Query("state") state?: string | string[],
     @Query("emulsionId") rawEmulsionId?: string,
@@ -83,6 +89,7 @@ export class FilmController {
     @Query("from") rawFrom?: string,
     @Query("to") rawTo?: string,
     @Query("q") rawQ?: string,
+    @Query("cameraId") rawCameraId?: string,
   ) {
     const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
     if (rawFrom && !dateRegex.test(rawFrom)) {
@@ -110,6 +117,8 @@ export class FilmController {
           .map((t) => parseInt(t, 10))
           .filter((n) => !isNaN(n))
       : undefined;
+    const cameraId =
+      rawCameraId !== undefined ? parseInt(rawCameraId, 10) : undefined;
     return this.filmService.findAll({
       stateNames,
       emulsionId,
@@ -118,6 +127,7 @@ export class FilmController {
       from: rawFrom,
       to: rawTo,
       q: rawQ,
+      cameraId,
     });
   }
 

--- a/apps/frollz-ui/package.json
+++ b/apps/frollz-ui/package.json
@@ -16,20 +16,20 @@
   },
   "dependencies": {
     "@frollz/shared": "workspace:*",
-    "zod": "^4.3.6",
     "@heroicons/vue": "^2.2.0",
     "@tailwindcss/postcss": "^4.2.2",
     "eslint-config-prettier": "^10.1.8",
     "pinia": "^3.0.4",
     "vue": "^3.5.32",
-    "vue-router": "^5.0.4"
+    "vue-router": "^5.0.4",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@frollz/vitest-config": "workspace:*",
-    "@frollz/typescript-config": "workspace:*",
     "@eslint-community/eslint-utils": "^4.9.1",
     "@eslint/eslintrc": "^3.3.5",
     "@eslint/js": "^10.0.1",
+    "@frollz/typescript-config": "workspace:*",
+    "@frollz/vitest-config": "workspace:*",
     "@rushstack/eslint-patch": "^1.16.1",
     "@tsconfig/node20": "^20.1.9",
     "@types/node": "^25.6.0",
@@ -55,6 +55,7 @@
     "typescript": "~6.0.2",
     "typescript-eslint": "^8.58.1",
     "vite": "^8.0.8",
+    "vite-plugin-vue-devtools": "^8.1.1",
     "vitest": "^4.1.4",
     "vitest-axe": "^0.1.0",
     "vitest-canvas-mock": "^1.1.4",

--- a/apps/frollz-ui/src/router/index.ts
+++ b/apps/frollz-ui/src/router/index.ts
@@ -46,6 +46,11 @@ const router = createRouter({
       meta: { title: "Cameras" },
     },
     {
+      path: "/cameras/:id",
+      name: "camera-detail",
+      component: () => import("@/views/CameraDetailView.vue"),
+    },
+    {
       path: "/stats",
       name: "stats",
       component: () => import("@/views/StatsView.vue"),
@@ -60,7 +65,13 @@ router.afterEach((to) => {
     const metaTitle = typeof to.meta.title === "string" ? to.meta.title : "";
     const filmKey =
       to.name === "film-detail" && to.params.key ? String(to.params.key) : "";
-    const pageTitle = filmKey ? `Film ${filmKey}` : metaTitle;
+    const cameraKey =
+      to.name === "camera-detail" && to.params.id ? String(to.params.id) : "";
+    const pageTitle = filmKey
+      ? `Film ${filmKey}`
+      : cameraKey
+        ? `Camera ${cameraKey}`
+        : metaTitle;
     document.title = pageTitle ? `${pageTitle} | Frollz` : "Frollz";
     document.getElementById("main-content")?.focus();
   });

--- a/apps/frollz-ui/src/services/api-client.ts
+++ b/apps/frollz-ui/src/services/api-client.ts
@@ -124,6 +124,7 @@ export const filmApi = {
     from?: string;
     to?: string;
     q?: string;
+    cameraId?: number;
   }) => apiFetch(Film.array(), "GET", "/films", undefined, params),
   getById: (id: number) => apiFetch(Film, "GET", `/films/${id}`),
   getChildren: (id: number) =>

--- a/apps/frollz-ui/src/views/CameraDetailView.vue
+++ b/apps/frollz-ui/src/views/CameraDetailView.vue
@@ -1,0 +1,210 @@
+<template>
+  <div>
+    <div class="mb-6">
+      <button
+        @click="$router.push({ name: 'cameras' })"
+        class="inline-flex items-center min-h-[44px] text-sm text-primary-600 dark:text-primary-400 hover:underline"
+      >
+        ← Back to Cameras
+      </button>
+    </div>
+
+    <div
+      v-if="loading"
+      role="status"
+      aria-label="Loading camera detail"
+      class="text-center py-12 text-gray-600 dark:text-gray-400"
+    >
+      Loading...
+    </div>
+
+    <div
+      v-else-if="!camera"
+      class="text-center py-12 text-gray-600 dark:text-gray-400"
+    >
+      Camera not found.
+    </div>
+
+    <div v-else class="space-y-6">
+      <!-- Header -->
+      <div>
+        <h1 class="text-3xl font-bold text-gray-900 dark:text-gray-100">
+          {{ camera.brand }} {{ camera.model }}
+        </h1>
+        <span :class="statusClass(camera.status)" class="mt-2 inline-block">
+          {{ statusLabel(camera.status) }}
+        </span>
+      </div>
+
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <!-- Details card -->
+        <div class="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6">
+          <h2
+            class="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-4"
+          >
+            Details
+          </h2>
+          <dl class="space-y-3">
+            <div class="flex justify-between text-sm">
+              <dt class="text-gray-500 dark:text-gray-400">Brand</dt>
+              <dd class="text-gray-900 dark:text-gray-100">{{ camera.brand }}</dd>
+            </div>
+            <div class="flex justify-between text-sm">
+              <dt class="text-gray-500 dark:text-gray-400">Model</dt>
+              <dd class="text-gray-900 dark:text-gray-100">{{ camera.model }}</dd>
+            </div>
+            <div class="flex justify-between text-sm">
+              <dt class="text-gray-500 dark:text-gray-400">Status</dt>
+              <dd>
+                <span :class="statusClass(camera.status)">{{
+                  statusLabel(camera.status)
+                }}</span>
+              </dd>
+            </div>
+            <div
+              v-if="camera.acceptedFormats.length"
+              class="flex justify-between text-sm"
+            >
+              <dt class="text-gray-500 dark:text-gray-400">Accepted Formats</dt>
+              <dd class="text-gray-900 dark:text-gray-100 text-right">
+                {{ formatNames }}
+              </dd>
+            </div>
+            <div v-if="camera.serialNumber" class="flex justify-between text-sm">
+              <dt class="text-gray-500 dark:text-gray-400">Serial Number</dt>
+              <dd class="text-gray-900 dark:text-gray-100">
+                {{ camera.serialNumber }}
+              </dd>
+            </div>
+            <div v-if="camera.purchasePrice" class="flex justify-between text-sm">
+              <dt class="text-gray-500 dark:text-gray-400">Purchase Price</dt>
+              <dd class="text-gray-900 dark:text-gray-100">
+                ${{ camera.purchasePrice.toFixed(2) }}
+              </dd>
+            </div>
+            <div v-if="camera.acquiredAt" class="flex justify-between text-sm">
+              <dt class="text-gray-500 dark:text-gray-400">Acquired</dt>
+              <dd class="text-gray-900 dark:text-gray-100">
+                {{ formatDate(camera.acquiredAt) }}
+              </dd>
+            </div>
+            <div v-if="camera.notes" class="flex flex-col gap-1 text-sm">
+              <dt class="text-gray-500 dark:text-gray-400">Notes</dt>
+              <dd class="text-gray-900 dark:text-gray-100 whitespace-pre-wrap">
+                {{ camera.notes }}
+              </dd>
+            </div>
+          </dl>
+        </div>
+
+        <!-- Film history card -->
+        <div class="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6">
+          <h2
+            class="text-sm font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-4"
+          >
+            Film History
+          </h2>
+
+          <div
+            v-if="filmsLoading"
+            role="status"
+            aria-label="Loading film history"
+            class="text-sm text-gray-600 dark:text-gray-400 py-4 text-center"
+          >
+            Loading...
+          </div>
+
+          <div
+            v-else-if="films.length === 0"
+            class="text-sm text-gray-600 dark:text-gray-400 py-4 text-center italic"
+          >
+            No films have been loaded into this camera yet.
+          </div>
+
+          <ul v-else class="space-y-3">
+            <li
+              v-for="film in films"
+              :key="film.id"
+              class="flex items-center justify-between text-sm border-b border-gray-100 dark:border-gray-700 pb-3 last:border-0 last:pb-0"
+            >
+              <RouterLink
+                :to="{ name: 'film-detail', params: { key: film.id } }"
+                class="text-primary-600 dark:text-primary-400 hover:underline font-medium"
+              >
+                {{ film.name }}
+              </RouterLink>
+              <span
+                class="px-2 text-xs leading-5 font-semibold rounded-full shrink-0"
+                :class="getStateColor(currentStateName(film))"
+              >
+                {{ currentStateName(film) || "No state" }}
+              </span>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from "vue";
+import { RouterLink, useRoute } from "vue-router";
+import { cameraApi, filmApi } from "@/services/api-client";
+import type { Camera, Film } from "@frollz/shared";
+import { currentStateName } from "@/types";
+import { getStateColor } from "@/utils/stateColors";
+
+const route = useRoute();
+
+const camera = ref<Camera | null>(null);
+const films = ref<Film[]>([]);
+const loading = ref(true);
+const filmsLoading = ref(true);
+
+const formatNames = computed(() =>
+  camera.value
+    ? camera.value.acceptedFormats
+        .map((af) => af.format?.name ?? `Format ${af.formatId}`)
+        .join(", ")
+    : "",
+);
+
+function statusLabel(status: Camera["status"]): string {
+  if (status === "active") return "Active";
+  if (status === "retired") return "Retired";
+  return "In Repair";
+}
+
+function statusClass(status: Camera["status"]): string {
+  const base =
+    "inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium";
+  if (status === "active")
+    return `${base} bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300`;
+  if (status === "retired")
+    return `${base} bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300`;
+  return `${base} bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-300`;
+}
+
+function formatDate(date: string): string {
+  return new Date(date).toLocaleDateString();
+}
+
+onMounted(async () => {
+  const id = Number(route.params.id);
+  try {
+    const res = await cameraApi.getById(id);
+    camera.value = res.data;
+  } finally {
+    loading.value = false;
+  }
+
+  filmsLoading.value = true;
+  try {
+    const res = await filmApi.getAll({ cameraId: id });
+    films.value = res.data;
+  } finally {
+    filmsLoading.value = false;
+  }
+});
+</script>

--- a/apps/frollz-ui/src/views/CameraDetailView.vue
+++ b/apps/frollz-ui/src/views/CameraDetailView.vue
@@ -131,7 +131,8 @@
                 :to="{ name: 'film-detail', params: { key: film.id } }"
                 class="text-primary-600 dark:text-primary-400 hover:underline font-medium"
               >
-                {{ film.name }}
+                {{ film.name }} — {{ film.emulsion.manufacturer }}
+                {{ film.emulsion.brand }} ISO {{ film.emulsion.speed }}
               </RouterLink>
               <span
                 class="px-2 text-xs leading-5 font-semibold rounded-full shrink-0"

--- a/apps/frollz-ui/src/views/CamerasView.vue
+++ b/apps/frollz-ui/src/views/CamerasView.vue
@@ -33,9 +33,12 @@
       >
         <div class="flex items-start justify-between gap-3">
           <div class="min-w-0">
-            <p class="font-semibold text-gray-900 dark:text-gray-100 truncate">
+            <RouterLink
+              :to="{ name: 'camera-detail', params: { id: camera.id } }"
+              class="font-semibold text-primary-600 dark:text-primary-400 hover:underline truncate block"
+            >
               {{ camera.brand }} {{ camera.model }}
-            </p>
+            </RouterLink>
             <p class="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
               <span :class="statusClass(camera.status)">{{
                 statusLabel(camera.status)
@@ -112,7 +115,12 @@
               <td
                 class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100"
               >
-                {{ camera.brand }} {{ camera.model }}
+                <RouterLink
+                  :to="{ name: 'camera-detail', params: { id: camera.id } }"
+                  class="text-primary-600 dark:text-primary-400 hover:underline font-medium"
+                >
+                  {{ camera.brand }} {{ camera.model }}
+                </RouterLink>
                 <span
                   v-if="camera.serialNumber"
                   class="block text-xs text-gray-400 dark:text-gray-500"
@@ -383,6 +391,7 @@
 
 <script setup lang="ts">
 import { ref, onMounted } from "vue";
+import { RouterLink } from "vue-router";
 import { cameraApi, formatApi } from "@/services/api-client";
 import type { Camera, Format } from "@/types";
 import BaseModal from "@/components/BaseModal.vue";

--- a/apps/frollz-ui/src/views/CamerasView.vue
+++ b/apps/frollz-ui/src/views/CamerasView.vue
@@ -50,6 +50,13 @@
             >
               {{ formatNames(camera) }}
             </p>
+            <RouterLink
+              v-if="loadedFilmByCameraId.get(camera.id)"
+              :to="{ name: 'film-detail', params: { key: loadedFilmByCameraId.get(camera.id)!.id } }"
+              class="mt-1 text-xs text-primary-600 dark:text-primary-400 hover:underline block"
+            >
+              ↳ {{ loadedFilmByCameraId.get(camera.id)!.name }} (loaded)
+            </RouterLink>
           </div>
           <div class="flex gap-2 shrink-0">
             <button
@@ -126,6 +133,13 @@
                   class="block text-xs text-gray-400 dark:text-gray-500"
                   >#{{ camera.serialNumber }}</span
                 >
+                <RouterLink
+                  v-if="loadedFilmByCameraId.get(camera.id)"
+                  :to="{ name: 'film-detail', params: { key: loadedFilmByCameraId.get(camera.id)!.id } }"
+                  class="block text-xs text-primary-600 dark:text-primary-400 hover:underline mt-0.5"
+                >
+                  ↳ {{ loadedFilmByCameraId.get(camera.id)!.name }} (loaded)
+                </RouterLink>
               </td>
               <td class="px-6 py-4 whitespace-nowrap text-sm">
                 <span :class="statusClass(camera.status)">{{
@@ -390,10 +404,10 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from "vue";
+import { ref, computed, onMounted } from "vue";
 import { RouterLink } from "vue-router";
-import { cameraApi, formatApi } from "@/services/api-client";
-import type { Camera, Format } from "@/types";
+import { cameraApi, filmApi, formatApi } from "@/services/api-client";
+import type { Camera, Film, Format } from "@/types";
 import BaseModal from "@/components/BaseModal.vue";
 import { useNotificationStore } from "@/stores/notification";
 
@@ -403,7 +417,30 @@ type FormMode = "create" | "edit" | null;
 
 const cameras = ref<Camera[]>([]);
 const formats = ref<Format[]>([]);
+const loadedFilms = ref<Film[]>([]);
 const isLoading = ref(false);
+
+function getCameraIdFromLoadedFilm(film: Film): number | null {
+  const loadedState = [...film.states]
+    .sort((a, b) => b.id - a.id)
+    .find((s) => s.state?.name === "Loaded");
+  if (!loadedState) return null;
+  const meta = loadedState.metadata.find(
+    (m) => m.transitionStateMetadata?.field?.name === "cameraId",
+  );
+  const val = meta?.value;
+  if (!val || Array.isArray(val)) return null;
+  return parseInt(val, 10) || null;
+}
+
+const loadedFilmByCameraId = computed(() => {
+  const map = new Map<number, Film>();
+  for (const film of loadedFilms.value) {
+    const cameraId = getCameraIdFromLoadedFilm(film);
+    if (cameraId !== null) map.set(cameraId, film);
+  }
+  return map;
+});
 
 const formMode = ref<FormMode>(null);
 const editingId = ref<number | null>(null);
@@ -455,8 +492,12 @@ function toIsoDateTime(dateOnly: string): string {
 const loadCameras = async () => {
   isLoading.value = true;
   try {
-    const res = await cameraApi.getAll();
-    cameras.value = res.data;
+    const [cameraRes, filmRes] = await Promise.all([
+      cameraApi.getAll(),
+      filmApi.getAll({ state: ["Loaded"] }),
+    ]);
+    cameras.value = cameraRes.data;
+    loadedFilms.value = filmRes.data;
   } catch (err) {
     console.error("Error loading cameras:", err);
   } finally {

--- a/apps/frollz-ui/src/views/FilmsView.vue
+++ b/apps/frollz-ui/src/views/FilmsView.vue
@@ -506,10 +506,10 @@
                 {{ film.emulsion?.brand ?? "—" }}
               </p>
               <p
-                v-if="getLoadedCamera(film)"
+                v-if="loadedCameraByFilmId.has(film.id)"
                 class="text-xs text-gray-500 dark:text-gray-400 mt-0.5 truncate"
               >
-                {{ getLoadedCamera(film)!.brand }} {{ getLoadedCamera(film)!.model }}
+                {{ loadedCameraByFilmId.get(film.id)!.brand }} {{ loadedCameraByFilmId.get(film.id)!.model }}
               </p>
             </div>
             <div class="shrink-0 flex items-center gap-2">
@@ -667,7 +667,7 @@
               <tr
                 v-for="film in filteredFilms"
                 :key="film.id"
-                v-memo="[film, film.states]"
+                v-memo="[film, film.states, loadedCameraByFilmId.get(film.id)]"
               >
                 <td
                   class="px-6 py-4 whitespace-nowrap text-sm font-medium text-primary-600 dark:text-primary-400 cursor-pointer hover:underline"
@@ -696,8 +696,8 @@
                   class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400"
                 >
                   {{
-                    getLoadedCamera(film)
-                      ? `${getLoadedCamera(film)!.brand} ${getLoadedCamera(film)!.model}`
+                    loadedCameraByFilmId.has(film.id)
+                      ? `${loadedCameraByFilmId.get(film.id)!.brand} ${loadedCameraByFilmId.get(film.id)!.model}`
                       : "—"
                   }}
                 </td>
@@ -1146,16 +1146,26 @@ const clearAllFilters = () => {
 
 const getStateName = (film: Film): string => currentStateName(film);
 
-const getLoadedCamera = (film: Film): Camera | null => {
+function extractLoadedCameraId(film: Film): number | null {
   const loadedState = film.states.find((s) => s.state?.name === "Loaded");
   const meta = loadedState?.metadata.find(
     (m) => m.transitionStateMetadata?.field?.name === "cameraId",
   );
   const val = meta?.value;
   if (!val || Array.isArray(val)) return null;
-  const id = parseInt(val, 10);
-  return cameras.value.find((c) => c.id === id) ?? null;
-};
+  return parseInt(val, 10) || null;
+}
+
+const loadedCameraByFilmId = computed(() => {
+  const map = new Map<number, Camera>();
+  for (const film of films.value) {
+    const cameraId = extractLoadedCameraId(film);
+    if (cameraId === null) continue;
+    const camera = cameras.value.find((c) => c.id === cameraId);
+    if (camera) map.set(film.id, camera);
+  }
+  return map;
+});
 
 const emptyForm = () => ({
   name: "",

--- a/apps/frollz-ui/vite.config.ts
+++ b/apps/frollz-ui/vite.config.ts
@@ -1,10 +1,11 @@
 import { defineConfig } from 'vite';
 import vue from '@vitejs/plugin-vue';
+import vueDevTools from 'vite-plugin-vue-devtools'
 import { resolve } from 'path'
 
 
 export default defineConfig({
-  plugins: [vue()],
+  plugins: [vue(), vueDevTools()],
   optimizeDeps: {
     include: ['@frollz/shared'],
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,6 +238,9 @@ importers:
       vite:
         specifier: ^8.0.8
         version: 8.0.8(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)
+      vite-plugin-vue-devtools:
+        specifier: ^8.1.1
+        version: 8.1.1(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))(vue@3.5.32(typescript@6.0.2))
       vitest:
         specifier: ^4.1.4
         version: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
@@ -386,8 +389,66 @@ packages:
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/compat-data@7.29.0':
+    resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.0':
+    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/generator@7.29.1':
     resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-annotate-as-pure@7.27.3':
+    resolution: {integrity: sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.28.6':
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-create-class-features-plugin@7.28.6':
+    resolution: {integrity: sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-member-expression-to-functions@7.28.5':
+    resolution: {integrity: sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.28.6':
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.28.6':
+    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-optimise-call-expression@7.27.1':
+    resolution: {integrity: sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-plugin-utils@7.28.6':
+    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-replace-supers@7.28.6':
+    resolution: {integrity: sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
+    resolution: {integrity: sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-string-parser@7.27.1':
@@ -398,10 +459,67 @@ packages:
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.2':
+    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/parser@7.29.2':
     resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  '@babel/plugin-proposal-decorators@7.29.0':
+    resolution: {integrity: sha512-CVBVv3VY/XRMxRYq5dwr2DS7/MvqPm23cOCjbwNnVrfOqcWlnefua1uUs0sjdKOGjvPUG633o07uWzJq4oI6dA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-decorators@7.28.6':
+    resolution: {integrity: sha512-71EYI0ONURHJBL4rSFXnITXqXrrY8q4P0q006DPfN+Rk+ASM+++IBXem/ruokgBZR8YNEWZ8R6B+rCb8VcUTqA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-import-attributes@7.28.6':
+    resolution: {integrity: sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-import-meta@7.10.4':
+    resolution: {integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-jsx@7.28.6':
+    resolution: {integrity: sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-syntax-typescript@7.28.6':
+    resolution: {integrity: sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-typescript@7.28.6':
+    resolution: {integrity: sha512-0YWL2RFxOqEm9Efk5PvreamxPME8OyY0wM5wh5lHjF+VtVhdneCWGzZeSqzOfiobVqQaNCd2z0tQvnI9DaPWPw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
+    engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
@@ -866,6 +984,9 @@ packages:
   '@pkgr/core@0.2.9':
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
+
+  '@polka/url@1.0.0-next.29':
+    resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.15':
     resolution: {integrity: sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==}
@@ -1423,6 +1544,22 @@ packages:
       vue:
         optional: true
 
+  '@vue/babel-helper-vue-transform-on@1.5.0':
+    resolution: {integrity: sha512-0dAYkerNhhHutHZ34JtTl2czVQHUNWv6xEbkdF5W+Yrv5pCWsqjeORdOgbtW2I9gWlt+wBmVn+ttqN9ZxR5tzA==}
+
+  '@vue/babel-plugin-jsx@1.5.0':
+    resolution: {integrity: sha512-mneBhw1oOqCd2247O0Yw/mRwC9jIGACAJUlawkmMBiNmL4dGA2eMzuNZVNqOUfYTa6vqmND4CtOPzmEEEqLKFw==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+
+  '@vue/babel-plugin-resolve-type@1.5.0':
+    resolution: {integrity: sha512-Wm/60o+53JwJODm4Knz47dxJnLDJ9FnKnGZJbUUf8nQRAtt6P+undLUAVU3Ha33LxOJe6IPoifRQ6F/0RrU31w==}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@vue/compiler-core@3.5.32':
     resolution: {integrity: sha512-4x74Tbtqnda8s/NSD6e1Dr5p1c8HdMU5RWSjMSUzb8RTcUQqevDCxVAitcLBKT+ie3o0Dl9crc/S/opJM7qBGQ==}
 
@@ -1440,6 +1577,11 @@ packages:
 
   '@vue/devtools-api@8.1.1':
     resolution: {integrity: sha512-bsDMJ07b3GN1puVwJb/fyFnj/U2imyswK5UQVLZwVl7O05jDrt6BHxeG5XffmOOdasOj/bOmIjxJvGPxU7pcqw==}
+
+  '@vue/devtools-core@8.1.1':
+    resolution: {integrity: sha512-bCCsSABp1/ot4j8xJEycM6Mtt2wbuucfByr6hMgjbYhrtlscOJypZKvy8f1FyWLYrLTchB5Qz216Lm92wfbq0A==}
+    peerDependencies:
+      vue: ^3.0.0
 
   '@vue/devtools-kit@7.7.9':
     resolution: {integrity: sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==}
@@ -1740,6 +1882,10 @@ packages:
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
+  bundle-name@4.1.0:
+    resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
+    engines: {node: '>=18'}
+
   busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
     engines: {node: '>=10.16.0'}
@@ -1975,8 +2121,20 @@ packages:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
 
+  default-browser-id@5.0.1:
+    resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
+    engines: {node: '>=18'}
+
+  default-browser@5.5.0:
+    resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
+    engines: {node: '>=18'}
+
   defaults@1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
+
+  define-lazy-prop@3.0.0:
+    resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
+    engines: {node: '>=12'}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -2049,6 +2207,9 @@ packages:
 
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
+
+  error-stack-parser-es@1.0.5:
+    resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -2355,6 +2516,10 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -2489,6 +2654,11 @@ packages:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
     engines: {node: '>= 0.4'}
 
+  is-docker@3.0.0:
+    resolution: {integrity: sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    hasBin: true
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -2500,6 +2670,11 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-inside-container@1.0.0:
+    resolution: {integrity: sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==}
+    engines: {node: '>=14.16'}
+    hasBin: true
 
   is-interactive@1.0.0:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
@@ -2522,6 +2697,10 @@ packages:
   is-what@5.5.0:
     resolution: {integrity: sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==}
     engines: {node: '>=18'}
+
+  is-wsl@3.1.1:
+    resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
+    engines: {node: '>=16'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -2662,6 +2841,9 @@ packages:
       tedious:
         optional: true
 
+  kolorist@1.8.0:
+    resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
+
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
@@ -2785,6 +2967,9 @@ packages:
   lru-cache@11.3.5:
     resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
     engines: {node: 20 || >=22}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
   magic-string-ast@1.0.3:
     resolution: {integrity: sha512-CvkkH1i81zl7mmb94DsRiFeG9V2fR2JeuK8yDgS8oiZSFa++wWLEgZ5ufEOyLHbvSbD1gTRKv9NdX69Rnvr9JA==}
@@ -3031,6 +3216,10 @@ packages:
   moo-color@1.0.3:
     resolution: {integrity: sha512-i/+ZKXMDf6aqYtBhuOcej71YSlbjT3wCO/4H1j8rPvxDJEifdwgg5MaFyu6iYAT8GBZJg2z0dkgK4YMzvURALQ==}
 
+  mrmime@2.0.1:
+    resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
+    engines: {node: '>=10'}
+
   ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
 
@@ -3107,6 +3296,9 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
+  ohash@2.0.11:
+    resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -3117,6 +3309,10 @@ packages:
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
+
+  open@10.2.0:
+    resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
+    engines: {node: '>=18'}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -3408,6 +3604,10 @@ packages:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
 
+  run-applescript@7.1.0:
+    resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
+    engines: {node: '>=18'}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -3437,6 +3637,10 @@ packages:
 
   scule@1.3.0:
     resolution: {integrity: sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
@@ -3497,6 +3701,10 @@ packages:
 
   simple-get@4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
+  sirv@3.0.2:
+    resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
+    engines: {node: '>=18'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -3681,6 +3889,10 @@ packages:
     resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
     engines: {node: '>=14.16'}
 
+  totalist@3.0.1:
+    resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
+    engines: {node: '>=6'}
+
   tough-cookie@6.0.1:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
@@ -3826,6 +4038,37 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vite-dev-rpc@1.1.0:
+    resolution: {integrity: sha512-pKXZlgoXGoE8sEKiKJSng4hI1sQ4wi5YT24FCrwrLt6opmkjlqPPVmiPWWJn8M8byMxRGzp1CrFuqQs4M/Z39A==}
+    peerDependencies:
+      vite: ^2.9.0 || ^3.0.0-0 || ^4.0.0-0 || ^5.0.0-0 || ^6.0.1 || ^7.0.0-0
+
+  vite-hot-client@2.1.0:
+    resolution: {integrity: sha512-7SpgZmU7R+dDnSmvXE1mfDtnHLHQSisdySVR7lO8ceAXvM0otZeuQQ6C8LrS5d/aYyP/QZ0hI0L+dIPrm4YlFQ==}
+    peerDependencies:
+      vite: ^2.6.0 || ^3.0.0 || ^4.0.0 || ^5.0.0-0 || ^6.0.0-0 || ^7.0.0-0
+
+  vite-plugin-inspect@11.3.3:
+    resolution: {integrity: sha512-u2eV5La99oHoYPHE6UvbwgEqKKOQGz86wMg40CCosP6q8BkB6e5xPneZfYagK4ojPJSj5anHCrnvC20DpwVdRA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@nuxt/kit': '*'
+      vite: ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      '@nuxt/kit':
+        optional: true
+
+  vite-plugin-vue-devtools@8.1.1:
+    resolution: {integrity: sha512-9qTpOmZ2vHpvlI9hdVXAQ1Ry4I8GcBArU7aPi0qfIaV7fQIXy0L1nb6X4mFY2Gw0dYshHuLbIl0Ulb572SCjsQ==}
+    engines: {node: '>=v14.21.3'}
+    peerDependencies:
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  vite-plugin-vue-inspector@5.4.0:
+    resolution: {integrity: sha512-Iq/024CydcE46FZqWPU4t4lw4uYOdLnFSO1RNxJVt2qY9zxIjmnkBqhHnYaReWM82kmNnaXs7OkfgRrV2GEjyw==}
+    peerDependencies:
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
   vite@8.0.8:
     resolution: {integrity: sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==}
@@ -4040,6 +4283,10 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  wsl-utils@0.1.0:
+    resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
+    engines: {node: '>=18'}
+
   xml-name-validator@4.0.0:
     resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
     engines: {node: '>=12'}
@@ -4054,6 +4301,9 @@ packages:
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
   yaml@2.8.3:
     resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
@@ -4141,6 +4391,28 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/compat-data@7.29.0': {}
+
+  '@babel/core@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helpers': 7.29.2
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/generator@7.29.1':
     dependencies:
       '@babel/parser': 7.29.2
@@ -4149,13 +4421,155 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
+  '@babel/helper-annotate-as-pure@7.27.3':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/helper-compilation-targets@7.28.6':
+    dependencies:
+      '@babel/compat-data': 7.29.0
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-create-class-features-plugin@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-member-expression-to-functions': 7.28.5
+      '@babel/helper-optimise-call-expression': 7.27.1
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/traverse': 7.29.0
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-member-expression-to-functions@7.28.5':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-imports@7.28.6':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-optimise-call-expression@7.27.1':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/helper-plugin-utils@7.28.6': {}
+
+  '@babel/helper-replace-supers@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-member-expression-to-functions': 7.28.5
+      '@babel/helper-optimise-call-expression': 7.27.1
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-string-parser@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
 
+  '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helpers@7.29.2':
+    dependencies:
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+
   '@babel/parser@7.29.2':
     dependencies:
       '@babel/types': 7.29.0
+
+  '@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/plugin-syntax-decorators': 7.28.6(@babel/core@7.29.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-syntax-decorators@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-typescript@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/template@7.28.6':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+
+  '@babel/traverse@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/types@7.29.0':
     dependencies:
@@ -4640,6 +5054,8 @@ snapshots:
     optional: true
 
   '@pkgr/core@0.2.9': {}
+
+  '@polka/url@1.0.0-next.29': {}
 
   '@rolldown/binding-android-arm64@1.0.0-rc.15':
     optional: true
@@ -5152,6 +5568,35 @@ snapshots:
     optionalDependencies:
       vue: 3.5.32(typescript@6.0.2)
 
+  '@vue/babel-helper-vue-transform-on@1.5.0': {}
+
+  '@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@vue/babel-helper-vue-transform-on': 1.5.0
+      '@vue/babel-plugin-resolve-type': 1.5.0(@babel/core@7.29.0)
+      '@vue/shared': 3.5.32
+    optionalDependencies:
+      '@babel/core': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vue/babel-plugin-resolve-type@1.5.0(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/parser': 7.29.2
+      '@vue/compiler-sfc': 3.5.32
+    transitivePeerDependencies:
+      - supports-color
+
   '@vue/compiler-core@3.5.32':
     dependencies:
       '@babel/parser': 7.29.2
@@ -5189,6 +5634,12 @@ snapshots:
   '@vue/devtools-api@8.1.1':
     dependencies:
       '@vue/devtools-kit': 8.1.1
+
+  '@vue/devtools-core@8.1.1(vue@3.5.32(typescript@6.0.2))':
+    dependencies:
+      '@vue/devtools-kit': 8.1.1
+      '@vue/devtools-shared': 8.1.1
+      vue: 3.5.32(typescript@6.0.2)
 
   '@vue/devtools-kit@7.7.9':
     dependencies:
@@ -5537,6 +5988,10 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  bundle-name@4.1.0:
+    dependencies:
+      run-applescript: 7.1.0
+
   busboy@1.6.0:
     dependencies:
       streamsearch: 1.1.0
@@ -5729,9 +6184,18 @@ snapshots:
 
   deepmerge@4.3.1: {}
 
+  default-browser-id@5.0.1: {}
+
+  default-browser@5.5.0:
+    dependencies:
+      bundle-name: 4.1.0
+      default-browser-id: 5.0.1
+
   defaults@1.0.4:
     dependencies:
       clone: 1.0.4
+
+  define-lazy-prop@3.0.0: {}
 
   depd@2.0.0: {}
 
@@ -5790,6 +6254,8 @@ snapshots:
   error-ex@1.3.4:
     dependencies:
       is-arrayish: 0.2.1
+
+  error-stack-parser-es@1.0.5: {}
 
   es-define-property@1.0.1: {}
 
@@ -6129,6 +6595,8 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  gensync@1.0.0-beta.2: {}
+
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -6249,6 +6717,8 @@ snapshots:
     dependencies:
       hasown: 2.0.2
 
+  is-docker@3.0.0: {}
+
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
@@ -6256,6 +6726,10 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-inside-container@1.0.0:
+    dependencies:
+      is-docker: 3.0.0
 
   is-interactive@1.0.0: {}
 
@@ -6268,6 +6742,10 @@ snapshots:
   is-unicode-supported@0.1.0: {}
 
   is-what@5.5.0: {}
+
+  is-wsl@3.1.1:
+    dependencies:
+      is-inside-container: 1.0.0
 
   isexe@2.0.0: {}
 
@@ -6406,6 +6884,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  kolorist@1.8.0: {}
+
   levn@0.4.1:
     dependencies:
       prelude-ls: 1.2.1
@@ -6495,6 +6975,10 @@ snapshots:
   lru-cache@10.4.3: {}
 
   lru-cache@11.3.5: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
 
   magic-string-ast@1.0.3:
     dependencies:
@@ -6927,6 +7411,8 @@ snapshots:
     dependencies:
       color-name: 1.1.4
 
+  mrmime@2.0.1: {}
+
   ms@2.1.2: {}
 
   ms@2.1.3: {}
@@ -6991,6 +7477,8 @@ snapshots:
 
   obug@2.1.1: {}
 
+  ohash@2.0.11: {}
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -7002,6 +7490,13 @@ snapshots:
   onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
+
+  open@10.2.0:
+    dependencies:
+      default-browser: 5.5.0
+      define-lazy-prop: 3.0.0
+      is-inside-container: 1.0.0
+      wsl-utils: 0.1.0
 
   optionator@0.9.4:
     dependencies:
@@ -7308,6 +7803,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  run-applescript@7.1.0: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -7342,6 +7839,8 @@ snapshots:
       ajv-keywords: 5.1.0(ajv@8.18.0)
 
   scule@1.3.0: {}
+
+  semver@6.3.1: {}
 
   semver@7.7.4: {}
 
@@ -7421,6 +7920,12 @@ snapshots:
       decompress-response: 6.0.0
       once: 1.4.0
       simple-concat: 1.0.1
+
+  sirv@3.0.2:
+    dependencies:
+      '@polka/url': 1.0.0-next.29
+      mrmime: 2.0.1
+      totalist: 3.0.1
 
   source-map-js@1.2.1: {}
 
@@ -7577,6 +8082,8 @@ snapshots:
       '@borewit/text-codec': 0.2.2
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
+
+  totalist@3.0.1: {}
 
   tough-cookie@6.0.1:
     dependencies:
@@ -7735,6 +8242,60 @@ snapshots:
     optional: true
 
   vary@1.1.2: {}
+
+  vite-dev-rpc@1.1.0(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)):
+    dependencies:
+      birpc: 2.9.0
+      vite: 8.0.8(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)
+      vite-hot-client: 2.1.0(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+
+  vite-hot-client@2.1.0(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)):
+    dependencies:
+      vite: 8.0.8(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)
+
+  vite-plugin-inspect@11.3.3(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)):
+    dependencies:
+      ansis: 4.2.0
+      debug: 4.4.3
+      error-stack-parser-es: 1.0.5
+      ohash: 2.0.11
+      open: 10.2.0
+      perfect-debounce: 2.1.0
+      sirv: 3.0.2
+      unplugin-utils: 0.3.1
+      vite: 8.0.8(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)
+      vite-dev-rpc: 1.1.0(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+    transitivePeerDependencies:
+      - supports-color
+
+  vite-plugin-vue-devtools@8.1.1(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))(vue@3.5.32(typescript@6.0.2)):
+    dependencies:
+      '@vue/devtools-core': 8.1.1(vue@3.5.32(typescript@6.0.2))
+      '@vue/devtools-kit': 8.1.1
+      '@vue/devtools-shared': 8.1.1
+      sirv: 3.0.2
+      vite: 8.0.8(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)
+      vite-plugin-inspect: 11.3.3(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+      vite-plugin-vue-inspector: 5.4.0(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+    transitivePeerDependencies:
+      - '@nuxt/kit'
+      - supports-color
+      - vue
+
+  vite-plugin-vue-inspector@5.4.0(vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
+      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.0)
+      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
+      '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.29.0)
+      '@vue/compiler-dom': 3.5.32
+      kolorist: 1.8.0
+      magic-string: 0.30.21
+      vite: 8.0.8(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - supports-color
 
   vite@8.0.8(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3):
     dependencies:
@@ -7949,6 +8510,10 @@ snapshots:
 
   wrappy@1.0.2: {}
 
+  wsl-utils@0.1.0:
+    dependencies:
+      is-wsl: 3.1.1
+
   xml-name-validator@4.0.0: {}
 
   xml-name-validator@5.0.0: {}
@@ -7956,6 +8521,8 @@ snapshots:
   xmlchars@2.2.0: {}
 
   xtend@4.0.2: {}
+
+  yallist@3.1.1: {}
 
   yaml@2.8.3: {}
 


### PR DESCRIPTION
## What does this PR do?

Closes: #287

This pull request introduces a new camera detail page to the UI, enables filtering films by camera, and improves the linkage between cameras and their loaded films throughout the application. The backend is updated to support filtering films by camera ID, and the frontend now provides richer navigation and detail views for cameras and their associated film history.

### Backend: Film Filtering by Camera

* Added a `cameraId` filter to the `FilmFilters` interface and implemented filtering logic in the `FilmKnexRepository` to allow querying films loaded into a specific camera.
* Updated the film service and controller to accept and process the `cameraId` query parameter, including API documentation and parameter parsing.
**Frontend: Camera Detail Page and Navigation**
* Added a new route `/cameras/:id` and implemented the `CameraDetailView.vue` component, displaying camera details and the history of films loaded into that camera.
* Updated `CamerasView.vue` to link each camera to its detail page and to show the currently loaded film for each camera, both in card and table views.
* Enhanced page title logic in the router to reflect camera detail pages.
**Frontend: Film and Camera Association**
* Updated the film API client to support the `cameraId` parameter, and improved `FilmsView.vue` to use a map for associating films with their loaded cameras, optimizing rendering and lookup.

### Tooling and Dependencies

* Minor updates to `package.json` for dependency ordering, and added `vite-plugin-vue-devtools` for improved development experience.

## How was it tested?

<!-- Describe how you verified the change works. -->

## Checklist

- [x] Tests added or updated
- [x] All tests pass (`npm test` in `frollz-api/` and `frollz-ui/`)
- [x] Lint passes (`npm run lint` in both)
- [x] No `console.log` left in committed code
- [x] PR targets the `development` branch (not `main`)
