### PR TITLE
ci(github): add explicit permissions to ci-cd workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -8,6 +8,9 @@ on:
       - 'v*'
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   ci-api:
     name: API — Lint & Test


### PR DESCRIPTION
## Summary

- Added explicit least-privilege `permissions: contents: read` to top-level of ci-cd workflow
- Resolves GitHub security code scanning flag for missing workflow permissions
- Follows OWASP and GitHub best practices for least-privilege access

## Changes

- `.github/workflows/ci-cd.yml` — Added top-level `permissions` block

## Test Plan

- [x] Pre-commit checks: linting, type-checking, tests all passed
- [x] Review the permissions change in the PR