### PR TITLE
fix(ui): improve Add Emulsion modal — box image upload button contrast

### DIFF
--- a/apps/frollz-ui/src/views/EmulsionsView.vue
+++ b/apps/frollz-ui/src/views/EmulsionsView.vue
@@ -426,7 +426,7 @@
                 type="file"
                 accept="image/jpeg,image/png,image/webp,image/gif"
                 @change="onBoxImageChange"
-                class="mt-1 w-full text-sm text-gray-700 dark:text-gray-300 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-medium file:bg-primary-50 file:text-primary-700 dark:file:bg-primary-900 dark:file:text-primary-200 hover:file:bg-primary-100"
+                class="mt-1 w-full text-sm text-gray-700 dark:text-gray-300 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-medium file:bg-primary-600 file:text-white dark:file:bg-primary-600 dark:file:text-white hover:file:bg-primary-700 dark:hover:file:bg-primary-700 focus-visible:file:outline-2 focus-visible:file:outline-offset-2 focus-visible:file:outline-primary-500"
               />
             </label>
             <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">


### PR DESCRIPTION
## Summary

- Fixed unreadable button text on hover in the Add Emulsion modal's box image upload field
- Changed button styling from light background to dark button with white text for better accessibility
- Added proper dark mode support and focus-visible styling

## Changes

- `apps/frollz-ui/src/views/EmulsionsView.vue` — Updated file input button styling to ensure WCAG AA 4.5:1 contrast ratio across all states

## Test Plan

- [x] Visual verification: button text is readable in default, hover, and dark mode states
- [x] Lighthouse accessibility audit: confirmed contrast ratios meet WCAG AA standards
- [x] Manual test: button remains accessible with keyboard navigation (focus-visible state)
- [x] Run `pnpm test` — all tests pass
- [x] Run `pnpm check-types` — no type errors
- [x] Run `pnpm lint` — no lint errors

## Closes

Closes #298