### PR TITLE
style(ui): FilmsView accessibility and UX quick wins

### DIFF
--- a/apps/frollz-ui/src/utils/stateColors.ts
+++ b/apps/frollz-ui/src/utils/stateColors.ts
@@ -23,3 +23,21 @@ const DEFAULT_COLOR =
 
 export const getStateColor = (state: string): string =>
   STATE_COLORS[state] ?? DEFAULT_COLOR;
+
+const STATE_BORDER_COLORS: Record<string, string> = {
+  Imported: "border-teal-400 dark:border-teal-500",
+  Added: "border-orange-400 dark:border-orange-500",
+  Frozen: "border-blue-400 dark:border-blue-500",
+  Refrigerated: "border-cyan-400 dark:border-cyan-500",
+  Shelved: "border-gray-400 dark:border-gray-500",
+  Loaded: "border-yellow-400 dark:border-yellow-500",
+  Finished: "border-green-400 dark:border-green-500",
+  "Sent For Development": "border-orange-400 dark:border-orange-500",
+  Developed: "border-purple-400 dark:border-purple-500",
+  Received: "border-indigo-400 dark:border-indigo-500",
+};
+
+const DEFAULT_BORDER_COLOR = "border-gray-400 dark:border-gray-500";
+
+export const getStateBorderColor = (state: string): string =>
+  STATE_BORDER_COLORS[state] ?? DEFAULT_BORDER_COLOR;

--- a/apps/frollz-ui/src/views/FilmsView.vue
+++ b/apps/frollz-ui/src/views/FilmsView.vue
@@ -95,12 +95,12 @@
       class="mb-3 bg-white dark:bg-gray-800 rounded-lg shadow-md p-4"
     >
       <!-- State -->
-      <div class="mb-4">
-        <div
-          class="text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 mb-2"
+      <fieldset class="mb-6">
+        <legend
+          class="text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-300 mb-2"
         >
           State
-        </div>
+        </legend>
         <div class="flex flex-wrap gap-2">
           <label
             v-for="state in filmStateOptions"
@@ -109,7 +109,7 @@
             class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md border cursor-pointer text-sm transition-colors"
             :class="
               selectedStates.includes(state)
-                ? 'bg-primary-100 dark:bg-primary-900 border-primary-600 dark:border-primary-400 text-primary-800 dark:text-primary-200'
+                ? `${getStateColor(state)} ${getStateBorderColor(state)}`
                 : 'bg-white dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-600'
             "
           >
@@ -123,10 +123,10 @@
             {{ state }}
           </label>
         </div>
-      </div>
+      </fieldset>
 
       <!-- Emulsion / Format -->
-      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6 border-t border-gray-700 pt-4">
         <div>
           <label
             for="filter-emulsion"
@@ -174,21 +174,21 @@
       </div>
 
       <!-- Tags (searchable multi-select) -->
-      <div class="mb-4" v-if="tags.length > 0">
-        <div
-          class="text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 mb-2"
+      <fieldset class="mb-6 border-t border-gray-700 pt-4" v-if="tags.length > 0">
+        <legend
+          class="text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-300 mb-2"
         >
           Tags
-        </div>
+        </legend>
         <TagMultiSelect
           v-model="selectedTagIds"
           :available-tags="tags"
           placeholder="Search tags…"
         />
-      </div>
+      </fieldset>
 
       <!-- Loaded date range -->
-      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 border-t border-gray-700 pt-4">
         <div>
           <label
             for="filter-from"
@@ -224,6 +224,9 @@
         class="mt-2 text-sm text-red-600 dark:text-red-400"
       >
         {{ dateRangeError }}
+      </p>
+      <p class="mt-4 border-t border-gray-700 pt-3 text-sm text-gray-500 dark:text-gray-400">
+        {{ filteredFilms.length }} result(s)
       </p>
     </div>
 
@@ -408,31 +411,30 @@
           <thead class="bg-gray-50 dark:bg-gray-700">
             <tr>
               <th
-                class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider cursor-pointer select-none"
+                class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider cursor-pointer select-none"
               >
                 Name
               </th>
               <th
-                class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider cursor-pointer select-none"
+                class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider cursor-pointer select-none"
               >
                 Emulsion
               </th>
               <th
-                class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider cursor-pointer select-none"
+                class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider cursor-pointer select-none"
               >
                 State
               </th>
               <th
-                class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider select-none"
+                class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider select-none"
               >
                 Camera
               </th>
               <th
-                class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider select-none"
+                class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider select-none"
               >
                 Scans
               </th>
-              <th class="px-6 py-3"></th>
             </tr>
           </thead>
           <tbody
@@ -462,13 +464,12 @@
                   ></div>
                 </td>
                 <td class="px-6 py-4"></td>
-                <td class="px-6 py-4"></td>
               </tr>
             </template>
             <template v-else>
               <tr v-if="filteredFilms.length === 0">
                 <td
-                  colspan="6"
+                  colspan="5"
                   class="px-6 py-8 text-center text-sm text-gray-600 dark:text-gray-400 italic"
                 >
                   No films found.
@@ -479,16 +480,11 @@
                 :key="film.id"
                 v-memo="[film, film.states, loadedCameraByFilmId.get(film.id)]"
               >
-                <td
-                  class="px-6 py-4 whitespace-nowrap text-sm font-medium text-primary-600 dark:text-primary-400 cursor-pointer hover:underline"
-                  @click="
-                    $router.push({
-                      name: 'film-detail',
-                      params: { key: film.id },
-                    })
-                  "
-                >
-                  {{ film.name }}
+                <td class="px-6 py-4 whitespace-nowrap text-sm font-medium">
+                  <RouterLink
+                    :to="{ name: 'film-detail', params: { key: film.id } }"
+                    class="text-primary-600 dark:text-primary-400 hover:underline"
+                  >{{ film.name }}</RouterLink>
                 </td>
                 <td
                   class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400"
@@ -574,19 +570,6 @@
                       {{ getScanUrls(film).length }}
                     </RouterLink>
                   </template>
-                </td>
-                <td class="px-6 py-4 whitespace-nowrap text-right">
-                  <button
-                    @click="
-                      $router.push({
-                        name: 'film-detail',
-                        params: { key: film.id },
-                      })
-                    "
-                    class="px-3 py-2 min-h-[44px] text-xs font-medium text-primary-600 dark:text-primary-400 border border-primary-300 dark:border-primary-600 rounded hover:bg-primary-50 dark:hover:bg-primary-900/30"
-                  >
-                    View
-                  </button>
                 </td>
               </tr>
             </template>
@@ -765,7 +748,7 @@ import TagMultiSelect from "@/components/TagMultiSelect.vue";
 import type { Film, Emulsion, TransitionProfile, Format, Tag } from "@/types";
 import type { Camera } from "@frollz/shared";
 import { currentStateName, getScanUrls } from "@/types";
-import { getStateColor } from "@/utils/stateColors";
+import { getStateColor, getStateBorderColor } from "@/utils/stateColors";
 
 const route = useRoute();
 const router = useRouter();


### PR DESCRIPTION
## Summary

- Six targeted fixes to `FilmsView.vue` addressing WCAG AA contrast, screen-reader semantics, redundant navigation, and filter panel polish — no new components required
- STATE filter chips now use the existing `getStateColor` badge palette when selected (filled) vs. grey border (unselected), via a new `getStateBorderColor` companion exported from `stateColors.ts`
- The redundant "View" button column is fully removed; film names link directly via `<RouterLink>` for proper keyboard and assistive-tech navigation

## Changes

- `apps/frollz-ui/src/utils/stateColors.ts` — add `getStateBorderColor` export matching each state to its border color class
- `apps/frollz-ui/src/views/FilmsView.vue`
  - `<th>` labels: `dark:text-gray-400` → `dark:text-gray-300` (WCAG AA 4.5:1)
  - STATE and TAGS filter groups wrapped in `<fieldset>` / `<legend>`
  - STATE chips color-coded via `getStateColor` + `getStateBorderColor`
  - `border-t border-gray-700` dividers and `mb-6` spacing between filter sections
  - Live `filteredFilms.length result(s)` count at bottom of filter panel
  - Film name column uses `<RouterLink>` instead of imperative `@click`
  - Redundant "View" button `<td>` and its `<th>` removed; skeleton and `colspan` fixed to 5

## Test Plan

- [ ] `pnpm test` — all 142 UI tests pass
- [ ] `pnpm check-types` — no type errors
- [ ] `pnpm lint` — no lint errors
- [ ] Open FilmsView in dark mode — table headers (NAME, EMULSION, STATE, CAMERA, SCANS) are visibly brighter than before
- [ ] Open filter panel — STATE and TAGS sections appear as `<fieldset>` groups with visible dividers; result count updates as filters change
- [ ] Select a STATE filter chip — chip fills with the state's badge color (e.g. orange for Added, yellow for Loaded); deselect returns to grey border
- [ ] Click a film name in the table — navigates to film detail page; no "View" button present in any row
- [ ] Run Lighthouse accessibility audit — `td-has-header` failure is resolved; fieldset/legend improves form region score

## Closes

Closes #294