### PR TITLE
fix(ui): Add idempotency key to all ui components

### DIFF
--- a/apps/ui/src/composables/useApi.ts
+++ b/apps/ui/src/composables/useApi.ts
@@ -19,6 +19,19 @@ export function useApi() {
     let response = await fetch(input, { ...init, headers });
 
     if (response.status === 401 && authStore.refreshToken) {
+      const method = (init.method ?? 'GET').toUpperCase();
+      const isMutation = method === 'POST' || method === 'PATCH' || method === 'PUT' || method === 'DELETE';
+      const hasIdempotencyKey = new Headers(init.headers).has('idempotency-key');
+
+      // Never retry a mutation without an idempotency key — the server would execute it twice.
+      if (isMutation && !hasIdempotencyKey) {
+        authStore.clearTokens();
+        if (router.currentRoute.value.path !== '/login') {
+          await router.replace('/login');
+        }
+        return response;
+      }
+
       const tokenPair = await authStore.refreshAccessToken();
 
       if (tokenPair) {

--- a/apps/ui/src/pages/DevicesPage.vue
+++ b/apps/ui/src/pages/DevicesPage.vue
@@ -34,6 +34,7 @@ const route = useRoute();
 
 const isCreateDrawerOpen = ref(false);
 const isCreatingDevice = ref(false);
+const pendingCreateKey = ref<string>(createIdempotencyKey());
 const cameraDateAcquiredTimestamp = ref<number | null>(null);
 const createState = ref<FormState>({ loading: false, fieldErrors: {}, formError: null });
 
@@ -255,6 +256,11 @@ onMounted(async () => {
   }
 });
 
+function openCreateDrawer(): void {
+  pendingCreateKey.value = createIdempotencyKey();
+  isCreateDrawerOpen.value = true;
+}
+
 async function submitCreateDevice(): Promise<void> {
   if (isCreatingDevice.value) {
     return;
@@ -315,8 +321,9 @@ async function submitCreateDevice(): Promise<void> {
   createState.value.formError = null;
 
   try {
-    await deviceStore.createDevice(payload, createIdempotencyKey());
+    await deviceStore.createDevice(payload, pendingCreateKey.value);
     isCreateDrawerOpen.value = false;
+    pendingCreateKey.value = createIdempotencyKey();
     resetCreateForm();
     feedback.success('Device added successfully.');
   } catch (error) {
@@ -331,7 +338,7 @@ async function submitCreateDevice(): Promise<void> {
 <template>
   <PageShell title="Devices" :subtitle="pageSubtitle">
     <template #actions>
-      <NButton type="primary" @click="isCreateDrawerOpen = true">Add device</NButton>
+      <NButton type="primary" @click="openCreateDrawer">Add device</NButton>
       <NButton tertiary @click="refresh">Refresh</NButton>
     </template>
 

--- a/apps/ui/src/pages/FilmDetailPage.vue
+++ b/apps/ui/src/pages/FilmDetailPage.vue
@@ -44,6 +44,7 @@ const feedback = useUiFeedback();
 const filmId = computed(() => Number(route.params.id));
 const isEventDrawerOpen = ref(false);
 const isSavingEvent = ref(false);
+const pendingEventKey = ref<string>(createIdempotencyKey());
 const occurredAtTimestamp = ref<number | null>(Date.now());
 
 const eventForm = reactive<{
@@ -516,6 +517,11 @@ function buildEventData(): Record<string, unknown> {
   }
 }
 
+function openEventDrawer(): void {
+  pendingEventKey.value = createIdempotencyKey();
+  isEventDrawerOpen.value = true;
+}
+
 async function submitEvent(): Promise<void> {
   if (isSavingEvent.value || !selectedFilm.value) {
     return;
@@ -547,15 +553,16 @@ async function submitEvent(): Promise<void> {
         frameStateCode: eventForm.filmStateCode as CreateFrameJourneyEventRequest['frameStateCode'],
         ...payloadBase
       };
-      await filmStore.addFrameEvent(selectedFilm.value.id, frameId, payload, createIdempotencyKey());
+      await filmStore.addFrameEvent(selectedFilm.value.id, frameId, payload, pendingEventKey.value);
     } else {
       const payload: CreateFilmJourneyEventRequest = {
         filmStateCode: eventForm.filmStateCode as FilmStateCode,
         ...payloadBase
       };
-      await filmStore.addEvent(selectedFilm.value.id, payload, createIdempotencyKey());
+      await filmStore.addEvent(selectedFilm.value.id, payload, pendingEventKey.value);
     }
     isEventDrawerOpen.value = false;
+    pendingEventKey.value = createIdempotencyKey();
     feedback.success('Event saved. Timeline updated.');
   } catch (error) {
     eventState.value.formError = feedback.toErrorMessage(error, 'Could not save this event.');
@@ -578,6 +585,7 @@ onMounted(async () => {
     await filmStore.loadFilm(filmId.value);
 
     if (route.query.openEvent === '1' && transitions.value.length > 0) {
+      pendingEventKey.value = createIdempotencyKey();
       isEventDrawerOpen.value = true;
     }
   } catch (error) {
@@ -595,7 +603,7 @@ onBeforeUnmount(() => {
   <PageShell title="Film Detail" subtitle="Review state history and add the next transition.">
     <template #actions>
       <NButton tertiary @click="goBack">Back</NButton>
-      <NButton type="primary" @click="isEventDrawerOpen = true">Add transition event</NButton>
+      <NButton type="primary" @click="openEventDrawer">Add transition event</NButton>
     </template>
 
     <NAlert v-if="filmStore.detailError" type="error" :show-icon="true" style="margin-bottom: 12px;">

--- a/apps/ui/src/pages/FilmPage.vue
+++ b/apps/ui/src/pages/FilmPage.vue
@@ -50,6 +50,7 @@ const feedback = useUiFeedback();
 
 const isCreateDrawerOpen = ref(false);
 const isCreatingFilm = ref(false);
+const pendingCreateKey = ref<string>(createIdempotencyKey());
 const expirationTimestamp = ref<number | null>(null);
 const childStateFilter = ref<string | null>(null);
 const childSearchTerm = ref('');
@@ -252,6 +253,11 @@ function resetCreateForm(): void {
   createState.value.formError = null;
 }
 
+function openCreateDrawer(): void {
+  pendingCreateKey.value = createIdempotencyKey();
+  isCreateDrawerOpen.value = true;
+}
+
 async function submitCreateFilm(): Promise<void> {
   if (isCreatingFilm.value) {
     return;
@@ -276,8 +282,9 @@ async function submitCreateFilm(): Promise<void> {
   createState.value.formError = null;
 
   try {
-    await filmStore.createFilm(payload, createIdempotencyKey());
+    await filmStore.createFilm(payload, pendingCreateKey.value);
     isCreateDrawerOpen.value = false;
+    pendingCreateKey.value = createIdempotencyKey();
     resetCreateForm();
     feedback.success('Film created successfully.');
   } catch (error) {
@@ -292,7 +299,7 @@ async function submitCreateFilm(): Promise<void> {
 <template>
   <PageShell title="Film Inventory" :subtitle="pageSubtitle">
     <template #actions>
-      <NButton type="primary" @click="isCreateDrawerOpen = true">Add film</NButton>
+      <NButton type="primary" @click="openCreateDrawer">Add film</NButton>
       <NButton tertiary @click="refresh">Refresh</NButton>
     </template>
 


### PR DESCRIPTION
The UI could replay certain requests on the API and cause it to attempt to save data twice. Adding this key to the header to allow the API to discard replays

## What does this PR do?

<!-- Brief description of the change and why it was needed. -->

## How was it tested?

<!-- Describe how you verified the change works. -->

## Checklist

- [ ] Tests added or updated
- [ ] All tests pass (`npm test` in `frollz-api/` and `frollz-ui/`)
- [ ] Lint passes (`npm run lint` in both)
- [ ] No `console.log` left in committed code
- [ ] PR targets the `development` branch (not `main`)
