### PR TITLE
Refactor code simplification across API, UI, and E2E tests

### DIFF
--- a/apps/api/src/infrastructure/repositories/mikro-orm-film.repository.ts
+++ b/apps/api/src/infrastructure/repositories/mikro-orm-film.repository.ts
@@ -1,6 +1,15 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { EntityManager } from '@mikro-orm/core';
-import { filmJourneyEventDataLoadedSchema, type DeviceLoadTimelineEvent } from '@frollz2/schema';
+import {
+  filmJourneyEventDataLoadedSchema,
+  type DeviceLoadTimelineEvent,
+  type FilmDetail,
+  type FilmFrame,
+  type FilmJourneyEvent,
+  type FilmListQuery,
+  type FilmSummary,
+  type FilmUpdateRequest
+} from '@frollz2/schema';
 import { FilmRepository } from './film.repository.js';
 import { FilmEntity, FilmFrameEntity, FilmJourneyEventEntity } from '../entities/index.js';
 import { mapFilmDetailEntity, mapFilmFrameEntity, mapFilmJourneyEventEntity, mapFilmSummaryEntity } from '../mappers/index.js';
@@ -62,7 +71,7 @@ export class MikroOrmFilmRepository extends FilmRepository {
     super();
   }
 
-  async list(userId: number, query: { stateCode?: 'purchased' | 'stored' | 'loaded' | 'exposed' | 'removed' | 'sent_for_dev' | 'developed' | 'scanned' | 'archived'; filmFormatId?: number; emulsionId?: number }) {
+  async list(userId: number, query: FilmListQuery): Promise<FilmSummary[]> {
     const films = await this.entityManager.find(
       FilmEntity,
       {
@@ -77,7 +86,7 @@ export class MikroOrmFilmRepository extends FilmRepository {
     return films.map(mapFilmSummaryEntity);
   }
 
-  async findById(userId: number, filmId: number) {
+  async findById(userId: number, filmId: number): Promise<FilmDetail | null> {
     const film = await this.entityManager.findOne(
       FilmEntity,
       { id: filmId, user: userId },
@@ -97,7 +106,7 @@ export class MikroOrmFilmRepository extends FilmRepository {
     return mapFilmDetailEntity(film, latestEvent ?? null);
   }
 
-  async findByIdSummary(userId: number, filmId: number) {
+  async findByIdSummary(userId: number, filmId: number): Promise<FilmSummary | null> {
     const film = await this.entityManager.findOne(
       FilmEntity,
       { id: filmId, user: userId },
@@ -107,7 +116,7 @@ export class MikroOrmFilmRepository extends FilmRepository {
     return film ? mapFilmSummaryEntity(film) : null;
   }
 
-  async update(userId: number, filmId: number, input: { name?: string; expirationDate?: string | null }) {
+  async update(userId: number, filmId: number, input: FilmUpdateRequest): Promise<FilmSummary | null> {
     const film = await this.entityManager.findOne(FilmEntity, { id: filmId, user: userId });
 
     if (!film) {
@@ -134,7 +143,7 @@ export class MikroOrmFilmRepository extends FilmRepository {
     return mapFilmSummaryEntity(persisted);
   }
 
-  async listEvents(userId: number, filmId: number) {
+  async listEvents(userId: number, filmId: number): Promise<FilmJourneyEvent[]> {
     const events = await this.entityManager.find(
       FilmJourneyEventEntity,
       { film: filmId, user: userId },
@@ -144,7 +153,7 @@ export class MikroOrmFilmRepository extends FilmRepository {
     return events.map(mapFilmJourneyEventEntity);
   }
 
-  async listFrames(userId: number, filmId: number) {
+  async listFrames(userId: number, filmId: number): Promise<FilmFrame[]> {
     const frames = await this.entityManager.find(
       FilmFrameEntity,
       { user: userId, legacyFilm: filmId },

--- a/apps/api/src/modules/film/film.service.ts
+++ b/apps/api/src/modules/film/film.service.ts
@@ -935,7 +935,12 @@ export class FilmService {
       if (packageTypeCode === '100ft_bulk') {
         throw new DomainError('DOMAIN_ERROR', '35mm 100ft bulk must be converted to a supported roll before loading');
       }
-      const exposures = packageTypeCode === '24exp' ? 24 : packageTypeCode === '36exp' ? 36 : null;
+      let exposures: number | null = null;
+      if (packageTypeCode === '24exp') {
+        exposures = 24;
+      } else if (packageTypeCode === '36exp') {
+        exposures = 36;
+      }
       if (!exposures) {
         throw new DomainError('DOMAIN_ERROR', 'Unsupported 35mm package type for frame generation');
       }

--- a/apps/ui/e2e/ux-flows.e2e.ts
+++ b/apps/ui/e2e/ux-flows.e2e.ts
@@ -39,23 +39,49 @@ const referencePayload = {
   }
 };
 
+const authTokenResponse = { data: { accessToken: 'access-token', refreshToken: 'refresh-token' } };
+const authUserResponse = { data: { id: 1, email: 'ux@example.com', name: 'UX User', createdAt: '2026-01-01T00:00:00.000Z' } };
+const defaultPassword = 'good-password';
+
+async function fillLoginForm(page: Page, password: string): Promise<void> {
+  await page.locator('[data-testid="login-email"] input').fill(authUserResponse.data.email);
+  await page.locator('[data-testid="login-password"] input').fill(password);
+}
+
+async function stubReference(page: Page, payload: unknown = referencePayload): Promise<void> {
+  await page.route('**/api/v1/reference', async (route) => {
+    await route.fulfill({ json: payload });
+  });
+}
+
+async function stubEmptyFilms(page: Page): Promise<void> {
+  await page.route('**/api/v1/film*', async (route) => {
+    await route.fulfill({ json: { data: [] } });
+  });
+}
+
+async function stubEmptyDevices(page: Page): Promise<void> {
+  await page.route('**/api/v1/devices*', async (route) => {
+    await route.fulfill({ json: { data: [] } });
+  });
+}
+
 async function mockLogin(page: Page): Promise<void> {
   await page.route('**/api/v1/auth/login', async (route) => {
-    await route.fulfill({ json: { data: { accessToken: 'access-token', refreshToken: 'refresh-token' } } });
+    await route.fulfill({ json: authTokenResponse });
   });
   await page.route('**/api/v1/auth/refresh', async (route) => {
-    await route.fulfill({ json: { data: { accessToken: 'access-token', refreshToken: 'refresh-token' } } });
+    await route.fulfill({ json: authTokenResponse });
   });
 
   await page.route('**/api/v1/auth/me', async (route) => {
-    await route.fulfill({ json: { data: { id: 1, email: 'ux@example.com', name: 'UX User', createdAt: '2026-01-01T00:00:00.000Z' } } });
+    await route.fulfill({ json: authUserResponse });
   });
 }
 
 async function loginThroughUi(page: Page): Promise<void> {
   await page.goto('/login');
-  await page.locator('[data-testid="login-email"] input').fill('ux@example.com');
-  await page.locator('[data-testid="login-password"] input').fill('good-password');
+  await fillLoginForm(page, defaultPassword);
   await page.getByTestId('login-submit').click();
   await expect(page).toHaveURL(/\/dashboard/);
 }
@@ -74,29 +100,23 @@ test('auth flow shows error and succeeds with visible feedback', async ({ page }
       return;
     }
 
-    await route.fulfill({ json: { data: { accessToken: 'access-token', refreshToken: 'refresh-token' } } });
+    await route.fulfill({ json: authTokenResponse });
   });
 
   await page.route('**/api/v1/auth/me', async (route) => {
-    await route.fulfill({ json: { data: { id: 1, email: 'ux@example.com', name: 'UX User', createdAt: '2026-01-01T00:00:00.000Z' } } });
+    await route.fulfill({ json: authUserResponse });
   });
 
-  await page.route('**/api/v1/reference', async (route) => {
-    await route.fulfill({ json: referencePayload });
-  });
-
-  await page.route('**/api/v1/film*', async (route) => {
-    await route.fulfill({ json: { data: [] } });
-  });
+  await stubReference(page);
+  await stubEmptyFilms(page);
 
   await page.goto('/login');
-  await page.locator('[data-testid="login-email"] input').fill('ux@example.com');
-  await page.locator('[data-testid="login-password"] input').fill('wrong-password');
+  await fillLoginForm(page, 'wrong-password');
   await page.getByTestId('login-submit').click();
 
   await expect(page.getByText(/Invalid credentials/i)).toBeVisible();
 
-  await page.locator('[data-testid="login-password"] input').fill('good-password');
+  await page.locator('[data-testid="login-password"] input').fill(defaultPassword);
   await page.getByTestId('login-submit').click();
 
   await expect(page).toHaveURL(/\/dashboard/);
@@ -108,9 +128,7 @@ test('film create flow validates required fields from dashboard create action', 
 
   const films: FilmSummary[] = [];
 
-  await page.route('**/api/v1/reference', async (route) => {
-    await route.fulfill({ json: referencePayload });
-  });
+  await stubReference(page);
 
   await page.route('**/api/v1/film*', async (route) => {
     if (route.request().method() === 'POST') {
@@ -159,9 +177,7 @@ test('film create flow validates required fields from dashboard create action', 
 test('event composer opens from inventory and supports conditional fields', async ({ page }) => {
   await mockLogin(page);
 
-  await page.route('**/api/v1/reference', async (route) => {
-    await route.fulfill({ json: referencePayload });
-  });
+  await stubReference(page);
 
   await page.route('**/api/v1/film*', async (route) => {
     const url = new URL(route.request().url());
@@ -302,9 +318,7 @@ test('mini dashboards render recent tail-window lists and stats cards', async ({
     }
   };
 
-  await page.route('**/api/v1/reference', async (route) => {
-    await route.fulfill({ json: expandedReferencePayload });
-  });
+  await stubReference(page, expandedReferencePayload);
 
   await page.route('**/api/v1/film*', async (route) => {
     await route.fulfill({
@@ -343,9 +357,12 @@ test('mini dashboards render recent tail-window lists and stats cards', async ({
           deviceTypeId: 1,
           deviceTypeCode: 'camera',
           filmFormatId: 1,
-          frameSize: '36x24',
+          frameSize: 'full_frame',
           make: 'Nikon',
           model: `F${index + 1}`,
+          loadMode: 'direct',
+          canUnload: true,
+          cameraSystem: '',
           serialNumber: null,
           dateAcquired: null
         }))
@@ -380,29 +397,34 @@ test('mini dashboards render recent tail-window lists and stats cards', async ({
 test('device sub-route uses page-centric table and links to device detail', async ({ page }) => {
   await mockLogin(page);
 
-  await page.route('**/api/v1/reference', async (route) => {
-    await route.fulfill({
-      json: {
-        data: {
-          ...referencePayload.data,
-          filmFormats: [
-            { id: 1, code: '35mm', label: '35mm' },
-            { id: 2, code: '120', label: '120' },
-            { id: 3, code: '4x5', label: '4x5' }
-          ],
-          deviceTypes: [
-            { id: 1, code: 'camera', label: 'Camera' },
-            { id: 2, code: 'interchangeable_back', label: 'Interchangeable back' },
-            { id: 3, code: 'film_holder', label: 'Film holder' }
-          ],
-          holderTypes: [{ id: 1, code: 'standard', label: 'Standard' }]
-        }
-      }
-    });
+  await stubReference(page, {
+    data: {
+      ...referencePayload.data,
+      filmFormats: [
+        { id: 1, code: '35mm', label: '35mm' },
+        { id: 2, code: '120', label: '120' },
+        { id: 3, code: '4x5', label: '4x5' }
+      ],
+      deviceTypes: [
+        { id: 1, code: 'camera', label: 'Camera' },
+        { id: 2, code: 'interchangeable_back', label: 'Interchangeable back' },
+        { id: 3, code: 'film_holder', label: 'Film holder' }
+      ],
+      holderTypes: [{ id: 1, code: 'standard', label: 'Standard' }]
+    }
   });
 
   await page.route('**/api/v1/devices**', async (route) => {
     const url = new URL(route.request().url());
+
+    if (/^\/api\/v1\/devices\/\d+\/load-events$/.test(url.pathname)) {
+      await route.fulfill({
+        json: {
+          data: []
+        }
+      });
+      return;
+    }
 
     if (/^\/api\/v1\/devices\/\d+$/.test(url.pathname)) {
       await route.fulfill({
@@ -413,9 +435,12 @@ test('device sub-route uses page-centric table and links to device detail', asyn
             deviceTypeId: 1,
             deviceTypeCode: 'camera',
             filmFormatId: 1,
-            frameSize: '36x24',
+            frameSize: 'full_frame',
             make: 'Nikon',
             model: 'F3',
+            loadMode: 'direct',
+            canUnload: true,
+            cameraSystem: '',
             serialNumber: null,
             dateAcquired: null
           }
@@ -433,9 +458,12 @@ test('device sub-route uses page-centric table and links to device detail', asyn
             deviceTypeId: 1,
             deviceTypeCode: 'camera',
             filmFormatId: 1,
-            frameSize: '36x24',
+            frameSize: 'full_frame',
             make: 'Nikon',
             model: 'F3',
+            loadMode: 'direct',
+            canUnload: true,
+            cameraSystem: '',
             serialNumber: null,
             dateAcquired: null
           },
@@ -454,9 +482,7 @@ test('device sub-route uses page-centric table and links to device detail', asyn
     });
   });
 
-  await page.route('**/api/v1/film*', async (route) => {
-    await route.fulfill({ json: { data: [] } });
-  });
+  await stubEmptyFilms(page);
 
   await loginThroughUi(page);
   await page.goto('/devices/cameras');
@@ -469,7 +495,7 @@ test('device sub-route uses page-centric table and links to device detail', asyn
 
   await page.getByRole('link', { name: 'Nikon F3' }).click();
   await expect(page).toHaveURL(/\/devices\/1$/);
-  await expect(page.getByRole('heading', { name: 'Device Detail' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Device Detail', exact: true })).toBeVisible();
   await expect(page.getByText('Nikon F3')).toBeVisible();
 
   await page.getByRole('button', { name: 'Back' }).click();
@@ -524,13 +550,8 @@ test('emulsion sub-route uses page-centric table and links to emulsion detail', 
     });
   });
 
-  await page.route('**/api/v1/film*', async (route) => {
-    await route.fulfill({ json: { data: [] } });
-  });
-
-  await page.route('**/api/v1/devices*', async (route) => {
-    await route.fulfill({ json: { data: [] } });
-  });
+  await stubEmptyFilms(page);
+  await stubEmptyDevices(page);
 
   await loginThroughUi(page);
   await page.goto('/emulsions/color-negative-c41');
@@ -553,13 +574,8 @@ test('emulsion sub-route uses page-centric table and links to emulsion detail', 
 test('mobile navigation uses drawer menu', async ({ page }) => {
   await mockLogin(page);
 
-  await page.route('**/api/v1/reference', async (route) => {
-    await route.fulfill({ json: referencePayload });
-  });
-
-  await page.route('**/api/v1/film*', async (route) => {
-    await route.fulfill({ json: { data: [] } });
-  });
+  await stubReference(page);
+  await stubEmptyFilms(page);
 
   await page.setViewportSize({ width: 390, height: 844 });
   await loginThroughUi(page);
@@ -586,12 +602,8 @@ test('mobile navigation uses drawer menu', async ({ page }) => {
 
 test('layouts expose one main landmark in auth and app routes', async ({ page }) => {
   await mockLogin(page);
-  await page.route('**/api/v1/reference', async (route) => {
-    await route.fulfill({ json: referencePayload });
-  });
-  await page.route('**/api/v1/film*', async (route) => {
-    await route.fulfill({ json: { data: [] } });
-  });
+  await stubReference(page);
+  await stubEmptyFilms(page);
 
   await page.goto('/login');
   await expect(page.locator('main')).toHaveCount(1);
@@ -630,11 +642,11 @@ test('route entry performs one bootstrap fetch per dataset', async ({ page }) =>
   await page.goto('/film');
   await expect(page.getByRole('heading', { name: 'Film Inventory' })).toBeVisible();
   expect(referenceRequests).toBe(1);
-  expect(filmRequests).toBe(1);
+  await expect.poll(() => filmRequests).toBe(1);
 
   await page.goto('/devices');
   await expect(page.getByRole('heading', { name: 'Devices', exact: true })).toBeVisible();
-  expect(deviceRequests).toBe(1);
+  await expect.poll(() => deviceRequests).toBe(1);
 });
 
 test('refresh failure gracefully routes to login without hard reload', async ({ page }) => {
@@ -654,9 +666,7 @@ test('refresh failure gracefully routes to login without hard reload', async ({ 
     });
   });
 
-  await page.route('**/api/v1/film*', async (route) => {
-    await route.fulfill({ json: { data: [] } });
-  });
+  await stubEmptyFilms(page);
 
   await loginThroughUi(page);
   await page.goto('/film');

--- a/apps/ui/src/components/AppRouteTextLink.vue
+++ b/apps/ui/src/components/AppRouteTextLink.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import { RouterLink } from 'vue-router';
+
+defineProps<{
+  label: string;
+  to: string;
+  testId?: string;
+}>();
+</script>
+
+<template>
+  <RouterLink :to="to" class="app-route-text-link" :data-testid="testId">
+    {{ label }}
+  </RouterLink>
+</template>
+
+<style scoped>
+.app-route-text-link {
+  color: var(--n-primary-color);
+  font-weight: 600;
+  text-decoration: none;
+  text-decoration-color: var(--n-primary-color);
+}
+
+.app-route-text-link:hover {
+  text-decoration: underline;
+}
+
+.app-route-text-link:visited {
+  color: var(--n-primary-color);
+}
+
+.app-route-text-link:focus-visible {
+  border-radius: 4px;
+  outline: 2px solid var(--n-primary-color);
+  outline-offset: 2px;
+}
+</style>

--- a/apps/ui/src/components/DetailPageShell.vue
+++ b/apps/ui/src/components/DetailPageShell.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+import { useRouter } from 'vue-router';
+import { NAlert, NButton } from 'naive-ui';
+import PageShell from './PageShell.vue';
+
+const props = defineProps<{
+  title: string;
+  subtitle: string;
+  fallbackPath: string;
+  errorMessage?: string | null;
+}>();
+
+const router = useRouter();
+
+function goBack(): void {
+  if (window.history.length > 1) {
+    router.back();
+    return;
+  }
+
+  router.push(props.fallbackPath);
+}
+</script>
+
+<template>
+  <PageShell :title="title" :subtitle="subtitle">
+    <template #actions>
+      <NButton tertiary @click="goBack">Back</NButton>
+      <slot name="actions" />
+    </template>
+
+    <NAlert
+      v-if="errorMessage"
+      type="error"
+      :show-icon="true"
+      class="detail-page-shell__alert"
+    >
+      {{ errorMessage }}
+    </NAlert>
+
+    <slot />
+  </PageShell>
+</template>
+
+<style scoped>
+.detail-page-shell__alert {
+  margin-bottom: 12px;
+}
+</style>

--- a/apps/ui/src/components/MiniDashboardLayout.vue
+++ b/apps/ui/src/components/MiniDashboardLayout.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import DashboardSplitLayout from './inventory/DashboardSplitLayout.vue';
+
 defineProps<{
   leftPanelTitle: string;
   rightPanelTitle: string;
@@ -6,69 +8,18 @@ defineProps<{
 </script>
 
 <template>
-  <div class="mini-dashboard">
-    <section class="mini-dashboard__left">
-      <slot name="left-header">
-        <h2 class="mini-dashboard__title">{{ leftPanelTitle }}</h2>
-      </slot>
-      <div class="mini-dashboard__scroll-body">
-        <slot name="left" />
-      </div>
-    </section>
-
-    <section class="mini-dashboard__right">
-      <slot name="right-header">
-        <h2 class="mini-dashboard__title">{{ rightPanelTitle }}</h2>
-      </slot>
-      <div class="mini-dashboard__stats-body">
-        <slot name="right" />
-      </div>
-    </section>
-  </div>
+  <DashboardSplitLayout :left-panel-title="leftPanelTitle" :right-panel-title="rightPanelTitle">
+    <template v-if="$slots['left-header']" #left-header>
+      <slot name="left-header" />
+    </template>
+    <template #left>
+      <slot name="left" />
+    </template>
+    <template v-if="$slots['right-header']" #right-header>
+      <slot name="right-header" />
+    </template>
+    <template #right>
+      <slot name="right" />
+    </template>
+  </DashboardSplitLayout>
 </template>
-
-<style scoped>
-.mini-dashboard {
-  display: grid;
-  gap: 16px;
-  grid-template-columns: minmax(0, 1.9fr) minmax(280px, 1fr);
-}
-
-.mini-dashboard__left,
-.mini-dashboard__right {
-  display: grid;
-  gap: 10px;
-  min-width: 0;
-}
-
-.mini-dashboard__title {
-  font-size: 0.95rem;
-  font-weight: 600;
-  letter-spacing: 0.01em;
-  margin: 0;
-}
-
-.mini-dashboard__scroll-body {
-  max-height: 540px;
-  min-height: 420px;
-  overflow-y: auto;
-  padding-right: 6px;
-}
-
-.mini-dashboard__stats-body {
-  display: grid;
-  gap: 12px;
-}
-
-@media (max-width: 980px) {
-  .mini-dashboard {
-    grid-template-columns: minmax(0, 1fr);
-  }
-
-  .mini-dashboard__scroll-body {
-    max-height: 420px;
-    min-height: 280px;
-    padding-right: 0;
-  }
-}
-</style>

--- a/apps/ui/src/components/PageShell.vue
+++ b/apps/ui/src/components/PageShell.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { NFlex, NSpace, NThing } from 'naive-ui';
+
 defineProps<{
   title: string;
   subtitle?: string;
@@ -8,18 +10,16 @@ defineProps<{
 
 <template>
   <section class="page-shell" :class="{ 'page-shell--compact': compact }">
-    <header class="page-shell__header">
-      <div>
-        <h1 class="page-shell__title">{{ title }}</h1>
-        <p v-if="subtitle" class="page-shell__subtitle">{{ subtitle }}</p>
-      </div>
-      <div v-if="$slots.actions" class="page-shell__actions">
+    <NFlex class="page-shell__header" justify="space-between" align="flex-start" :wrap="false">
+      <NThing v-if="subtitle" class="page-shell__heading" :title="title" :description="subtitle" />
+      <NThing v-else class="page-shell__heading" :title="title" />
+      <NFlex v-if="$slots.actions" class="page-shell__actions" justify="end">
         <slot name="actions" />
-      </div>
-    </header>
-    <div class="page-shell__body">
+      </NFlex>
+    </NFlex>
+    <NSpace vertical :size="16">
       <slot />
-    </div>
+    </NSpace>
   </section>
 </template>
 
@@ -36,36 +36,19 @@ defineProps<{
 }
 
 .page-shell__header {
-  align-items: flex-start;
-  display: flex;
   gap: 12px;
-  justify-content: space-between;
   margin-bottom: 18px;
 }
 
-.page-shell__title {
-  font-size: 1.25rem;
-  letter-spacing: 0.01em;
-  line-height: 1.25;
-  margin: 0;
-}
-
-.page-shell__subtitle {
-  color: #b9c5d4;
-  margin: 6px 0 0;
+.page-shell__heading {
   max-width: 74ch;
+  min-width: 0;
 }
 
 .page-shell__actions {
-  display: flex;
   flex-wrap: wrap;
   gap: 8px;
-  justify-content: flex-end;
-}
-
-.page-shell__body {
-  display: grid;
-  gap: 16px;
+  min-width: fit-content;
 }
 
 @media (max-width: 900px) {
@@ -74,8 +57,8 @@ defineProps<{
   }
 
   .page-shell__header {
-    flex-direction: column;
     margin-bottom: 12px;
+    flex-wrap: wrap;
   }
 
   .page-shell__actions {

--- a/apps/ui/src/components/device/DeviceCreateDrawer.vue
+++ b/apps/ui/src/components/device/DeviceCreateDrawer.vue
@@ -1,0 +1,496 @@
+<script setup lang="ts">
+import { computed, reactive, ref, watch } from 'vue';
+import {
+  NAlert,
+  NButton,
+  NDatePicker,
+  NDrawer,
+  NDrawerContent,
+  NFlex,
+  NForm,
+  NFormItem,
+  NGrid,
+  NGridItem,
+  NInput,
+  NSelect,
+  NSwitch
+} from 'naive-ui';
+import type { CreateFilmDeviceRequest } from '@frollz2/schema';
+import { createIdempotencyKey } from '../../composables/idempotency.js';
+import { useUiFeedback } from '../../composables/useUiFeedback.js';
+import { useReferenceStore } from '../../stores/reference.js';
+import { useDeviceStore } from '../../stores/devices.js';
+import type { FormState } from '../../composables/ui-state.js';
+
+const props = defineProps<{
+  show: boolean;
+}>();
+
+const emit = defineEmits<{
+  'update:show': [value: boolean];
+  created: [];
+}>();
+
+const referenceStore = useReferenceStore();
+const deviceStore = useDeviceStore();
+const feedback = useUiFeedback();
+
+const isCreatingDevice = ref(false);
+const pendingCreateKey = ref<string>(createIdempotencyKey());
+const cameraDateAcquiredTimestamp = ref<number | null>(null);
+const createState = ref<FormState>({ loading: false, fieldErrors: {}, formError: null });
+
+const createForm = reactive({
+  deviceTypeCode: null as string | null,
+  filmFormatId: null as number | null,
+  frameSize: '',
+  make: '',
+  model: '',
+  serialNumber: '',
+  loadMode: 'direct' as 'direct' | 'interchangeable_back' | 'film_holder',
+  canUnload: true,
+  cameraSystem: '',
+  name: '',
+  system: '',
+  brand: '',
+  slotCount: 1 as 1 | 2,
+  holderTypeId: null as number | null
+});
+
+const isOpen = computed<boolean>({
+  get: (): boolean => props.show,
+  set: (value: boolean): void => {
+    emit('update:show', value);
+  }
+});
+
+const deviceTypeOptions = computed(() =>
+  referenceStore.deviceTypes.map((entry) => ({ label: entry.label, value: entry.code }))
+);
+
+const filmFormatOptions = computed(() =>
+  referenceStore.filmFormats.map((entry) => ({ label: entry.label, value: entry.id }))
+);
+
+const selectedFormatCode = computed(() => {
+  if (!createForm.filmFormatId) {
+    return null;
+  }
+
+  return referenceStore.filmFormats.find((entry) => entry.id === createForm.filmFormatId)?.code ?? null;
+});
+
+const frameSizeOptions = computed(() => {
+  const code = selectedFormatCode.value;
+  if (!code) {
+    return [];
+  }
+
+  if (code === '35mm') {
+    return [
+      { label: 'Full Frame', value: 'full_frame' },
+      { label: 'Half Frame', value: 'half_frame' }
+    ];
+  }
+
+  if (code === '120' || code === '220') {
+    return ['645', '6x6', '6x7', '6x8', '6x9', '6x12', '6x17'].map((value) => ({ label: value, value }));
+  }
+
+  if (code === '4x5' || code === '8x10' || code === '2x3') {
+    return [{ label: code, value: code }];
+  }
+
+  if (code === 'InstaxMini' || code === 'InstaxWide' || code === 'InstaxSquare') {
+    return [{ label: 'Instax', value: 'instax' }];
+  }
+
+  return [];
+});
+
+const holderTypeOptions = computed(() =>
+  referenceStore.holderTypes.map((entry) => ({ label: entry.label, value: entry.id }))
+);
+
+const cameraLoadModeOptions = computed(() => [
+  { label: 'Direct', value: 'direct' },
+  { label: 'Interchangeable back', value: 'interchangeable_back' },
+  { label: 'Film holder', value: 'film_holder' }
+]);
+
+const holderSlotCountOptions = computed(() => [
+  { label: '1 slot', value: 1 },
+  { label: '2 slots', value: 2 }
+]);
+
+function validateCreateForm(): Record<string, string> {
+  const errors: Record<string, string> = {};
+
+  if (!createForm.deviceTypeCode) {
+    errors.deviceTypeCode = 'Device type is required.';
+  }
+  if (!createForm.filmFormatId) {
+    errors.filmFormatId = 'Film format is required.';
+  }
+  if (!createForm.frameSize) {
+    errors.frameSize = 'Frame size is required.';
+  }
+
+  if (createForm.deviceTypeCode === 'camera') {
+    if (!createForm.make.trim()) {
+      errors.make = 'Camera make is required.';
+    }
+    if (!createForm.model.trim()) {
+      errors.model = 'Camera model is required.';
+    }
+    if (createForm.loadMode === 'interchangeable_back' && !createForm.cameraSystem.trim()) {
+      errors.cameraSystem = 'Camera system is required for interchangeable back cameras.';
+    }
+  }
+
+  if (createForm.deviceTypeCode === 'interchangeable_back') {
+    if (!createForm.name.trim()) {
+      errors.name = 'Back name is required.';
+    }
+    if (!createForm.system.trim()) {
+      errors.system = 'System is required.';
+    }
+  }
+
+  if (createForm.deviceTypeCode === 'film_holder') {
+    if (!createForm.name.trim()) {
+      errors.name = 'Holder name is required.';
+    }
+    if (!createForm.brand.trim()) {
+      errors.brand = 'Brand is required.';
+    }
+    if (!createForm.holderTypeId) {
+      errors.holderTypeId = 'Holder type is required.';
+    }
+  }
+
+  return errors;
+}
+
+function resetCreateForm(): void {
+  createForm.deviceTypeCode = null;
+  createForm.filmFormatId = null;
+  createForm.frameSize = '';
+  createForm.make = '';
+  createForm.model = '';
+  createForm.serialNumber = '';
+  createForm.loadMode = 'direct';
+  createForm.canUnload = true;
+  createForm.cameraSystem = '';
+  createForm.name = '';
+  createForm.system = '';
+  createForm.brand = '';
+  createForm.slotCount = 1;
+  createForm.holderTypeId = null;
+  cameraDateAcquiredTimestamp.value = null;
+  createState.value = {
+    loading: false,
+    fieldErrors: {},
+    formError: null
+  };
+}
+
+function handleClose(): void {
+  isOpen.value = false;
+}
+
+async function submitCreateDevice(): Promise<void> {
+  if (isCreatingDevice.value) {
+    return;
+  }
+
+  createState.value.fieldErrors = validateCreateForm();
+  if (Object.keys(createState.value.fieldErrors).length > 0) {
+    createState.value.formError = 'Please complete required fields.';
+    return;
+  }
+
+  const deviceType = referenceStore.deviceTypes.find((entry) => entry.code === createForm.deviceTypeCode);
+  if (!deviceType) {
+    createState.value.formError = 'Device type is not available.';
+    return;
+  }
+
+  let payload: CreateFilmDeviceRequest;
+
+  if (createForm.deviceTypeCode === 'camera') {
+    payload = {
+      deviceTypeCode: 'camera',
+      deviceTypeId: deviceType.id,
+      filmFormatId: createForm.filmFormatId as number,
+      frameSize: createForm.frameSize as CreateFilmDeviceRequest['frameSize'],
+      make: createForm.make.trim(),
+      model: createForm.model.trim(),
+      loadMode: createForm.loadMode,
+      canUnload: createForm.canUnload,
+      cameraSystem: createForm.cameraSystem.trim() || null,
+      serialNumber: createForm.serialNumber || null,
+      dateAcquired: cameraDateAcquiredTimestamp.value ? new Date(cameraDateAcquiredTimestamp.value).toISOString() : null
+    };
+  } else if (createForm.deviceTypeCode === 'interchangeable_back') {
+    payload = {
+      deviceTypeCode: 'interchangeable_back',
+      deviceTypeId: deviceType.id,
+      filmFormatId: createForm.filmFormatId as number,
+      frameSize: createForm.frameSize as CreateFilmDeviceRequest['frameSize'],
+      name: createForm.name.trim(),
+      system: createForm.system.trim()
+    };
+  } else {
+    payload = {
+      deviceTypeCode: 'film_holder',
+      deviceTypeId: deviceType.id,
+      filmFormatId: createForm.filmFormatId as number,
+      frameSize: createForm.frameSize as CreateFilmDeviceRequest['frameSize'],
+      name: createForm.name.trim(),
+      brand: createForm.brand.trim(),
+      slotCount: createForm.slotCount,
+      holderTypeId: createForm.holderTypeId as number
+    };
+  }
+
+  isCreatingDevice.value = true;
+  createState.value.loading = true;
+  createState.value.formError = null;
+
+  try {
+    await deviceStore.createDevice(payload, pendingCreateKey.value);
+    pendingCreateKey.value = createIdempotencyKey();
+    resetCreateForm();
+    handleClose();
+    emit('created');
+    feedback.success('Device added successfully.');
+  } catch (error) {
+    createState.value.formError = feedback.toErrorMessage(error, 'Could not create device.');
+  } finally {
+    isCreatingDevice.value = false;
+    createState.value.loading = false;
+  }
+}
+
+watch(
+  () => props.show,
+  (value) => {
+    if (value) {
+      pendingCreateKey.value = createIdempotencyKey();
+      return;
+    }
+
+    resetCreateForm();
+  }
+);
+</script>
+
+<template>
+  <NDrawer v-model:show="isOpen" placement="right" width="min(100vw, 440px)">
+    <NDrawerContent title="Add device" closable>
+      <NForm label-placement="top" @submit.prevent="submitCreateDevice">
+        <NAlert v-if="createState.formError" type="error" :show-icon="true" style="margin-bottom: 10px;">
+          {{ createState.formError }}
+        </NAlert>
+
+        <NGrid cols="1" :y-gap="4">
+          <NGridItem>
+            <NFormItem
+              label="Device type"
+              required
+              :label-props="{ for: 'device-create-type-input' }"
+              :feedback="createState.fieldErrors.deviceTypeCode || ''"
+            >
+              <NSelect
+                :value="createForm.deviceTypeCode"
+                :options="deviceTypeOptions"
+                :input-props="{ id: 'device-create-type-input', name: 'deviceTypeCode' }"
+                @update:value="(value) => { createForm.deviceTypeCode = value; }"
+              />
+            </NFormItem>
+          </NGridItem>
+
+          <NGridItem>
+            <NFormItem
+              label="Film format"
+              required
+              :label-props="{ for: 'device-create-format-input' }"
+              :feedback="createState.fieldErrors.filmFormatId || ''"
+            >
+              <NSelect
+                :value="createForm.filmFormatId"
+                :options="filmFormatOptions"
+                :input-props="{ id: 'device-create-format-input', name: 'filmFormatId' }"
+                @update:value="(value) => { createForm.filmFormatId = value; }"
+              />
+            </NFormItem>
+          </NGridItem>
+
+          <NGridItem>
+            <NFormItem
+              label="Frame size"
+              required
+              :label-props="{ for: 'device-create-frame-size-input' }"
+              :feedback="createState.fieldErrors.frameSize || ''"
+            >
+              <NSelect
+                :value="createForm.frameSize"
+                :options="frameSizeOptions"
+                placeholder="Select frame size"
+                :input-props="{ id: 'device-create-frame-size-input', name: 'frameSize' }"
+                @update:value="(value) => { createForm.frameSize = value; }"
+              />
+            </NFormItem>
+          </NGridItem>
+
+          <template v-if="createForm.deviceTypeCode === 'camera'">
+            <NGridItem>
+              <NFormItem label="Make" required :label-props="{ for: 'device-create-make-input' }" :feedback="createState.fieldErrors.make || ''">
+                <NInput
+                  :value="createForm.make"
+                  :input-props="{ id: 'device-create-make-input', name: 'make' }"
+                  @update:value="(value) => { createForm.make = value; }"
+                />
+              </NFormItem>
+            </NGridItem>
+            <NGridItem>
+              <NFormItem label="Model" required :label-props="{ for: 'device-create-model-input' }" :feedback="createState.fieldErrors.model || ''">
+                <NInput
+                  :value="createForm.model"
+                  :input-props="{ id: 'device-create-model-input', name: 'model' }"
+                  @update:value="(value) => { createForm.model = value; }"
+                />
+              </NFormItem>
+            </NGridItem>
+            <NGridItem>
+              <NFormItem label="Serial number" :label-props="{ for: 'device-create-serial-input' }">
+                <NInput
+                  :value="createForm.serialNumber"
+                  :input-props="{ id: 'device-create-serial-input', name: 'serialNumber' }"
+                  @update:value="(value) => { createForm.serialNumber = value; }"
+                />
+              </NFormItem>
+            </NGridItem>
+            <NGridItem>
+              <NFormItem label="Load mode" :label-props="{ for: 'device-create-load-mode-input' }">
+                <NSelect
+                  :value="createForm.loadMode"
+                  :options="cameraLoadModeOptions"
+                  :input-props="{ id: 'device-create-load-mode-input', name: 'loadMode' }"
+                  @update:value="(value) => { createForm.loadMode = value; }"
+                />
+              </NFormItem>
+            </NGridItem>
+            <NGridItem>
+              <NFormItem label="Can unload film">
+                <NSwitch
+                  :value="createForm.canUnload"
+                  @update:value="(value) => { createForm.canUnload = value; }"
+                />
+              </NFormItem>
+            </NGridItem>
+            <NGridItem>
+              <NFormItem
+                v-if="createForm.loadMode === 'interchangeable_back'"
+                label="Camera system"
+                :label-props="{ for: 'device-create-camera-system-input' }"
+              >
+                <NInput
+                  :value="createForm.cameraSystem"
+                  :input-props="{ id: 'device-create-camera-system-input', name: 'cameraSystem' }"
+                  @update:value="(value) => { createForm.cameraSystem = value; }"
+                />
+              </NFormItem>
+            </NGridItem>
+            <NGridItem>
+              <NFormItem label="Date acquired" :label-props="{ for: 'device-create-date-acquired-input' }">
+                <NDatePicker
+                  :value="cameraDateAcquiredTimestamp"
+                  type="datetime"
+                  clearable
+                  :input-props="{ id: 'device-create-date-acquired-input', name: 'dateAcquired' }"
+                  @update:value="(value) => { cameraDateAcquiredTimestamp = value; }"
+                />
+              </NFormItem>
+            </NGridItem>
+          </template>
+
+          <template v-if="createForm.deviceTypeCode === 'interchangeable_back'">
+            <NGridItem>
+              <NFormItem label="Name" required :label-props="{ for: 'device-create-back-name-input' }" :feedback="createState.fieldErrors.name || ''">
+                <NInput
+                  :value="createForm.name"
+                  :input-props="{ id: 'device-create-back-name-input', name: 'name' }"
+                  @update:value="(value) => { createForm.name = value; }"
+                />
+              </NFormItem>
+            </NGridItem>
+            <NGridItem>
+              <NFormItem label="System" required :label-props="{ for: 'device-create-system-input' }" :feedback="createState.fieldErrors.system || ''">
+                <NInput
+                  :value="createForm.system"
+                  :input-props="{ id: 'device-create-system-input', name: 'system' }"
+                  @update:value="(value) => { createForm.system = value; }"
+                />
+              </NFormItem>
+            </NGridItem>
+          </template>
+
+          <template v-if="createForm.deviceTypeCode === 'film_holder'">
+            <NGridItem>
+              <NFormItem label="Name" required :label-props="{ for: 'device-create-holder-name-input' }" :feedback="createState.fieldErrors.name || ''">
+                <NInput
+                  :value="createForm.name"
+                  :input-props="{ id: 'device-create-holder-name-input', name: 'name' }"
+                  @update:value="(value) => { createForm.name = value; }"
+                />
+              </NFormItem>
+            </NGridItem>
+            <NGridItem>
+              <NFormItem label="Brand" required :label-props="{ for: 'device-create-holder-brand-input' }" :feedback="createState.fieldErrors.brand || ''">
+                <NInput
+                  :value="createForm.brand"
+                  :input-props="{ id: 'device-create-holder-brand-input', name: 'brand' }"
+                  @update:value="(value) => { createForm.brand = value; }"
+                />
+              </NFormItem>
+            </NGridItem>
+            <NGridItem>
+              <NFormItem
+                label="Holder type"
+                required
+                :label-props="{ for: 'device-create-holder-type-input' }"
+                :feedback="createState.fieldErrors.holderTypeId || ''"
+              >
+                <NSelect
+                  :value="createForm.holderTypeId"
+                  :options="holderTypeOptions"
+                  :input-props="{ id: 'device-create-holder-type-input', name: 'holderTypeId' }"
+                  @update:value="(value) => { createForm.holderTypeId = value; }"
+                />
+              </NFormItem>
+            </NGridItem>
+            <NGridItem>
+              <NFormItem label="Slot count" :label-props="{ for: 'device-create-holder-slot-count-input' }">
+                <NSelect
+                  :value="createForm.slotCount"
+                  :options="holderSlotCountOptions"
+                  :input-props="{ id: 'device-create-holder-slot-count-input', name: 'slotCount' }"
+                  @update:value="(value) => { createForm.slotCount = value; }"
+                />
+              </NFormItem>
+            </NGridItem>
+          </template>
+        </NGrid>
+
+        <NFlex justify="end">
+          <NButton tertiary @click="handleClose">Cancel</NButton>
+          <NButton type="primary" attr-type="submit" :loading="isCreatingDevice" :disabled="isCreatingDevice">
+            Create device
+          </NButton>
+        </NFlex>
+      </NForm>
+    </NDrawerContent>
+  </NDrawer>
+</template>

--- a/apps/ui/src/components/device/DeviceLoadTimelineCard.vue
+++ b/apps/ui/src/components/device/DeviceLoadTimelineCard.vue
@@ -1,0 +1,120 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { NCard, NEmpty, NText, NTimeline, NTimelineItem } from 'naive-ui';
+import type { DeviceLoadTimelineEvent } from '@frollz2/schema';
+import { useResponsiveTimelinePlacement } from '../../composables/useResponsiveTimelinePlacement.js';
+import { mapDeviceLoadEventsToTimeline } from '../../pages/device-detail-timeline.js';
+
+const props = defineProps<{
+  events: DeviceLoadTimelineEvent[];
+  loading: boolean;
+}>();
+
+const timelineItems = computed(() => mapDeviceLoadEventsToTimeline(props.events));
+const { timelinePlacement } = useResponsiveTimelinePlacement();
+</script>
+
+<template>
+  <NCard>
+    <NTimeline
+      v-if="timelineItems.length > 0"
+      :item-placement="timelinePlacement"
+      class="device-load-timeline-card__timeline"
+    >
+      <NTimelineItem
+        v-for="item in timelineItems"
+        :key="item.eventId"
+        class="device-load-timeline-card__item"
+      >
+        <template #icon>
+          <span
+            class="device-load-timeline-card__dot"
+            :style="{ backgroundColor: item.dotColor }"
+          />
+        </template>
+
+        <div class="device-load-timeline-card__content">
+          <NText
+            class="device-load-timeline-card__title"
+            :style="{ color: item.titleColor }"
+          >
+            {{ item.filmName }}
+          </NText>
+          <NText class="device-load-timeline-card__emulsion">
+            {{ item.emulsionName }}
+          </NText>
+          <NText
+            v-if="item.stockLabel"
+            depth="3"
+            class="device-load-timeline-card__stock"
+          >
+            {{ item.stockLabel }}
+          </NText>
+          <NText depth="3" class="device-load-timeline-card__date">
+            {{ item.occurredLabel }}
+          </NText>
+          <NText
+            v-if="item.removedLabel"
+            depth="3"
+            class="device-load-timeline-card__date"
+          >
+            Removed: {{ item.removedLabel }}
+          </NText>
+          <NText v-if="item.slotLabel" depth="3">
+            {{ item.slotLabel }}
+          </NText>
+        </div>
+      </NTimelineItem>
+    </NTimeline>
+
+    <NEmpty
+      v-else-if="!loading"
+      description="No load events yet for this device."
+    />
+  </NCard>
+</template>
+
+<style scoped>
+.device-load-timeline-card__timeline {
+  margin-top: 0;
+}
+
+.device-load-timeline-card__item {
+  padding-bottom: 8px;
+}
+
+.device-load-timeline-card__content {
+  width: 100%;
+}
+
+.device-load-timeline-card__title {
+  display: block;
+  font-weight: 600;
+  line-height: 1.2;
+  margin-bottom: 2px;
+}
+
+.device-load-timeline-card__emulsion {
+  display: block;
+  line-height: 1.2;
+  margin-bottom: 2px;
+}
+
+.device-load-timeline-card__stock {
+  display: block;
+  line-height: 1.2;
+  margin-bottom: 2px;
+}
+
+.device-load-timeline-card__date {
+  display: block;
+  line-height: 1.2;
+}
+
+.device-load-timeline-card__dot {
+  border-radius: 999px;
+  display: inline-block;
+  height: 10px;
+  width: 10px;
+}
+</style>

--- a/apps/ui/src/components/device/RecentDevicesCard.vue
+++ b/apps/ui/src/components/device/RecentDevicesCard.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+import { computed } from 'vue';
+import { NCard, NEmpty, NFlex, NTag, NText } from 'naive-ui';
+import type { FilmDevice, FilmFormat } from '@frollz2/schema';
+
+const props = defineProps<{
+  devices: FilmDevice[];
+  filmFormats: FilmFormat[];
+  loading?: boolean;
+  tagTypeByCode: Record<string, 'default' | 'info' | 'primary'>;
+}>();
+
+function deviceDetail(device: FilmDevice): string {
+  if (device.deviceTypeCode === 'camera') {
+    return `${device.make} ${device.model}`;
+  }
+
+  if (device.deviceTypeCode === 'interchangeable_back') {
+    return `${device.name} · ${device.system}`;
+  }
+
+  return `${device.name} · ${device.brand} · ${device.holderTypeCode}`;
+}
+
+function filmFormatLabel(device: FilmDevice): string {
+  return props.filmFormats.find((format: FilmFormat) => format.id === device.filmFormatId)?.code ?? String(device.filmFormatId);
+}
+</script>
+
+<template>
+  <NCard :loading="loading">
+    <NEmpty
+      v-if="!loading && devices.length === 0"
+      description="No devices found."
+    />
+    <NFlex v-else vertical size="small">
+      <NCard v-for="device in devices" :key="device.id" size="small" embedded>
+        <NFlex justify="space-between" align="center" :wrap="false">
+          <NTag size="small" :type="tagTypeByCode[device.deviceTypeCode] ?? 'default'">
+            {{ device.deviceTypeCode.replace('_', ' ') }}
+          </NTag>
+          <NText depth="3">
+            {{ filmFormatLabel(device) }} · {{ device.frameSize }}
+          </NText>
+        </NFlex>
+        <NText strong>{{ deviceDetail(device) }}</NText>
+      </NCard>
+    </NFlex>
+  </NCard>
+</template>

--- a/apps/ui/src/components/emulsion/RecentEmulsionsCard.vue
+++ b/apps/ui/src/components/emulsion/RecentEmulsionsCard.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import { NCard, NEmpty, NFlex, NTag, NText } from 'naive-ui';
+import type { Emulsion } from '@frollz2/schema';
+
+defineProps<{
+  emulsions: Emulsion[];
+  loading?: boolean;
+}>();
+</script>
+
+<template>
+  <NCard :loading="loading">
+    <NEmpty
+      v-if="!loading && emulsions.length === 0"
+      description="No emulsions are available."
+    />
+    <NFlex v-else vertical size="small">
+      <NCard v-for="emulsion in emulsions" :key="emulsion.id" size="small" embedded>
+        <NFlex justify="space-between" align="center" :wrap="false">
+          <NText strong>{{ emulsion.manufacturer }} {{ emulsion.brand }}</NText>
+          <NTag size="small" type="primary">ISO {{ emulsion.isoSpeed }}</NTag>
+        </NFlex>
+        <NText depth="3">{{ emulsion.developmentProcess.label }} · {{ emulsion.balance }}</NText>
+        <NText depth="3">
+          Formats: {{ emulsion.filmFormats.map((format) => format.code).join(', ') || 'None' }}
+        </NText>
+      </NCard>
+    </NFlex>
+  </NCard>
+</template>

--- a/apps/ui/src/components/film/FilmCreateDrawer.vue
+++ b/apps/ui/src/components/film/FilmCreateDrawer.vue
@@ -1,0 +1,277 @@
+<script setup lang="ts">
+import { computed, reactive, ref, watch } from 'vue';
+import {
+  NAlert,
+  NButton,
+  NDatePicker,
+  NDrawer,
+  NDrawerContent,
+  NFlex,
+  NForm,
+  NFormItem,
+  NGrid,
+  NGridItem,
+  NInput,
+  NSelect,
+  NText
+} from 'naive-ui';
+import type { FilmCreateRequest } from '@frollz2/schema';
+import { createIdempotencyKey } from '../../composables/idempotency.js';
+import { useUiFeedback } from '../../composables/useUiFeedback.js';
+import { useFilmStore } from '../../stores/film.js';
+import { useReferenceStore } from '../../stores/reference.js';
+import type { FormState } from '../../composables/ui-state.js';
+
+const props = defineProps<{
+  show: boolean;
+}>();
+
+const emit = defineEmits<{
+  'update:show': [value: boolean];
+  created: [];
+}>();
+
+const filmStore = useFilmStore();
+const referenceStore = useReferenceStore();
+const feedback = useUiFeedback();
+
+const isCreatingFilm = ref(false);
+const pendingCreateKey = ref<string>(createIdempotencyKey());
+const expirationTimestamp = ref<number | null>(null);
+
+const createForm = reactive<{
+  name: string;
+  emulsionId: number | null;
+  filmFormatId: number | null;
+  packageTypeId: number | null;
+}>({
+  name: '',
+  emulsionId: null,
+  filmFormatId: null,
+  packageTypeId: null
+});
+
+const createState = ref<FormState>({
+  loading: false,
+  fieldErrors: {},
+  formError: null
+});
+
+const emulsionOptions = computed(() =>
+  referenceStore.emulsions.map((emulsion) => ({
+    label: `${emulsion.manufacturer} ${emulsion.brand} ${emulsion.isoSpeed}`,
+    value: emulsion.id
+  }))
+);
+
+const formatOptions = computed(() =>
+  referenceStore.filmFormats.map((format) => ({ label: format.label, value: format.id }))
+);
+
+const packageTypeOptions = computed(() => {
+  if (!createForm.filmFormatId) {
+    return [];
+  }
+
+  return referenceStore.packageTypesByFormat(createForm.filmFormatId).map((packageType) => ({
+    label: packageType.label,
+    value: packageType.id
+  }));
+});
+
+const createFieldErrors = computed<Record<string, string>>(() => {
+  const nextErrors: Record<string, string> = {};
+
+  if (!createForm.name.trim()) {
+    nextErrors.name = 'Film name is required.';
+  }
+  if (!createForm.emulsionId) {
+    nextErrors.emulsionId = 'Select an emulsion.';
+  }
+  if (!createForm.filmFormatId) {
+    nextErrors.filmFormatId = 'Select a film format.';
+  }
+  if (!createForm.packageTypeId) {
+    nextErrors.packageTypeId = 'Select a package type.';
+  }
+
+  return nextErrors;
+});
+
+const isOpen = computed<boolean>({
+  get: (): boolean => props.show,
+  set: (value: boolean): void => {
+    emit('update:show', value);
+  }
+});
+
+function resetCreateForm(): void {
+  createForm.name = '';
+  createForm.emulsionId = null;
+  createForm.filmFormatId = null;
+  createForm.packageTypeId = null;
+  expirationTimestamp.value = null;
+  createState.value = {
+    loading: false,
+    fieldErrors: {},
+    formError: null
+  };
+}
+
+function handleClose(): void {
+  isOpen.value = false;
+}
+
+async function submitCreateFilm(): Promise<void> {
+  if (isCreatingFilm.value) {
+    return;
+  }
+
+  createState.value.fieldErrors = createFieldErrors.value;
+  if (Object.keys(createState.value.fieldErrors).length > 0) {
+    createState.value.formError = 'Please complete all required fields.';
+    return;
+  }
+
+  const payload: FilmCreateRequest = {
+    name: createForm.name.trim(),
+    emulsionId: createForm.emulsionId as number,
+    filmFormatId: createForm.filmFormatId as number,
+    packageTypeId: createForm.packageTypeId as number,
+    expirationDate: expirationTimestamp.value ? new Date(expirationTimestamp.value).toISOString() : null
+  };
+
+  isCreatingFilm.value = true;
+  createState.value.loading = true;
+  createState.value.formError = null;
+
+  try {
+    await filmStore.createFilm(payload, pendingCreateKey.value);
+    pendingCreateKey.value = createIdempotencyKey();
+    resetCreateForm();
+    handleClose();
+    emit('created');
+    feedback.success('Film created successfully.');
+  } catch (error) {
+    createState.value.formError = feedback.toErrorMessage(error, 'Could not create film.');
+  } finally {
+    isCreatingFilm.value = false;
+    createState.value.loading = false;
+  }
+}
+
+watch(
+  () => props.show,
+  (value) => {
+    if (value) {
+      pendingCreateKey.value = createIdempotencyKey();
+      return;
+    }
+
+    resetCreateForm();
+  }
+);
+</script>
+
+<template>
+  <NDrawer v-model:show="isOpen" placement="right" width="min(100vw, 420px)">
+    <NDrawerContent title="Add film" closable>
+      <NForm label-placement="top" @submit.prevent="submitCreateFilm">
+        <NAlert v-if="createState.formError" type="error" :show-icon="true" style="margin-bottom: 10px;">
+          {{ createState.formError }}
+        </NAlert>
+
+        <NGrid cols="1" :y-gap="4">
+          <NGridItem>
+            <NFormItem
+              label="Name"
+              required
+              :label-props="{ for: 'film-create-name-input' }"
+              :feedback="createState.fieldErrors.name || ''"
+            >
+              <NInput
+                v-model:value="createForm.name"
+                placeholder="Film label"
+                :input-props="{ id: 'film-create-name-input', name: 'name' }"
+              />
+            </NFormItem>
+          </NGridItem>
+
+          <NGridItem>
+            <NFormItem
+              label="Emulsion"
+              required
+              :label-props="{ for: 'film-create-emulsion-input' }"
+              :feedback="createState.fieldErrors.emulsionId || ''"
+            >
+              <NSelect
+                v-model:value="createForm.emulsionId"
+                :options="emulsionOptions"
+                filterable
+                placeholder="Select emulsion"
+                data-testid="create-film-emulsion"
+                :input-props="{ id: 'film-create-emulsion-input', name: 'emulsionId' }"
+              />
+            </NFormItem>
+          </NGridItem>
+
+          <NGridItem>
+            <NFormItem
+              label="Film format"
+              required
+              :label-props="{ for: 'film-create-format-input' }"
+              :feedback="createState.fieldErrors.filmFormatId || ''"
+            >
+              <NSelect
+                v-model:value="createForm.filmFormatId"
+                :options="formatOptions"
+                placeholder="Select format"
+                data-testid="create-film-format"
+                :input-props="{ id: 'film-create-format-input', name: 'filmFormatId' }"
+                @update:value="createForm.packageTypeId = null"
+              />
+            </NFormItem>
+          </NGridItem>
+
+          <NGridItem>
+            <NFormItem
+              label="Package type"
+              required
+              :label-props="{ for: 'film-create-package-input' }"
+              :feedback="createState.fieldErrors.packageTypeId || ''"
+            >
+              <NSelect
+                v-model:value="createForm.packageTypeId"
+                :options="packageTypeOptions"
+                placeholder="Select package"
+                data-testid="create-film-package"
+                :input-props="{ id: 'film-create-package-input', name: 'packageTypeId' }"
+              />
+            </NFormItem>
+          </NGridItem>
+
+          <NGridItem>
+            <NFormItem label="Expiration date" :label-props="{ for: 'film-create-expiration-input' }">
+              <NDatePicker
+                v-model:value="expirationTimestamp"
+                type="datetime"
+                clearable
+                :input-props="{ id: 'film-create-expiration-input', name: 'expirationDate' }"
+              />
+            </NFormItem>
+          </NGridItem>
+        </NGrid>
+
+        <NFlex justify="space-between" align="center">
+          <NText depth="3">Required fields are marked with an asterisk.</NText>
+          <NFlex>
+            <NButton tertiary @click="handleClose">Cancel</NButton>
+            <NButton type="primary" attr-type="submit" :loading="isCreatingFilm" :disabled="isCreatingFilm">
+              Create film
+            </NButton>
+          </NFlex>
+        </NFlex>
+      </NForm>
+    </NDrawerContent>
+  </NDrawer>
+</template>

--- a/apps/ui/src/components/film/FilmEventDrawer.vue
+++ b/apps/ui/src/components/film/FilmEventDrawer.vue
@@ -1,0 +1,604 @@
+<script setup lang="ts">
+import { computed, reactive, ref, watch } from 'vue';
+import {
+  NAlert,
+  NButton,
+  NDatePicker,
+  NDrawer,
+  NDrawerContent,
+  NFlex,
+  NForm,
+  NFormItem,
+  NGrid,
+  NGridItem,
+  NInput,
+  NInputNumber,
+  NSelect,
+  NText
+} from 'naive-ui';
+import type { CreateFilmJourneyEventRequest, CreateFrameJourneyEventRequest, FilmDevice } from '@frollz2/schema';
+import { filmTransitionMap } from '@frollz2/schema';
+import { createIdempotencyKey } from '../../composables/idempotency.js';
+import { useUiFeedback } from '../../composables/useUiFeedback.js';
+import { useDeviceStore } from '../../stores/devices.js';
+import { useFilmStore } from '../../stores/film.js';
+import { useReferenceStore } from '../../stores/reference.js';
+import type { FormState } from '../../composables/ui-state.js';
+
+type FilmStateCode = CreateFilmJourneyEventRequest['filmStateCode'];
+
+const props = defineProps<{
+  show: boolean;
+  filmId: number | null;
+  currentStateCode: string | null;
+  filmFormatId: number | null;
+  isLargeFormatFilm: boolean;
+}>();
+
+const emit = defineEmits<{
+  'update:show': [value: boolean];
+  saved: [];
+}>();
+
+const filmStore = useFilmStore();
+const referenceStore = useReferenceStore();
+const deviceStore = useDeviceStore();
+const feedback = useUiFeedback();
+
+const isSavingEvent = ref(false);
+const pendingEventKey = ref<string>(createIdempotencyKey());
+const occurredAtTimestamp = ref<number | null>(Date.now());
+const eventState = ref<FormState>({
+  loading: false,
+  fieldErrors: {},
+  formError: null
+});
+
+const eventForm = reactive<{
+  filmStateCode: FilmStateCode | null;
+  notes: string;
+  storageLocationId: number | null;
+  filmFrameId: number | null;
+  deviceId: number | null;
+  slotSideNumber: number | null;
+  intendedPushPull: number | null;
+  labName: string;
+  labContact: string;
+  actualPushPull: number | null;
+  scannerOrSoftware: string;
+  scanLink: string;
+}>({
+  filmStateCode: null,
+  notes: '',
+  storageLocationId: null,
+  filmFrameId: null,
+  deviceId: null,
+  slotSideNumber: null,
+  intendedPushPull: null,
+  labName: '',
+  labContact: '',
+  actualPushPull: null,
+  scannerOrSoftware: '',
+  scanLink: ''
+});
+
+const isOpen = computed<boolean>({
+  get: (): boolean => props.show,
+  set: (value: boolean): void => {
+    emit('update:show', value);
+  }
+});
+
+const transitions = computed<Array<{ label: string; value: FilmStateCode }>>(() => {
+  if (props.isLargeFormatFilm) {
+    const selectedFrame = filmStore.currentFrames.find((frame) => frame.id === eventForm.filmFrameId) ?? null;
+    const current = selectedFrame?.currentStateCode ?? 'purchased';
+    const allowed = filmTransitionMap.get(current) ?? [];
+
+    return referenceStore.filmStates
+      .filter((state) => allowed.includes(state.code))
+      .map((state) => ({ label: state.label, value: state.code as FilmStateCode }));
+  }
+
+  if (!props.currentStateCode) {
+    return [];
+  }
+
+  const allowed = filmTransitionMap.get(props.currentStateCode) ?? [];
+  return referenceStore.filmStates
+    .filter((state) => allowed.includes(state.code))
+    .map((state) => ({ label: state.label, value: state.code as FilmStateCode }));
+});
+
+const storageLocationOptions = computed(() =>
+  referenceStore.storageLocations.map((location) => ({ label: location.label, value: location.id }))
+);
+
+const deviceOptions = computed(() =>
+  deviceStore.devices
+    .filter((device) => {
+      if (!props.filmFormatId || device.filmFormatId !== props.filmFormatId) {
+        return false;
+      }
+
+      if (device.deviceTypeCode === 'camera') {
+        return device.loadMode === 'direct';
+      }
+
+      return true;
+    })
+    .map((device) => ({
+      label: humanizeDevice(device),
+      value: device.id
+    }))
+);
+
+const selectedLoadDevice = computed(() =>
+  eventForm.filmStateCode === 'loaded' && eventForm.deviceId
+    ? deviceStore.devices.find((device) => device.id === eventForm.deviceId) ?? null
+    : null
+);
+
+const holderSlotOptions = computed(() => {
+  if (!selectedLoadDevice.value || selectedLoadDevice.value.deviceTypeCode !== 'film_holder') {
+    return [];
+  }
+
+  return Array.from({ length: selectedLoadDevice.value.slotCount }, (_, index) => {
+    const slotNumber = index + 1;
+    return { label: `Slot ${slotNumber}`, value: slotNumber };
+  });
+});
+
+const availableFrameOptions = computed(() =>
+  filmStore.currentFrames
+    .filter((frame) => props.isLargeFormatFilm || frame.firstLoadedAt === null)
+    .map((frame) => ({
+      label: `Frame #${frame.frameNumber}${props.isLargeFormatFilm ? ` (${humanizeCode(frame.currentStateCode)})` : ''}`,
+      value: frame.id
+    }))
+);
+
+function humanizeCode(value: string): string {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (match) => match.toUpperCase());
+}
+
+function humanizeDevice(device: FilmDevice): string {
+  if (device.deviceTypeCode === 'camera') {
+    return `${device.make} ${device.model}`.trim();
+  }
+  if (device.deviceTypeCode === 'interchangeable_back') {
+    return `${device.name} ${device.system}`.trim();
+  }
+
+  return `${device.name} ${device.brand}`.trim();
+}
+
+function onChangeFilmState(code: string | null): void {
+  eventForm.filmStateCode = code as FilmStateCode | null;
+  eventForm.storageLocationId = null;
+  eventForm.filmFrameId = null;
+  eventForm.deviceId = null;
+  eventForm.slotSideNumber = null;
+  eventForm.intendedPushPull = null;
+  eventForm.labName = '';
+  eventForm.labContact = '';
+  eventForm.actualPushPull = null;
+  eventForm.scannerOrSoftware = '';
+  eventForm.scanLink = '';
+  eventState.value.fieldErrors = {};
+  eventState.value.formError = null;
+}
+
+function onChangeDevice(value: number | null): void {
+  eventForm.deviceId = value;
+  if (!value) {
+    eventForm.slotSideNumber = null;
+    return;
+  }
+
+  const selectedDevice = deviceStore.devices.find((entry) => entry.id === value);
+  if (selectedDevice?.deviceTypeCode === 'film_holder') {
+    if (
+      typeof eventForm.slotSideNumber !== 'number'
+      || eventForm.slotSideNumber < 1
+      || eventForm.slotSideNumber > selectedDevice.slotCount
+    ) {
+      eventForm.slotSideNumber = 1;
+    }
+    return;
+  }
+
+  eventForm.slotSideNumber = null;
+}
+
+function validateEventForm(): Record<string, string> {
+  const errors: Record<string, string> = {};
+
+  if (!eventForm.filmStateCode) {
+    errors.filmStateCode = 'Choose a target state.';
+  }
+
+  if (!occurredAtTimestamp.value) {
+    errors.occurredAt = 'Occurred date and time is required.';
+  }
+
+  if (eventForm.filmStateCode === 'stored' && !eventForm.storageLocationId) {
+    errors.storageLocationId = 'Select a storage location.';
+  }
+
+  if (eventForm.filmStateCode === 'loaded' && !eventForm.deviceId) {
+    errors.deviceId = 'Select a device.';
+  }
+  if (props.isLargeFormatFilm && !eventForm.filmFrameId) {
+    errors.filmFrameId = 'Select a frame.';
+  }
+  if (eventForm.filmStateCode === 'loaded' && eventForm.deviceId) {
+    const selectedDevice = deviceStore.devices.find((entry) => entry.id === eventForm.deviceId);
+    if (!selectedDevice) {
+      errors.deviceId = 'Select a valid device.';
+    }
+    if (selectedDevice?.deviceTypeCode === 'film_holder') {
+      if (typeof eventForm.slotSideNumber !== 'number' || !Number.isInteger(eventForm.slotSideNumber)) {
+        errors.slotSideNumber = 'Select a holder slot.';
+      } else if (eventForm.slotSideNumber < 1 || eventForm.slotSideNumber > selectedDevice.slotCount) {
+        errors.slotSideNumber = `Slot must be between 1 and ${selectedDevice.slotCount}.`;
+      }
+    }
+  }
+
+  return errors;
+}
+
+function buildEventData(): Record<string, unknown> {
+  switch (eventForm.filmStateCode) {
+    case 'stored': {
+      const location = referenceStore.storageLocations.find((entry) => entry.id === eventForm.storageLocationId);
+      return {
+        storageLocationId: eventForm.storageLocationId,
+        storageLocationCode: location?.code ?? ''
+      };
+    }
+    case 'loaded': {
+      const selectedDevice = deviceStore.devices.find((entry) => entry.id === eventForm.deviceId);
+
+      if (!selectedDevice) {
+        return {};
+      }
+
+      if (selectedDevice.deviceTypeCode === 'camera') {
+        return {
+          loadTargetType: 'camera_direct',
+          ...(props.isLargeFormatFilm ? { filmFrameId: eventForm.filmFrameId } : {}),
+          cameraId: selectedDevice.id,
+          intendedPushPull: eventForm.intendedPushPull
+        };
+      }
+
+      if (selectedDevice.deviceTypeCode === 'interchangeable_back') {
+        return {
+          loadTargetType: 'interchangeable_back',
+          ...(props.isLargeFormatFilm ? { filmFrameId: eventForm.filmFrameId } : {}),
+          interchangeableBackId: selectedDevice.id,
+          intendedPushPull: eventForm.intendedPushPull
+        };
+      }
+
+      return {
+        loadTargetType: 'film_holder_slot',
+        ...(props.isLargeFormatFilm ? { filmFrameId: eventForm.filmFrameId } : {}),
+        filmHolderId: selectedDevice.id,
+        slotNumber: Number(eventForm.slotSideNumber ?? 1),
+        intendedPushPull: eventForm.intendedPushPull
+      };
+    }
+    case 'sent_for_dev':
+      return {
+        labName: eventForm.labName || null,
+        labContact: eventForm.labContact || null,
+        actualPushPull: eventForm.actualPushPull
+      };
+    case 'developed':
+      return {
+        labName: eventForm.labName || null,
+        actualPushPull: eventForm.actualPushPull
+      };
+    case 'scanned':
+      return {
+        scannerOrSoftware: eventForm.scannerOrSoftware || null,
+        scanLink: eventForm.scanLink || null
+      };
+    default:
+      return {};
+  }
+}
+
+async function submitEvent(): Promise<void> {
+  if (isSavingEvent.value || !props.filmId) {
+    return;
+  }
+
+  eventState.value.fieldErrors = validateEventForm();
+  if (Object.keys(eventState.value.fieldErrors).length > 0) {
+    eventState.value.formError = 'Please complete required fields before saving.';
+    return;
+  }
+
+  const payloadBase = {
+    occurredAt: new Date(occurredAtTimestamp.value as number).toISOString(),
+    notes: eventForm.notes || undefined,
+    eventData: buildEventData()
+  };
+
+  isSavingEvent.value = true;
+  eventState.value.loading = true;
+  eventState.value.formError = null;
+
+  try {
+    if (props.isLargeFormatFilm) {
+      const frameId = eventForm.filmFrameId;
+      if (!frameId) {
+        throw new Error('Select a frame');
+      }
+
+      const payload: CreateFrameJourneyEventRequest = {
+        frameStateCode: eventForm.filmStateCode as CreateFrameJourneyEventRequest['frameStateCode'],
+        ...payloadBase
+      };
+      await filmStore.addFrameEvent(props.filmId, frameId, payload, pendingEventKey.value);
+    } else {
+      const payload: CreateFilmJourneyEventRequest = {
+        filmStateCode: eventForm.filmStateCode as FilmStateCode,
+        ...payloadBase
+      };
+      await filmStore.addEvent(props.filmId, payload, pendingEventKey.value);
+    }
+
+    pendingEventKey.value = createIdempotencyKey();
+    isOpen.value = false;
+    emit('saved');
+    feedback.success('Event saved. Timeline updated.');
+  } catch (error) {
+    eventState.value.formError = feedback.toErrorMessage(error, 'Could not save this event.');
+  } finally {
+    isSavingEvent.value = false;
+    eventState.value.loading = false;
+  }
+}
+
+watch(
+  () => props.show,
+  (value) => {
+    if (value) {
+      pendingEventKey.value = createIdempotencyKey();
+    }
+  }
+);
+</script>
+
+<template>
+  <NDrawer v-model:show="isOpen" placement="right" width="min(100vw, 460px)">
+    <NDrawerContent title="Add journey event" closable>
+      <NForm label-placement="top" @submit.prevent="submitEvent">
+        <NAlert v-if="eventState.formError" type="error" :show-icon="true" style="margin-bottom: 10px;">
+          {{ eventState.formError }}
+        </NAlert>
+
+        <NGrid cols="1" :y-gap="4">
+          <NGridItem>
+            <NFormItem
+              label="Target state"
+              required
+              :label-props="{ for: 'event-target-state-input' }"
+              :feedback="eventState.fieldErrors.filmStateCode || ''"
+            >
+              <NSelect
+                :value="eventForm.filmStateCode"
+                :options="transitions"
+                placeholder="Select next state"
+                data-testid="event-target-state"
+                :input-props="{ id: 'event-target-state-input', name: 'filmStateCode' }"
+                @update:value="onChangeFilmState"
+              />
+            </NFormItem>
+          </NGridItem>
+
+          <NGridItem>
+            <NFormItem
+              label="Occurred at"
+              required
+              :label-props="{ for: 'event-occurred-at-input' }"
+              :feedback="eventState.fieldErrors.occurredAt || ''"
+            >
+              <NDatePicker
+                :value="occurredAtTimestamp"
+                type="datetime"
+                :input-props="{ id: 'event-occurred-at-input', name: 'occurredAt' }"
+                @update:value="(value) => { occurredAtTimestamp = value; }"
+              />
+            </NFormItem>
+          </NGridItem>
+
+          <NGridItem>
+            <NFormItem label="Notes" :label-props="{ for: 'event-notes-input' }">
+              <NInput
+                :value="eventForm.notes"
+                type="textarea"
+                placeholder="Optional context"
+                :input-props="{ id: 'event-notes-input', name: 'notes' }"
+                @update:value="(value) => { eventForm.notes = value; }"
+              />
+            </NFormItem>
+          </NGridItem>
+        </NGrid>
+
+        <NText depth="3">
+          Fields below change based on the transition state, so only relevant inputs are shown.
+        </NText>
+
+        <NGrid cols="1" :y-gap="4">
+          <NGridItem v-if="eventForm.filmStateCode === 'stored'">
+            <NFormItem
+              label="Storage location"
+              required
+              :label-props="{ for: 'event-storage-location-input' }"
+              :feedback="eventState.fieldErrors.storageLocationId || ''"
+            >
+              <NSelect
+                :value="eventForm.storageLocationId"
+                :options="storageLocationOptions"
+                placeholder="Select location"
+                data-testid="event-storage-location"
+                :input-props="{ id: 'event-storage-location-input', name: 'storageLocationId' }"
+                @update:value="(value) => { eventForm.storageLocationId = value; }"
+              />
+            </NFormItem>
+          </NGridItem>
+
+          <NGridItem v-if="isLargeFormatFilm && eventForm.filmStateCode">
+            <NFormItem
+              label="Frame"
+              required
+              :label-props="{ for: 'event-film-unit-input' }"
+              :feedback="eventState.fieldErrors.filmFrameId || ''"
+            >
+              <NSelect
+                :value="eventForm.filmFrameId"
+                :options="availableFrameOptions"
+                placeholder="Select frame"
+                :input-props="{ id: 'event-film-unit-input', name: 'filmFrameId' }"
+                @update:value="(value) => { eventForm.filmFrameId = value; }"
+              />
+            </NFormItem>
+          </NGridItem>
+
+          <template v-if="eventForm.filmStateCode === 'loaded'">
+            <NGridItem>
+              <NFormItem
+                label="Device"
+                required
+                :label-props="{ for: 'event-device-input' }"
+                :feedback="eventState.fieldErrors.deviceId || ''"
+              >
+                <NSelect
+                  :value="eventForm.deviceId"
+                  :options="deviceOptions"
+                  placeholder="Select device"
+                  :input-props="{ id: 'event-device-input', name: 'deviceId' }"
+                  @update:value="onChangeDevice"
+                />
+              </NFormItem>
+            </NGridItem>
+            <NGridItem v-if="selectedLoadDevice?.deviceTypeCode === 'film_holder'">
+              <NFormItem
+                label="Holder slot"
+                required
+                :label-props="{ for: 'event-slot-side-input' }"
+                :feedback="eventState.fieldErrors.slotSideNumber || ''"
+              >
+                <NSelect
+                  :value="eventForm.slotSideNumber"
+                  :options="holderSlotOptions"
+                  placeholder="Select holder slot"
+                  :input-props="{ id: 'event-slot-side-input', name: 'slotSideNumber' }"
+                  @update:value="(value) => { eventForm.slotSideNumber = value; }"
+                />
+              </NFormItem>
+            </NGridItem>
+            <NGridItem>
+              <NFormItem label="Intended push/pull" :label-props="{ for: 'event-intended-push-pull-input' }">
+                <NInputNumber
+                  :value="eventForm.intendedPushPull"
+                  :input-props="{ id: 'event-intended-push-pull-input', name: 'intendedPushPull' }"
+                  @update:value="(value) => { eventForm.intendedPushPull = value; }"
+                />
+              </NFormItem>
+            </NGridItem>
+          </template>
+
+          <template v-if="eventForm.filmStateCode === 'sent_for_dev'">
+            <NGridItem>
+              <NFormItem label="Lab name" :label-props="{ for: 'event-lab-name-sent-input' }">
+                <NInput
+                  :value="eventForm.labName"
+                  :input-props="{ id: 'event-lab-name-sent-input', name: 'labName' }"
+                  @update:value="(value) => { eventForm.labName = value; }"
+                />
+              </NFormItem>
+            </NGridItem>
+            <NGridItem>
+              <NFormItem label="Lab contact" :label-props="{ for: 'event-lab-contact-input' }">
+                <NInput
+                  :value="eventForm.labContact"
+                  :input-props="{ id: 'event-lab-contact-input', name: 'labContact' }"
+                  @update:value="(value) => { eventForm.labContact = value; }"
+                />
+              </NFormItem>
+            </NGridItem>
+            <NGridItem>
+              <NFormItem label="Actual push/pull" :label-props="{ for: 'event-actual-push-pull-sent-input' }">
+                <NInputNumber
+                  :value="eventForm.actualPushPull"
+                  :input-props="{ id: 'event-actual-push-pull-sent-input', name: 'actualPushPull' }"
+                  @update:value="(value) => { eventForm.actualPushPull = value; }"
+                />
+              </NFormItem>
+            </NGridItem>
+          </template>
+
+          <template v-if="eventForm.filmStateCode === 'developed'">
+            <NGridItem>
+              <NFormItem label="Lab name" :label-props="{ for: 'event-lab-name-developed-input' }">
+                <NInput
+                  :value="eventForm.labName"
+                  :input-props="{ id: 'event-lab-name-developed-input', name: 'labName' }"
+                  @update:value="(value) => { eventForm.labName = value; }"
+                />
+              </NFormItem>
+            </NGridItem>
+            <NGridItem>
+              <NFormItem label="Actual push/pull" :label-props="{ for: 'event-actual-push-pull-developed-input' }">
+                <NInputNumber
+                  :value="eventForm.actualPushPull"
+                  :input-props="{ id: 'event-actual-push-pull-developed-input', name: 'actualPushPull' }"
+                  @update:value="(value) => { eventForm.actualPushPull = value; }"
+                />
+              </NFormItem>
+            </NGridItem>
+          </template>
+
+          <template v-if="eventForm.filmStateCode === 'scanned'">
+            <NGridItem>
+              <NFormItem label="Scanner or software" :label-props="{ for: 'event-scanner-software-input' }">
+                <NInput
+                  :value="eventForm.scannerOrSoftware"
+                  :input-props="{ id: 'event-scanner-software-input', name: 'scannerOrSoftware' }"
+                  @update:value="(value) => { eventForm.scannerOrSoftware = value; }"
+                />
+              </NFormItem>
+            </NGridItem>
+            <NGridItem>
+              <NFormItem label="Scan link" :label-props="{ for: 'event-scan-link-input' }">
+                <NInput
+                  :value="eventForm.scanLink"
+                  :input-props="{ id: 'event-scan-link-input', name: 'scanLink' }"
+                  @update:value="(value) => { eventForm.scanLink = value; }"
+                />
+              </NFormItem>
+            </NGridItem>
+          </template>
+        </NGrid>
+
+        <NFlex justify="end">
+          <NButton tertiary @click="isOpen = false">Cancel</NButton>
+          <NButton type="primary" attr-type="submit" :loading="isSavingEvent" :disabled="isSavingEvent">
+            Save event
+          </NButton>
+        </NFlex>
+      </NForm>
+    </NDrawerContent>
+  </NDrawer>
+</template>

--- a/apps/ui/src/components/film/FilmTimelineCard.vue
+++ b/apps/ui/src/components/film/FilmTimelineCard.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
+import { computed } from 'vue';
 import { NCard, NEmpty, NText, NTimeline, NTimelineItem } from 'naive-ui';
 import type { FilmDevice, FilmJourneyEvent } from '@frollz2/schema';
+import { useResponsiveTimelinePlacement } from '../../composables/useResponsiveTimelinePlacement.js';
 
 type StorageLocation = {
   id: number;
@@ -38,8 +39,6 @@ const tagColorByType: Record<
   success: { dotColor: '#18a058' }
 };
 
-const isCompactTimeline = ref(false);
-const timelinePlacement = computed<'left' | 'right'>(() => (isCompactTimeline.value ? 'left' : 'right'));
 const timelineEvents = computed(() =>
   [...props.events]
     .sort((left, right) => {
@@ -60,8 +59,7 @@ const timelineEvents = computed(() =>
       dotColor: tagColorByType[stateTypeByCode[event.filmStateCode] ?? 'default'].dotColor
     }))
 );
-
-let timelineMediaQuery: MediaQueryList | null = null;
+const { timelinePlacement } = useResponsiveTimelinePlacement();
 
 function parseOccurredAt(value: string): number {
   const parsed = Date.parse(value);
@@ -93,10 +91,6 @@ function normalizeOptionalText(value: string | null | undefined): string | null 
 
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : null;
-}
-
-function syncTimelinePlacement(eventOrQuery: MediaQueryList | MediaQueryListEvent): void {
-  isCompactTimeline.value = eventOrQuery.matches;
 }
 
 function formatDateTime(value: string): string {
@@ -180,17 +174,6 @@ function toReadableEventField(key: string, value: unknown): { label: string; val
 function isDeviceReferenceKey(key: string): boolean {
   return /(?:device|receiver)Id$/i.test(key);
 }
-
-onMounted(() => {
-  timelineMediaQuery = window.matchMedia('(max-width: 768px)');
-  syncTimelinePlacement(timelineMediaQuery);
-  timelineMediaQuery.addEventListener('change', syncTimelinePlacement);
-});
-
-onBeforeUnmount(() => {
-  timelineMediaQuery?.removeEventListener('change', syncTimelinePlacement);
-  timelineMediaQuery = null;
-});
 </script>
 
 <template>

--- a/apps/ui/src/components/film/FilmTimelineCard.vue
+++ b/apps/ui/src/components/film/FilmTimelineCard.vue
@@ -1,0 +1,237 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
+import { NCard, NEmpty, NText, NTimeline, NTimelineItem } from 'naive-ui';
+import type { FilmDevice, FilmJourneyEvent } from '@frollz2/schema';
+
+type StorageLocation = {
+  id: number;
+  label: string;
+};
+
+const props = defineProps<{
+  events: FilmJourneyEvent[];
+  devices: FilmDevice[];
+  loading: boolean;
+  storageLocations: StorageLocation[];
+}>();
+
+const stateTypeByCode: Record<string, 'default' | 'info' | 'primary' | 'warning' | 'success'> = {
+  purchased: 'default',
+  stored: 'info',
+  loaded: 'primary',
+  exposed: 'warning',
+  removed: 'warning',
+  sent_for_dev: 'info',
+  developed: 'success',
+  scanned: 'success',
+  archived: 'default'
+};
+
+const tagColorByType: Record<
+  'default' | 'info' | 'primary' | 'warning' | 'success',
+  { dotColor: string }
+> = {
+  default: { dotColor: '#8c8c8c' },
+  info: { dotColor: '#2080f0' },
+  primary: { dotColor: '#4d6bfe' },
+  warning: { dotColor: '#f0a020' },
+  success: { dotColor: '#18a058' }
+};
+
+const isCompactTimeline = ref(false);
+const timelinePlacement = computed<'left' | 'right'>(() => (isCompactTimeline.value ? 'left' : 'right'));
+const timelineEvents = computed(() =>
+  [...props.events]
+    .sort((left, right) => {
+      const leftOccurredAt = parseOccurredAt(left.occurredAt);
+      const rightOccurredAt = parseOccurredAt(right.occurredAt);
+      if (leftOccurredAt !== rightOccurredAt) {
+        return rightOccurredAt - leftOccurredAt;
+      }
+
+      return right.id - left.id;
+    })
+    .map((event) => ({
+      id: event.id,
+      stateLabel: humanizeCode(event.filmStateCode),
+      occurredLabel: formatDateTime(event.occurredAt),
+      detailFields: eventDataEntries(event),
+      notes: normalizeOptionalText(event.notes),
+      dotColor: tagColorByType[stateTypeByCode[event.filmStateCode] ?? 'default'].dotColor
+    }))
+);
+
+let timelineMediaQuery: MediaQueryList | null = null;
+
+function parseOccurredAt(value: string): number {
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? Number.MIN_SAFE_INTEGER : parsed;
+}
+
+function humanizeCode(value: string): string {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (match) => match.toUpperCase());
+}
+
+function humanizeDevice(device: FilmDevice): string {
+  if (device.deviceTypeCode === 'camera') {
+    return `${device.make} ${device.model}`.trim();
+  }
+  if (device.deviceTypeCode === 'interchangeable_back') {
+    return `${device.name} ${device.system}`.trim();
+  }
+
+  return `${device.name} ${device.brand}`.trim();
+}
+
+function normalizeOptionalText(value: string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function syncTimelinePlacement(eventOrQuery: MediaQueryList | MediaQueryListEvent): void {
+  isCompactTimeline.value = eventOrQuery.matches;
+}
+
+function formatDateTime(value: string): string {
+  const parsed = Date.parse(value);
+  if (Number.isNaN(parsed)) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short'
+  }).format(parsed);
+}
+
+function eventDataEntries(event: FilmJourneyEvent): Array<{ label: string; value: string }> {
+  const loadTargetType = typeof event.eventData['loadTargetType'] === 'string' ? event.eventData['loadTargetType'] : null;
+  if (loadTargetType) {
+    const deviceId = (
+      typeof event.eventData['cameraId'] === 'number'
+        ? event.eventData['cameraId']
+        : typeof event.eventData['interchangeableBackId'] === 'number'
+          ? event.eventData['interchangeableBackId']
+          : typeof event.eventData['filmHolderId'] === 'number'
+            ? event.eventData['filmHolderId']
+            : null
+    );
+    const slotNumber = typeof event.eventData['slotNumber'] === 'number' ? event.eventData['slotNumber'] : null;
+    const device = deviceId ? props.devices.find((entry) => entry.id === deviceId) ?? null : null;
+
+    const entries: Array<{ label: string; value: string }> = [];
+    if (deviceId) {
+      entries.push({
+        label: 'Loaded Target',
+        value: device ? humanizeDevice(device) : String(deviceId)
+      });
+    }
+    if (slotNumber) {
+      entries.push({ label: 'Holder Slot', value: String(slotNumber) });
+    }
+
+    const passthrough = Object.entries(event.eventData)
+      .filter(([key]) => !['loadTargetType', 'cameraId', 'interchangeableBackId', 'filmHolderId', 'slotNumber'].includes(key))
+      .map(([key, value]) => toReadableEventField(key, value))
+      .filter((entry): entry is { label: string; value: string } => entry !== null);
+
+    return [...entries, ...passthrough];
+  }
+
+  return Object.entries(event.eventData)
+    .map(([key, value]) => toReadableEventField(key, value))
+    .filter((entry): entry is { label: string; value: string } => entry !== null);
+}
+
+function toReadableEventField(key: string, value: unknown): { label: string; value: string } | null {
+  if (value === null || value === '') {
+    return null;
+  }
+
+  if (isDeviceReferenceKey(key) && typeof value === 'number') {
+    const device = props.devices.find((entry) => entry.id === value);
+    return {
+      label: 'Device',
+      value: device ? humanizeDevice(device) : String(value)
+    };
+  }
+
+  if (key === 'storageLocationId' && typeof value === 'number') {
+    const location = props.storageLocations.find((entry) => entry.id === value);
+    return {
+      label: 'Storage Location',
+      value: location?.label ?? String(value)
+    };
+  }
+
+  return {
+    label: humanizeCode(key),
+    value: String(value)
+  };
+}
+
+function isDeviceReferenceKey(key: string): boolean {
+  return /(?:device|receiver)Id$/i.test(key);
+}
+
+onMounted(() => {
+  timelineMediaQuery = window.matchMedia('(max-width: 768px)');
+  syncTimelinePlacement(timelineMediaQuery);
+  timelineMediaQuery.addEventListener('change', syncTimelinePlacement);
+});
+
+onBeforeUnmount(() => {
+  timelineMediaQuery?.removeEventListener('change', syncTimelinePlacement);
+  timelineMediaQuery = null;
+});
+</script>
+
+<template>
+  <NCard>
+    <NTimeline v-if="timelineEvents.length > 0" :item-placement="timelinePlacement">
+      <NTimelineItem v-for="event in timelineEvents" :key="event.id" :title="event.stateLabel">
+        <template #icon>
+          <span class="film-timeline__dot" :style="{ backgroundColor: event.dotColor }" />
+        </template>
+        <div class="film-timeline__item-content">
+          <NText depth="3" class="film-timeline__item-date">{{ event.occurredLabel }}</NText>
+          <NText v-if="event.notes" class="film-timeline__item-notes">Notes: {{ event.notes }}</NText>
+          <NText v-for="field in event.detailFields" :key="`${event.id}-${field.label}`" depth="3">
+            {{ field.label }}: {{ field.value }}
+          </NText>
+        </div>
+      </NTimelineItem>
+    </NTimeline>
+    <NEmpty v-else-if="!loading" description="No events yet for this film." />
+  </NCard>
+</template>
+
+<style scoped>
+.film-timeline__item-content {
+  width: 100%;
+}
+
+.film-timeline__item-notes {
+  display: block;
+  margin: 4px 0;
+}
+
+.film-timeline__item-date {
+  display: block;
+  margin-bottom: 4px;
+}
+
+.film-timeline__dot {
+  border-radius: 999px;
+  display: inline-block;
+  height: 10px;
+  width: 10px;
+}
+</style>

--- a/apps/ui/src/components/film/RecentFilmsCard.vue
+++ b/apps/ui/src/components/film/RecentFilmsCard.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import { useRouter } from 'vue-router';
+import { NButton, NCard, NEmpty, NFlex, NTag, NText } from 'naive-ui';
+import type { FilmSummary } from '@frollz2/schema';
+
+defineProps<{
+  films: FilmSummary[];
+  loading?: boolean;
+  stateTypeByCode: Record<string, 'default' | 'info' | 'primary' | 'warning' | 'success'>;
+}>();
+
+const router = useRouter();
+</script>
+
+<template>
+  <NCard :loading="loading">
+    <NEmpty
+      v-if="!loading && films.length === 0"
+      description="No films are available yet."
+    />
+    <NFlex v-else vertical size="small">
+      <NCard v-for="film in films" :key="film.id" size="small" embedded>
+        <NFlex justify="space-between" align="center" :wrap="false">
+          <NText strong>{{ film.name }}</NText>
+          <NTag :type="stateTypeByCode[film.currentStateCode] ?? 'default'" size="small">
+            {{ film.currentState.label }}
+          </NTag>
+        </NFlex>
+        <NText depth="3">{{ film.emulsion.manufacturer }} {{ film.emulsion.brand }} · ISO {{ film.emulsion.isoSpeed }}</NText>
+        <NText depth="3">{{ film.filmFormat.code }} · {{ film.packageType.label }}</NText>
+        <NFlex justify="end">
+          <NButton tertiary size="small" @click="router.push(`/film/${film.id}`)">Open timeline</NButton>
+        </NFlex>
+      </NCard>
+    </NFlex>
+  </NCard>
+</template>

--- a/apps/ui/src/components/inventory/DashboardSplitLayout.vue
+++ b/apps/ui/src/components/inventory/DashboardSplitLayout.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { NGrid, NGridItem, NScrollbar, NSpace, NThing } from 'naive-ui';
+import { NGrid, NGridItem, NSpace, NThing } from 'naive-ui';
 
 defineProps<{
   leftPanelTitle: string;
@@ -8,27 +8,50 @@ defineProps<{
 </script>
 
 <template>
-  <NGrid cols="1 s:1 l:12" responsive="screen" :x-gap="16" :y-gap="16">
-    <NGridItem span="1 l:8">
-      <NSpace vertical :size="10">
+  <NGrid
+    cols="1 m:1 l:12"
+    responsive="screen"
+    item-responsive
+    :x-gap="16"
+    :y-gap="16"
+  >
+    <NGridItem span="1 l:7 xl:8">
+      <NSpace vertical :size="10" class="dashboard-split-layout__column">
         <slot name="left-header">
           <NThing :title="leftPanelTitle" />
         </slot>
-        <NScrollbar x-scrollable style="max-height: 540px; min-height: 420px;">
+        <div class="dashboard-split-layout__panel dashboard-split-layout__panel--left">
           <slot name="left" />
-        </NScrollbar>
+        </div>
       </NSpace>
     </NGridItem>
 
-    <NGridItem span="1 l:4">
-      <NSpace vertical :size="10">
+    <NGridItem span="1 l:5 xl:4">
+      <NSpace vertical :size="10" class="dashboard-split-layout__column">
         <slot name="right-header">
           <NThing :title="rightPanelTitle" />
         </slot>
-        <NSpace vertical :size="12">
+        <div class="dashboard-split-layout__panel dashboard-split-layout__panel--right">
           <slot name="right" />
-        </NSpace>
+        </div>
       </NSpace>
     </NGridItem>
   </NGrid>
 </template>
+
+<style scoped>
+.dashboard-split-layout__column {
+  height: 100%;
+}
+
+.dashboard-split-layout__panel {
+  min-width: 0;
+}
+
+.dashboard-split-layout__panel--left,
+.dashboard-split-layout__panel--right {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+</style>

--- a/apps/ui/src/components/inventory/DashboardSplitLayout.vue
+++ b/apps/ui/src/components/inventory/DashboardSplitLayout.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { NGrid, NGridItem, NScrollbar, NSpace, NThing } from 'naive-ui';
+
+defineProps<{
+  leftPanelTitle: string;
+  rightPanelTitle: string;
+}>();
+</script>
+
+<template>
+  <NGrid cols="1 s:1 l:12" responsive="screen" :x-gap="16" :y-gap="16">
+    <NGridItem span="1 l:8">
+      <NSpace vertical :size="10">
+        <slot name="left-header">
+          <NThing :title="leftPanelTitle" />
+        </slot>
+        <NScrollbar x-scrollable style="max-height: 540px; min-height: 420px;">
+          <slot name="left" />
+        </NScrollbar>
+      </NSpace>
+    </NGridItem>
+
+    <NGridItem span="1 l:4">
+      <NSpace vertical :size="10">
+        <slot name="right-header">
+          <NThing :title="rightPanelTitle" />
+        </slot>
+        <NSpace vertical :size="12">
+          <slot name="right" />
+        </NSpace>
+      </NSpace>
+    </NGridItem>
+  </NGrid>
+</template>

--- a/apps/ui/src/components/inventory/EntityTableCard.vue
+++ b/apps/ui/src/components/inventory/EntityTableCard.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts" generic="TRow extends Record<string, unknown>">
+import { NCard } from 'naive-ui';
+import type { DataTableColumns } from 'naive-ui';
+import EntityTablePanel from './EntityTablePanel.vue';
+
+type RowKey = string | number;
+
+const props = withDefaults(defineProps<{
+  columns: DataTableColumns<TRow>;
+  data: TRow[];
+  loading?: boolean;
+  rowKey: (row: TRow) => RowKey;
+  page: number;
+  pageSize: number;
+  itemCount: number;
+  pageSizes?: number[];
+  showSizePicker?: boolean;
+  emptyDescription?: string;
+  tableTestId?: string;
+  paginationTestId?: string;
+}>(), {
+  loading: false,
+  pageSizes: () => [10, 25, 50],
+  showSizePicker: true,
+  emptyDescription: 'No matching records found.',
+  tableTestId: '',
+  paginationTestId: ''
+});
+
+const emit = defineEmits<{
+  'update:page': [value: number];
+  'update:pageSize': [value: number];
+}>();
+</script>
+
+<template>
+  <NCard :loading="loading">
+    <slot name="before" />
+
+    <EntityTablePanel
+      :columns="columns"
+      :data="data"
+      :loading="loading"
+      :row-key="rowKey"
+      :page="page"
+      :page-size="pageSize"
+      :item-count="itemCount"
+      :page-sizes="pageSizes"
+      :show-size-picker="showSizePicker"
+      :empty-description="emptyDescription"
+      :table-test-id="tableTestId"
+      :pagination-test-id="paginationTestId"
+      @update:page="(value) => emit('update:page', value)"
+      @update:page-size="(value) => emit('update:pageSize', value)"
+    >
+      <template v-if="$slots.filters" #filters>
+        <slot name="filters" />
+      </template>
+    </EntityTablePanel>
+  </NCard>
+</template>

--- a/apps/ui/src/components/inventory/InventorySplitLayout.vue
+++ b/apps/ui/src/components/inventory/InventorySplitLayout.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import DashboardSplitLayout from './DashboardSplitLayout.vue';
+
 defineProps<{
   leftPanelTitle: string;
   rightPanelTitle: string;
@@ -6,70 +8,18 @@ defineProps<{
 </script>
 
 <template>
-  <div class="inventory-split">
-    <section class="inventory-split__left">
-      <slot name="left-header">
-        <h2 class="inventory-split__title">{{ leftPanelTitle }}</h2>
-      </slot>
-      <div class="inventory-split__scroll-body">
-        <slot name="left" />
-      </div>
-    </section>
-
-    <section class="inventory-split__right">
-      <slot name="right-header">
-        <h2 class="inventory-split__title">{{ rightPanelTitle }}</h2>
-      </slot>
-      <div class="inventory-split__stats-body">
-        <slot name="right" />
-      </div>
-    </section>
-  </div>
+  <DashboardSplitLayout :left-panel-title="leftPanelTitle" :right-panel-title="rightPanelTitle">
+    <template v-if="$slots['left-header']" #left-header>
+      <slot name="left-header" />
+    </template>
+    <template #left>
+      <slot name="left" />
+    </template>
+    <template v-if="$slots['right-header']" #right-header>
+      <slot name="right-header" />
+    </template>
+    <template #right>
+      <slot name="right" />
+    </template>
+  </DashboardSplitLayout>
 </template>
-
-<style scoped>
-.inventory-split {
-  display: grid;
-  gap: 16px;
-  grid-template-columns: minmax(0, 1.9fr) minmax(280px, 1fr);
-}
-
-.inventory-split__left,
-.inventory-split__right {
-  align-content: start;
-  display: grid;
-  gap: 10px;
-  min-width: 0;
-}
-
-.inventory-split__title {
-  font-size: 0.95rem;
-  font-weight: 600;
-  letter-spacing: 0.01em;
-  margin: 0;
-}
-
-.inventory-split__scroll-body {
-  max-height: 540px;
-  min-height: 420px;
-  overflow-y: auto;
-  padding-right: 6px;
-}
-
-.inventory-split__stats-body {
-  display: grid;
-  gap: 12px;
-}
-
-@media (max-width: 980px) {
-  .inventory-split {
-    grid-template-columns: minmax(0, 1fr);
-  }
-
-  .inventory-split__scroll-body {
-    max-height: 420px;
-    min-height: 280px;
-    padding-right: 0;
-  }
-}
-</style>

--- a/apps/ui/src/components/shell/AppHeaderBar.vue
+++ b/apps/ui/src/components/shell/AppHeaderBar.vue
@@ -1,0 +1,145 @@
+<script setup lang="ts">
+import { RouterLink } from 'vue-router';
+import { NBreadcrumb, NBreadcrumbItem, NButton, NIcon, NLayoutHeader, NSpace, NText } from 'naive-ui';
+import type { BreadcrumbItem } from '../../composables/useAppShellNavigation.js';
+import { CollapseIcon, ExpandIcon, MenuIcon } from './icons.js';
+
+defineProps<{
+  breadcrumbItems: BreadcrumbItem[];
+  isMobile: boolean;
+  isSidebarCollapsed: boolean;
+  userEmail: string | null;
+}>();
+
+const emit = defineEmits<{
+  logout: [];
+  'open:mobileMenu': [];
+  'toggle:sidebar': [];
+}>();
+</script>
+
+<template>
+  <NLayoutHeader bordered class="app-shell__header">
+    <NSpace justify="space-between" align="center" :wrap="false" style="width: 100%;">
+      <NSpace align="center" :wrap="false" class="app-shell__header-left">
+        <NButton v-if="isMobile" aria-label="Menu" secondary circle @click="emit('open:mobileMenu')">
+          <template #icon>
+            <NIcon>
+              <MenuIcon />
+            </NIcon>
+          </template>
+        </NButton>
+        <NButton v-else aria-label="Toggle sidebar" secondary circle @click="emit('toggle:sidebar')">
+          <template #icon>
+            <NIcon>
+              <CollapseIcon v-if="!isSidebarCollapsed" />
+              <ExpandIcon v-else />
+            </NIcon>
+          </template>
+        </NButton>
+        <nav class="app-shell__breadcrumb-wrap" aria-label="Breadcrumb">
+          <NBreadcrumb separator=">" class="app-shell__breadcrumb">
+            <NBreadcrumbItem v-for="crumb in breadcrumbItems" :key="crumb.key">
+              <RouterLink
+                v-if="crumb.to && !crumb.isCurrent"
+                :to="crumb.to"
+                class="app-shell__breadcrumb-link"
+                :aria-label="crumb.ariaLabel ?? crumb.label"
+              >
+                <NIcon v-if="crumb.icon" size="16" aria-hidden="true">
+                  <component :is="crumb.icon" />
+                </NIcon>
+                <span>{{ crumb.label }}</span>
+              </RouterLink>
+              <span v-else class="app-shell__breadcrumb-current" :aria-current="crumb.isCurrent ? 'page' : undefined">
+                <NIcon v-if="crumb.icon" size="16" aria-hidden="true">
+                  <component :is="crumb.icon" />
+                </NIcon>
+                <span>{{ crumb.label }}</span>
+              </span>
+            </NBreadcrumbItem>
+          </NBreadcrumb>
+        </nav>
+      </NSpace>
+      <NSpace align="center" :wrap="false" class="app-shell__header-right">
+        <NText v-if="userEmail" depth="3" class="app-shell__user">{{ userEmail }}</NText>
+        <NButton tertiary type="error" @click="emit('logout')">Logout</NButton>
+      </NSpace>
+    </NSpace>
+  </NLayoutHeader>
+</template>
+
+<style scoped>
+.app-shell__header {
+  align-items: center;
+  display: flex;
+  min-height: 64px;
+  padding: 8px 12px;
+}
+
+.app-shell__header-left {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.app-shell__header-right {
+  flex: 0 0 auto;
+}
+
+.app-shell__breadcrumb-wrap {
+  min-width: 0;
+  overflow: hidden;
+}
+
+.app-shell__breadcrumb {
+  min-width: 0;
+}
+
+.app-shell__breadcrumb-link,
+.app-shell__breadcrumb-current {
+  align-items: center;
+  display: inline-flex;
+  gap: 6px;
+  max-width: 32vw;
+}
+
+.app-shell__breadcrumb-link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.app-shell__breadcrumb-link:hover {
+  text-decoration: underline;
+}
+
+.app-shell__breadcrumb-link span,
+.app-shell__breadcrumb-current span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.app-shell__user {
+  max-width: 260px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@media (max-width: 900px) {
+  .app-shell__user {
+    display: none;
+  }
+}
+
+@media (min-width: 901px) {
+  .app-shell__header {
+    padding: 0 16px;
+  }
+
+  .app-shell__breadcrumb-link,
+  .app-shell__breadcrumb-current {
+    max-width: 220px;
+  }
+}
+</style>

--- a/apps/ui/src/components/shell/AppSidebarMenu.vue
+++ b/apps/ui/src/components/shell/AppSidebarMenu.vue
@@ -1,0 +1,81 @@
+<script setup lang="ts">
+import { NDrawer, NDrawerContent, NButton, NLayoutSider, NMenu, NSpace, NThing, type MenuOption } from 'naive-ui';
+
+defineProps<{
+  collapsed: boolean;
+  expandedKeys: string[];
+  isAuthenticated: boolean;
+  isMobile: boolean;
+  mobileMenuOpen: boolean;
+  selectedKey: string | null;
+  menuOptions: MenuOption[];
+}>();
+
+const emit = defineEmits<{
+  'toggle:mobileMenu': [value: boolean];
+  'update:collapsed': [value: boolean];
+  'update:expandedKeys': [value: string[]];
+  select: [key: string];
+  logout: [];
+}>();
+</script>
+
+<template>
+  <NLayoutSider
+    v-if="isAuthenticated && !isMobile"
+    bordered
+    collapse-mode="width"
+    :collapsed="collapsed"
+    :collapsed-width="64"
+    :width="280"
+    show-trigger="bar"
+    :native-scrollbar="false"
+    class="app-shell__sider"
+    @update:collapsed="(value) => emit('update:collapsed', value)"
+  >
+    <div class="app-shell__brand">
+      <NThing :title="collapsed ? 'F2' : 'Frollz2'" :description="collapsed ? '' : 'Admin shell'" />
+    </div>
+    <NMenu
+      :value="selectedKey"
+      :collapsed="collapsed"
+      :collapsed-width="64"
+      :indent="14"
+      :options="menuOptions"
+      :expanded-keys="expandedKeys"
+      @update:value="(value) => emit('select', value)"
+      @update:expanded-keys="(value) => emit('update:expandedKeys', value)"
+    />
+  </NLayoutSider>
+
+  <NDrawer
+    :show="mobileMenuOpen"
+    placement="left"
+    width="min(100vw, 360px)"
+    @update:show="(value) => emit('toggle:mobileMenu', value)"
+  >
+    <NDrawerContent title="Navigation" closable>
+      <NSpace vertical size="large">
+        <NMenu
+          :value="selectedKey"
+          :indent="14"
+          :options="menuOptions"
+          :expanded-keys="expandedKeys"
+          @update:value="(value) => emit('select', value)"
+          @update:expanded-keys="(value) => emit('update:expandedKeys', value)"
+        />
+        <NButton type="error" secondary @click="emit('logout')">Logout</NButton>
+      </NSpace>
+    </NDrawerContent>
+  </NDrawer>
+</template>
+
+<style scoped>
+.app-shell__sider {
+  border-right: 1px solid var(--n-border-color);
+}
+
+.app-shell__brand {
+  padding: 16px 12px 10px;
+}
+</style>

--- a/apps/ui/src/composables/useAppShellNavigation.ts
+++ b/apps/ui/src/composables/useAppShellNavigation.ts
@@ -1,0 +1,465 @@
+import { computed, h, onBeforeUnmount, onMounted, ref, watch, type Component } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import { NBadge, NIcon, type MenuOption } from 'naive-ui';
+import {
+  Camera,
+  CircleDot,
+  Contrast2,
+  Frame,
+  Home,
+  Movie,
+  Photo,
+  Rectangle,
+  Replace,
+  SwitchHorizontal
+} from '@vicons/tabler';
+import { useDeviceStore } from '../stores/devices.js';
+import { useFilmStore } from '../stores/film.js';
+import { useReferenceStore } from '../stores/reference.js';
+import { DashboardIcon, DeviceIcon, EmulsionIcon, FilmIcon } from '../components/shell/icons.js';
+
+const SIDEBAR_COLLAPSED_KEY = 'frollz.shell.sider.collapsed';
+const LAST_ACTIVE_SECTION_KEY = 'frollz.shell.last-section';
+const MOBILE_BREAKPOINT = 900;
+
+const navIconByKey = {
+  dashboard: DashboardIcon,
+  film: FilmIcon,
+  devices: DeviceIcon,
+  emulsions: EmulsionIcon
+} as const;
+
+const subNavIconByPath = {
+  '/devices/cameras': Camera,
+  '/devices/film-holders': Rectangle,
+  '/devices/interchangeable-backs': SwitchHorizontal,
+  '/emulsions/black-and-white': CircleDot,
+  '/emulsions/black-and-white-reversal': Contrast2,
+  '/emulsions/cine-ecn2': Movie,
+  '/emulsions/color-negative-c41': Photo,
+  '/emulsions/color-positive-e6': Replace,
+  '/film/35mm': Camera,
+  '/film/medium-format': Frame,
+  '/film/large-format-4x5': Rectangle,
+  '/film/large-format-8x10': Rectangle
+} as const;
+
+export type BreadcrumbItem = {
+  key: string;
+  label: string;
+  to?: string;
+  isCurrent?: boolean;
+  icon?: Component;
+  ariaLabel?: string;
+};
+
+export function useAppShellNavigation() {
+  const deviceStore = useDeviceStore();
+  const filmStore = useFilmStore();
+  const referenceStore = useReferenceStore();
+  const route = useRoute();
+  const router = useRouter();
+
+  const isMobile = ref(false);
+  const isMobileMenuOpen = ref(false);
+  const isSidebarCollapsed = ref(false);
+  const lastActiveSection = ref<string | null>(null);
+  const expandedKeys = ref<string[]>([]);
+
+  const navRoutes = computed(() =>
+    router
+      .getRoutes()
+      .filter((record) => record.meta.layout === 'app' && record.meta.showInNav)
+      .sort((a, b) => {
+        const orderA = Number(a.meta.order) || 0;
+        const orderB = Number(b.meta.order) || 0;
+
+        if (orderA === orderB) {
+          return a.path.localeCompare(b.path);
+        }
+
+        return orderA - orderB;
+      })
+  );
+
+  const parentNavRoutes = computed(() =>
+    navRoutes.value.filter((record) => typeof record.meta.navParent !== 'string')
+  );
+
+  const childRoutesByParent = computed(() => {
+    const grouped = new Map<string, typeof navRoutes.value>();
+
+    for (const routeRecord of navRoutes.value) {
+      if (typeof routeRecord.meta.navParent !== 'string') {
+        continue;
+      }
+
+      const existing = grouped.get(routeRecord.meta.navParent) ?? [];
+      existing.push(routeRecord);
+      grouped.set(routeRecord.meta.navParent, existing);
+    }
+
+    return grouped;
+  });
+
+  const deviceCountByType = computed(() =>
+    deviceStore.devices.reduce<Record<string, number>>((counts, device) => {
+      counts[device.deviceTypeCode] = (counts[device.deviceTypeCode] ?? 0) + 1;
+      return counts;
+    }, {})
+  );
+
+  const emulsionCountByProcess = computed(() =>
+    referenceStore.emulsions.reduce<Record<string, number>>((counts, emulsion) => {
+      const code = emulsion.developmentProcess.code;
+      counts[code] = (counts[code] ?? 0) + 1;
+      return counts;
+    }, {})
+  );
+
+  const filmCountByFormat = computed(() =>
+    filmStore.films.reduce<Record<string, number>>((counts, film) => {
+      const code = film.filmFormat.code;
+      counts[code] = (counts[code] ?? 0) + 1;
+      return counts;
+    }, {})
+  );
+
+  function badgeCountForRoute(path: string): number | undefined {
+    switch (path) {
+      case '/devices/cameras':
+        return deviceCountByType.value['camera'] ?? 0;
+      case '/devices/film-holders':
+        return deviceCountByType.value['film_holder'] ?? 0;
+      case '/devices/interchangeable-backs':
+        return deviceCountByType.value['interchangeable_back'] ?? 0;
+      case '/emulsions/black-and-white':
+        return emulsionCountByProcess.value['BW'] ?? 0;
+      case '/emulsions/black-and-white-reversal':
+        return emulsionCountByProcess.value['BWReversal'] ?? 0;
+      case '/emulsions/cine-ecn2':
+        return emulsionCountByProcess.value['ECN2'] ?? 0;
+      case '/emulsions/color-negative-c41':
+        return emulsionCountByProcess.value['C41'] ?? 0;
+      case '/emulsions/color-positive-e6':
+        return emulsionCountByProcess.value['E6'] ?? 0;
+      case '/film/35mm':
+        return filmCountByFormat.value['35mm'] ?? 0;
+      case '/film/medium-format':
+        return (filmCountByFormat.value['120'] ?? 0) + (filmCountByFormat.value['220'] ?? 0);
+      case '/film/large-format-4x5':
+        return filmCountByFormat.value['4x5'] ?? 0;
+      case '/film/large-format-8x10':
+        return filmCountByFormat.value['8x10'] ?? 0;
+      default:
+        return undefined;
+    }
+  }
+
+  function navCountDescription(routePath: string, count: number): string {
+    if (routePath.startsWith('/devices/')) {
+      return `${count} devices`;
+    }
+    if (routePath.startsWith('/film/')) {
+      return `${count} films`;
+    }
+    if (routePath.startsWith('/emulsions/')) {
+      return `${count} emulsions`;
+    }
+    return `${count} items`;
+  }
+
+  function toggleParentExpansion(parentKey: string): void {
+    if (expandedKeys.value.includes(parentKey)) {
+      expandedKeys.value = expandedKeys.value.filter((key) => key !== parentKey);
+      return;
+    }
+
+    expandedKeys.value = [...expandedKeys.value, parentKey];
+  }
+
+  function handleMenuLabelClick(event: MouseEvent, key: string): void {
+    event.stopPropagation();
+    const isParent = childRoutesByParent.value.has(key);
+
+    if (isParent) {
+      toggleParentExpansion(key);
+    }
+
+    isMobileMenuOpen.value = false;
+    if (route.path !== key) {
+      void router.push(key);
+    }
+  }
+
+  function toMenuOption(record: (typeof navRoutes.value)[number], includeBadge: boolean): MenuOption {
+    const titleText = String(record.meta.title ?? record.name ?? record.path);
+    const iconKey = String(record.meta.icon ?? '');
+    const icon = navIconByKey[iconKey as keyof typeof navIconByKey];
+    const subIcon = subNavIconByPath[record.path as keyof typeof subNavIconByPath];
+    const count = includeBadge ? badgeCountForRoute(record.path) : undefined;
+    const ariaLabel = typeof count === 'number' ? `${titleText}, ${navCountDescription(record.path, count)}` : titleText;
+    const option: MenuOption = {
+      key: record.path,
+      label: () =>
+        h('div', {
+          class: 'app-shell__menu-label',
+          'aria-label': ariaLabel,
+          onClick: (event: MouseEvent) => {
+            handleMenuLabelClick(event, record.path);
+          }
+        }, [
+          h('span', { class: 'app-shell__menu-text' }, titleText),
+          ...(typeof count === 'number'
+            ? [h('span', { class: 'sr-only' }, navCountDescription(record.path, count))]
+            : []),
+          ...(typeof count === 'number'
+            ? [h(NBadge, {
+              class: 'app-shell__menu-badge',
+              value: count,
+              showZero: true,
+              offset: [16, 0],
+              'aria-hidden': 'true'
+            })]
+            : [])
+        ])
+    };
+
+    if (subIcon) {
+      option.icon = () => h(NIcon, null, { default: () => h(subIcon) });
+    } else if (icon) {
+      option.icon = () => h(NIcon, null, { default: () => h(icon) });
+    }
+
+    return option;
+  }
+
+  const menuOptions = computed<MenuOption[]>(() =>
+    parentNavRoutes.value.map((record) => {
+      const children = childRoutesByParent.value.get(record.path) ?? [];
+      const option = toMenuOption(record, false);
+
+      if (children.length > 0) {
+        option.children = children.map((child) => toMenuOption(child, true));
+      }
+
+      return option;
+    })
+  );
+
+  const selectedKey = computed<string | null>(() => {
+    const explicitNavKey = route.meta.navKey;
+    if (typeof explicitNavKey === 'string') {
+      return explicitNavKey;
+    }
+
+    const currentPath = route.path;
+    const directMatch = navRoutes.value.find((navRoute) => navRoute.path === currentPath);
+    if (directMatch) {
+      return directMatch.path;
+    }
+
+    const prefixMatch = navRoutes.value.find((navRoute) => currentPath.startsWith(`${navRoute.path}/`));
+    if (prefixMatch) {
+      return prefixMatch.path;
+    }
+
+    return lastActiveSection.value;
+  });
+
+  const routePathSegments = computed(() => route.path.split('/').filter(Boolean));
+
+  const lastPathSegment = computed(() => {
+    const rawSegment = routePathSegments.value.at(-1);
+    if (!rawSegment) {
+      return 'frollz';
+    }
+
+    return decodeURIComponent(rawSegment);
+  });
+
+  const selectedRouteRecord = computed(() => {
+    if (!selectedKey.value) {
+      return null;
+    }
+
+    return navRoutes.value.find((record) => record.path === selectedKey.value) ?? null;
+  });
+
+  const directMatchedNavRecord = computed(() =>
+    navRoutes.value.find((record) => record.path === route.path) ?? null
+  );
+
+  const navRouteByPath = computed(() => {
+    const byPath = new Map<string, (typeof navRoutes.value)[number]>();
+    for (const record of navRoutes.value) {
+      byPath.set(record.path, record);
+    }
+    return byPath;
+  });
+
+  const breadcrumbItems = computed<BreadcrumbItem[]>(() => {
+    const items: BreadcrumbItem[] = [
+      {
+        key: 'home',
+        label: 'frollz',
+        to: '/',
+        icon: Home,
+        ariaLabel: 'frollz home'
+      }
+    ];
+
+    const currentRecord = selectedRouteRecord.value;
+    if (!currentRecord) {
+      items.push({
+        key: `current-${route.path}`,
+        label: lastPathSegment.value,
+        isCurrent: true
+      });
+      return items;
+    }
+
+    const isDirectMatch = directMatchedNavRecord.value?.path === currentRecord.path;
+    const parentPath = typeof currentRecord.meta.navParent === 'string' ? currentRecord.meta.navParent : null;
+
+    if (parentPath) {
+      const parentRecord = navRouteByPath.value.get(parentPath);
+
+      if (parentRecord) {
+        items.push({
+          key: parentRecord.path,
+          label: String(parentRecord.meta.title ?? parentRecord.name ?? parentRecord.path),
+          to: parentRecord.path
+        });
+      }
+
+      if (isDirectMatch) {
+        items.push({
+          key: currentRecord.path,
+          label: String(currentRecord.meta.title ?? currentRecord.name ?? currentRecord.path),
+          isCurrent: true
+        });
+        return items;
+      }
+    } else if (isDirectMatch) {
+      items.push({
+        key: currentRecord.path,
+        label: String(currentRecord.meta.title ?? currentRecord.name ?? currentRecord.path),
+        isCurrent: true
+      });
+      return items;
+    } else {
+      items.push({
+        key: currentRecord.path,
+        label: String(currentRecord.meta.title ?? currentRecord.name ?? currentRecord.path),
+        to: currentRecord.path
+      });
+    }
+
+    items.push({
+      key: `current-${route.path}`,
+      label: lastPathSegment.value,
+      isCurrent: true
+    });
+    return items;
+  });
+
+  function syncViewportState(): void {
+    isMobile.value = window.innerWidth < MOBILE_BREAKPOINT;
+    if (!isMobile.value) {
+      isMobileMenuOpen.value = false;
+    }
+  }
+
+  function readShellState(): void {
+    try {
+      isSidebarCollapsed.value = localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === '1';
+      lastActiveSection.value = localStorage.getItem(LAST_ACTIVE_SECTION_KEY);
+    } catch {
+      isSidebarCollapsed.value = false;
+      lastActiveSection.value = null;
+    }
+  }
+
+  function toggleDesktopSidebar(): void {
+    isSidebarCollapsed.value = !isSidebarCollapsed.value;
+  }
+
+  function handleMenuSelect(key: string): void {
+    isMobileMenuOpen.value = false;
+    void router.push(key);
+  }
+
+  function handleExpandedKeys(nextKeys: string[]): void {
+    expandedKeys.value = nextKeys;
+  }
+
+  function ensureParentExpanded(menuKey: string | null): void {
+    if (!menuKey) {
+      return;
+    }
+
+    const routeRecord = navRoutes.value.find((record) => record.path === menuKey);
+    if (!routeRecord || typeof routeRecord.meta.navParent !== 'string') {
+      return;
+    }
+
+    if (!expandedKeys.value.includes(routeRecord.meta.navParent)) {
+      expandedKeys.value = [...expandedKeys.value, routeRecord.meta.navParent];
+    }
+  }
+
+  watch(isSidebarCollapsed, (value) => {
+    try {
+      localStorage.setItem(SIDEBAR_COLLAPSED_KEY, value ? '1' : '0');
+    } catch {
+      // Ignore storage errors in private or constrained environments.
+    }
+  });
+
+  watch(selectedKey, (value) => {
+    if (!value) {
+      return;
+    }
+
+    ensureParentExpanded(value);
+    lastActiveSection.value = value;
+    try {
+      localStorage.setItem(LAST_ACTIVE_SECTION_KEY, value);
+    } catch {
+      // Ignore storage errors in private or constrained environments.
+    }
+  }, { immediate: true });
+
+  onMounted(() => {
+    readShellState();
+    syncViewportState();
+    window.addEventListener('resize', syncViewportState);
+  });
+
+  onBeforeUnmount(() => {
+    window.removeEventListener('resize', syncViewportState);
+  });
+
+  watch(
+    () => route.path,
+    () => {
+      document.title = `${lastPathSegment.value} | frollz`;
+    },
+    { immediate: true }
+  );
+
+  return {
+    breadcrumbItems,
+    expandedKeys,
+    handleExpandedKeys,
+    handleMenuSelect,
+    isMobile,
+    isMobileMenuOpen,
+    isSidebarCollapsed,
+    lastPathSegment,
+    menuOptions,
+    selectedKey,
+    toggleDesktopSidebar
+  };
+}

--- a/apps/ui/src/composables/useResponsiveTimelinePlacement.ts
+++ b/apps/ui/src/composables/useResponsiveTimelinePlacement.ts
@@ -1,0 +1,31 @@
+import { computed, onBeforeUnmount, onMounted, ref, type ComputedRef } from 'vue';
+
+type TimelinePlacement = 'left' | 'right';
+
+type UseResponsiveTimelinePlacementResult = {
+  timelinePlacement: ComputedRef<TimelinePlacement>;
+};
+
+export function useResponsiveTimelinePlacement(query = '(max-width: 768px)'): UseResponsiveTimelinePlacementResult {
+  const isCompactTimeline = ref(false);
+  let timelineMediaQuery: MediaQueryList | null = null;
+
+  function syncTimelinePlacement(eventOrQuery: MediaQueryList | MediaQueryListEvent): void {
+    isCompactTimeline.value = eventOrQuery.matches;
+  }
+
+  onMounted((): void => {
+    timelineMediaQuery = window.matchMedia(query);
+    syncTimelinePlacement(timelineMediaQuery);
+    timelineMediaQuery.addEventListener('change', syncTimelinePlacement);
+  });
+
+  onBeforeUnmount((): void => {
+    timelineMediaQuery?.removeEventListener('change', syncTimelinePlacement);
+    timelineMediaQuery = null;
+  });
+
+  return {
+    timelinePlacement: computed<TimelinePlacement>(() => (isCompactTimeline.value ? 'left' : 'right'))
+  };
+}

--- a/apps/ui/src/layouts/AppShellLayout.vue
+++ b/apps/ui/src/layouts/AppShellLayout.vue
@@ -1,548 +1,60 @@
 <script setup lang="ts">
-import { computed, h, onBeforeUnmount, onMounted, ref, watch, type Component } from 'vue';
-import { RouterView, useRoute, useRouter } from 'vue-router';
-import {
-  NBadge,
-  NBreadcrumb,
-  NBreadcrumbItem,
-  NButton,
-  NDrawer,
-  NDrawerContent,
-  NIcon,
-  NLayout,
-  NLayoutContent,
-  NLayoutHeader,
-  NLayoutSider,
-  NMenu,
-  NSpace,
-  NText,
-  NThing,
-  type MenuOption
-} from 'naive-ui';
-import {
-  Camera,
-  CircleDot,
-  Contrast2,
-  Frame,
-  Home,
-  Movie,
-  Photo,
-  Rectangle,
-  Replace,
-  SwitchHorizontal
-} from '@vicons/tabler';
+import { RouterView, useRouter } from 'vue-router';
+import { NLayout, NLayoutContent } from 'naive-ui';
 import { useAuthStore } from '../stores/auth.js';
-import { useDeviceStore } from '../stores/devices.js';
-import { useFilmStore } from '../stores/film.js';
-import { useReferenceStore } from '../stores/reference.js';
-import { CollapseIcon, DashboardIcon, EmulsionIcon, ExpandIcon, FilmIcon, MenuIcon, DeviceIcon } from '../components/shell/icons.js';
-
-const SIDEBAR_COLLAPSED_KEY = 'frollz.shell.sider.collapsed';
-const LAST_ACTIVE_SECTION_KEY = 'frollz.shell.last-section';
-const MOBILE_BREAKPOINT = 900;
+import AppHeaderBar from '../components/shell/AppHeaderBar.vue';
+import AppSidebarMenu from '../components/shell/AppSidebarMenu.vue';
+import { useAppShellNavigation } from '../composables/useAppShellNavigation.js';
 
 const authStore = useAuthStore();
-const referenceStore = useReferenceStore();
-const deviceStore = useDeviceStore();
-const filmStore = useFilmStore();
 const router = useRouter();
-const route = useRoute();
-
-const isMobile = ref(false);
-const isMobileMenuOpen = ref(false);
-const isSidebarCollapsed = ref(false);
-const lastActiveSection = ref<string | null>(null);
-const expandedKeys = ref<string[]>([]);
-
-const navIconByKey = {
-  dashboard: DashboardIcon,
-  film: FilmIcon,
-  devices: DeviceIcon,
-  emulsions: EmulsionIcon
-} as const;
-
-const subNavIconByPath = {
-  '/devices/cameras': Camera,
-  '/devices/film-holders': Rectangle,
-  '/devices/interchangeable-backs': SwitchHorizontal,
-  '/emulsions/black-and-white': CircleDot,
-  '/emulsions/black-and-white-reversal': Contrast2,
-  '/emulsions/cine-ecn2': Movie,
-  '/emulsions/color-negative-c41': Photo,
-  '/emulsions/color-positive-e6': Replace,
-  '/film/35mm': Camera,
-  '/film/medium-format': Frame,
-  '/film/large-format-4x5': Rectangle,
-  '/film/large-format-8x10': Rectangle
-} as const;
-
-type BreadcrumbItem = {
-  key: string;
-  label: string;
-  to?: string;
-  isCurrent?: boolean;
-  icon?: Component;
-  ariaLabel?: string;
-};
-
-const navRoutes = computed(() =>
-  router
-    .getRoutes()
-    .filter((record) => record.meta.layout === 'app' && record.meta.showInNav)
-    .sort((a, b) => {
-      const orderA = Number(a.meta.order) || 0;
-      const orderB = Number(b.meta.order) || 0;
-
-      if (orderA === orderB) {
-        return a.path.localeCompare(b.path);
-      }
-
-      return orderA - orderB;
-    })
-);
-
-const parentNavRoutes = computed(() =>
-  navRoutes.value.filter((record) => typeof record.meta.navParent !== 'string')
-);
-
-const childRoutesByParent = computed(() => {
-  const grouped = new Map<string, typeof navRoutes.value>();
-
-  for (const routeRecord of navRoutes.value) {
-    if (typeof routeRecord.meta.navParent !== 'string') {
-      continue;
-    }
-
-    const existing = grouped.get(routeRecord.meta.navParent) ?? [];
-    existing.push(routeRecord);
-    grouped.set(routeRecord.meta.navParent, existing);
-  }
-
-  return grouped;
-});
-
-const deviceCountByType = computed(() =>
-  deviceStore.devices.reduce<Record<string, number>>((counts, device) => {
-    counts[device.deviceTypeCode] = (counts[device.deviceTypeCode] ?? 0) + 1;
-    return counts;
-  }, {})
-);
-
-const emulsionCountByProcess = computed(() =>
-  referenceStore.emulsions.reduce<Record<string, number>>((counts, emulsion) => {
-    const code = emulsion.developmentProcess.code;
-    counts[code] = (counts[code] ?? 0) + 1;
-    return counts;
-  }, {})
-);
-
-const filmCountByFormat = computed(() =>
-  filmStore.films.reduce<Record<string, number>>((counts, film) => {
-    const code = film.filmFormat.code;
-    counts[code] = (counts[code] ?? 0) + 1;
-    return counts;
-  }, {})
-);
-
-function badgeCountForRoute(path: string): number | undefined {
-  switch (path) {
-    case '/devices/cameras':
-      return deviceCountByType.value['camera'] ?? 0;
-    case '/devices/film-holders':
-      return deviceCountByType.value['film_holder'] ?? 0;
-    case '/devices/interchangeable-backs':
-      return deviceCountByType.value['interchangeable_back'] ?? 0;
-    case '/emulsions/black-and-white':
-      return emulsionCountByProcess.value['BW'] ?? 0;
-    case '/emulsions/black-and-white-reversal':
-      return emulsionCountByProcess.value['BWReversal'] ?? 0;
-    case '/emulsions/cine-ecn2':
-      return emulsionCountByProcess.value['ECN2'] ?? 0;
-    case '/emulsions/color-negative-c41':
-      return emulsionCountByProcess.value['C41'] ?? 0;
-    case '/emulsions/color-positive-e6':
-      return emulsionCountByProcess.value['E6'] ?? 0;
-    case '/film/35mm':
-      return filmCountByFormat.value['35mm'] ?? 0;
-    case '/film/medium-format':
-      return (filmCountByFormat.value['120'] ?? 0) + (filmCountByFormat.value['220'] ?? 0);
-    case '/film/large-format-4x5':
-      return filmCountByFormat.value['4x5'] ?? 0;
-    case '/film/large-format-8x10':
-      return filmCountByFormat.value['8x10'] ?? 0;
-    default:
-      return undefined;
-  }
-}
-
-function navCountDescription(routePath: string, count: number): string {
-  if (routePath.startsWith('/devices/')) {
-    return `${count} devices`;
-  }
-  if (routePath.startsWith('/film/')) {
-    return `${count} films`;
-  }
-  if (routePath.startsWith('/emulsions/')) {
-    return `${count} emulsions`;
-  }
-  return `${count} items`;
-}
-
-function toMenuOption(record: (typeof navRoutes.value)[number], includeBadge: boolean): MenuOption {
-  const titleText = String(record.meta.title ?? record.name ?? record.path);
-  const iconKey = String(record.meta.icon ?? '');
-  const icon = navIconByKey[iconKey as keyof typeof navIconByKey];
-  const subIcon = subNavIconByPath[record.path as keyof typeof subNavIconByPath];
-  const count = includeBadge ? badgeCountForRoute(record.path) : undefined;
-  const ariaLabel = typeof count === 'number' ? `${titleText}, ${navCountDescription(record.path, count)}` : titleText;
-  const option: MenuOption = {
-    key: record.path,
-    label: () =>
-      h('div', {
-        class: 'app-shell__menu-label',
-        'aria-label': ariaLabel,
-        onClick: (event: MouseEvent) => {
-          handleMenuLabelClick(event, record.path);
-        }
-      }, [
-        h('span', { class: 'app-shell__menu-text' }, titleText),
-        ...(typeof count === 'number'
-          ? [h('span', { class: 'sr-only' }, navCountDescription(record.path, count))]
-          : []),
-        ...(typeof count === 'number'
-          ? [h(NBadge, {
-            class: 'app-shell__menu-badge',
-            value: count,
-            showZero: true,
-            offset: [16, 0],
-            'aria-hidden': 'true'
-          })]
-          : [])
-      ])
-  };
-
-  if (subIcon) {
-    option.icon = () => h(NIcon, null, { default: () => h(subIcon) });
-  } else if (icon) {
-    option.icon = () => h(NIcon, null, { default: () => h(icon) });
-  }
-
-  return option;
-}
-
-const menuOptions = computed<MenuOption[]>(() =>
-  parentNavRoutes.value.map((record) => {
-    const children = childRoutesByParent.value.get(record.path) ?? [];
-    const option = toMenuOption(record, false);
-
-    if (children.length > 0) {
-      option.children = children.map((child) => toMenuOption(child, true));
-    }
-
-    return option;
-  })
-);
-
-const selectedKey = computed(() => {
-  const explicitNavKey = route.meta.navKey;
-  if (typeof explicitNavKey === 'string') {
-    return explicitNavKey;
-  }
-
-  const currentPath = route.path;
-  const directMatch = navRoutes.value.find((navRoute) => navRoute.path === currentPath);
-  if (directMatch) {
-    return directMatch.path;
-  }
-
-  const prefixMatch = navRoutes.value.find((navRoute) => currentPath.startsWith(`${navRoute.path}/`));
-  if (prefixMatch) {
-    return prefixMatch.path;
-  }
-
-  return lastActiveSection.value;
-});
-
-const routePathSegments = computed(() => route.path.split('/').filter(Boolean));
-
-const lastPathSegment = computed(() => {
-  const segments = routePathSegments.value;
-  const rawSegment = segments.at(-1);
-
-  if (!rawSegment) {
-    return 'frollz';
-  }
-
-  return decodeURIComponent(rawSegment);
-});
-
-const selectedRouteRecord = computed(() => {
-  if (!selectedKey.value) {
-    return null;
-  }
-
-  return navRoutes.value.find((record) => record.path === selectedKey.value) ?? null;
-});
-
-const directMatchedNavRecord = computed(() =>
-  navRoutes.value.find((record) => record.path === route.path) ?? null
-);
-
-const navRouteByPath = computed(() => {
-  const byPath = new Map<string, (typeof navRoutes.value)[number]>();
-  for (const record of navRoutes.value) {
-    byPath.set(record.path, record);
-  }
-  return byPath;
-});
-
-const breadcrumbItems = computed<BreadcrumbItem[]>(() => {
-  const items: BreadcrumbItem[] = [
-    {
-      key: 'home',
-      label: 'frollz',
-      to: '/',
-      icon: Home,
-      ariaLabel: 'frollz home'
-    }
-  ];
-
-  const currentRecord = selectedRouteRecord.value;
-  if (!currentRecord) {
-    items.push({
-      key: `current-${route.path}`,
-      label: lastPathSegment.value,
-      isCurrent: true
-    });
-    return items;
-  }
-
-  const isDirectMatch = directMatchedNavRecord.value?.path === currentRecord.path;
-  const parentPath = typeof currentRecord.meta.navParent === 'string' ? currentRecord.meta.navParent : null;
-
-  if (parentPath) {
-    const parentRecord = navRouteByPath.value.get(parentPath);
-
-    if (parentRecord) {
-      items.push({
-        key: parentRecord.path,
-        label: String(parentRecord.meta.title ?? parentRecord.name ?? parentRecord.path),
-        to: parentRecord.path
-      });
-    }
-
-    if (isDirectMatch) {
-      items.push({
-        key: currentRecord.path,
-        label: String(currentRecord.meta.title ?? currentRecord.name ?? currentRecord.path),
-        isCurrent: true
-      });
-      return items;
-    }
-  } else if (isDirectMatch) {
-    items.push({
-      key: currentRecord.path,
-      label: String(currentRecord.meta.title ?? currentRecord.name ?? currentRecord.path),
-      isCurrent: true
-    });
-    return items;
-  } else {
-    items.push({
-      key: currentRecord.path,
-      label: String(currentRecord.meta.title ?? currentRecord.name ?? currentRecord.path),
-      to: currentRecord.path
-    });
-  }
-
-  items.push({
-    key: `current-${route.path}`,
-    label: lastPathSegment.value,
-    isCurrent: true
-  });
-  return items;
-});
-
-function syncViewportState(): void {
-  isMobile.value = window.innerWidth < MOBILE_BREAKPOINT;
-  if (!isMobile.value) {
-    isMobileMenuOpen.value = false;
-  }
-}
-
-function readShellState(): void {
-  try {
-    isSidebarCollapsed.value = localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === '1';
-    lastActiveSection.value = localStorage.getItem(LAST_ACTIVE_SECTION_KEY);
-  } catch {
-    isSidebarCollapsed.value = false;
-    lastActiveSection.value = null;
-  }
-}
-
-function toggleDesktopSidebar(): void {
-  isSidebarCollapsed.value = !isSidebarCollapsed.value;
-}
-
-function handleMenuSelect(key: string): void {
-  isMobileMenuOpen.value = false;
-  void router.push(key);
-}
-
-function toggleParentExpansion(parentKey: string): void {
-  if (expandedKeys.value.includes(parentKey)) {
-    expandedKeys.value = expandedKeys.value.filter((key) => key !== parentKey);
-    return;
-  }
-
-  expandedKeys.value = [...expandedKeys.value, parentKey];
-}
-
-function handleMenuLabelClick(event: MouseEvent, key: string): void {
-  event.stopPropagation();
-  const isParent = childRoutesByParent.value.has(key);
-
-  if (isParent) {
-    toggleParentExpansion(key);
-  }
-
-  isMobileMenuOpen.value = false;
-  if (route.path !== key) {
-    void router.push(key);
-  }
-}
-
-function handleExpandedKeys(nextKeys: string[]): void {
-  expandedKeys.value = nextKeys;
-}
-
-function ensureParentExpanded(menuKey: string | null): void {
-  if (!menuKey) {
-    return;
-  }
-
-  const routeRecord = navRoutes.value.find((record) => record.path === menuKey);
-  if (!routeRecord || typeof routeRecord.meta.navParent !== 'string') {
-    return;
-  }
-
-  if (!expandedKeys.value.includes(routeRecord.meta.navParent)) {
-    expandedKeys.value = [...expandedKeys.value, routeRecord.meta.navParent];
-  }
-}
+const {
+  breadcrumbItems,
+  expandedKeys,
+  handleExpandedKeys,
+  handleMenuSelect,
+  isMobile,
+  isMobileMenuOpen,
+  isSidebarCollapsed,
+  menuOptions,
+  selectedKey,
+  toggleDesktopSidebar
+} = useAppShellNavigation();
 
 async function handleLogout(): Promise<void> {
   await authStore.logout();
   isMobileMenuOpen.value = false;
   await router.replace('/login');
 }
-
-watch(
-  isSidebarCollapsed,
-  (value) => {
-    try {
-      localStorage.setItem(SIDEBAR_COLLAPSED_KEY, value ? '1' : '0');
-    } catch {
-      // Ignore storage errors in private or constrained environments.
-    }
-  },
-  { immediate: false }
-);
-
-watch(
-  selectedKey,
-  (value) => {
-    if (!value) {
-      return;
-    }
-
-    ensureParentExpanded(value);
-    lastActiveSection.value = value;
-    try {
-      localStorage.setItem(LAST_ACTIVE_SECTION_KEY, value);
-    } catch {
-      // Ignore storage errors in private or constrained environments.
-    }
-  },
-  { immediate: true }
-);
-
-onMounted(() => {
-  readShellState();
-  syncViewportState();
-  window.addEventListener('resize', syncViewportState);
-});
-
-onBeforeUnmount(() => {
-  window.removeEventListener('resize', syncViewportState);
-});
-
-watch(
-  () => route.path,
-  () => {
-    document.title = `${lastPathSegment.value} | frollz`;
-  },
-  { immediate: true }
-);
 </script>
 
 <template>
   <NLayout has-sider class="app-shell">
-    <NLayoutSider v-if="authStore.isAuthenticated && !isMobile" bordered collapse-mode="width"
-      :collapsed="isSidebarCollapsed" :collapsed-width="64" :width="280" show-trigger="bar" :native-scrollbar="false"
-      class="app-shell__sider" @update:collapsed="(value) => { isSidebarCollapsed = value; }">
-      <div class="app-shell__brand">
-        <NThing :title="isSidebarCollapsed ? 'F2' : 'Frollz2'" :description="isSidebarCollapsed ? '' : 'Admin shell'" />
-      </div>
-      <NMenu :value="selectedKey" :collapsed="isSidebarCollapsed" :collapsed-width="64" :indent="14"
-        :options="menuOptions" :expanded-keys="expandedKeys" @update:value="handleMenuSelect"
-        @update:expanded-keys="handleExpandedKeys" />
-    </NLayoutSider>
+    <AppSidebarMenu
+      :collapsed="isSidebarCollapsed"
+      :expanded-keys="expandedKeys"
+      :is-authenticated="authStore.isAuthenticated"
+      :is-mobile="isMobile"
+      :mobile-menu-open="isMobileMenuOpen"
+      :selected-key="selectedKey"
+      :menu-options="menuOptions"
+      @logout="handleLogout"
+      @select="handleMenuSelect"
+      @toggle:mobile-menu="(value) => { isMobileMenuOpen = value; }"
+      @update:collapsed="(value) => { isSidebarCollapsed = value; }"
+      @update:expanded-keys="handleExpandedKeys"
+    />
 
     <NLayout>
-      <NLayoutHeader bordered class="app-shell__header">
-        <NSpace justify="space-between" align="center" :wrap="false" style="width: 100%;">
-          <NSpace align="center" :wrap="false" class="app-shell__header-left">
-            <NButton v-if="isMobile" aria-label="Menu" secondary circle @click="isMobileMenuOpen = true">
-              <template #icon>
-                <NIcon>
-                  <MenuIcon />
-                </NIcon>
-              </template>
-            </NButton>
-            <NButton v-else aria-label="Toggle sidebar" secondary circle @click="toggleDesktopSidebar">
-              <template #icon>
-                <NIcon>
-                  <CollapseIcon v-if="!isSidebarCollapsed" />
-                  <ExpandIcon v-else />
-                </NIcon>
-              </template>
-            </NButton>
-            <nav class="app-shell__breadcrumb-wrap" aria-label="Breadcrumb">
-              <NBreadcrumb separator=">" class="app-shell__breadcrumb">
-                <NBreadcrumbItem v-for="crumb in breadcrumbItems" :key="crumb.key">
-                  <RouterLink v-if="crumb.to && !crumb.isCurrent" :to="crumb.to" class="app-shell__breadcrumb-link"
-                    :aria-label="crumb.ariaLabel ?? crumb.label">
-                    <NIcon v-if="crumb.icon" size="16" aria-hidden="true">
-                      <component :is="crumb.icon" />
-                    </NIcon>
-                    <span>{{ crumb.label }}</span>
-                  </RouterLink>
-                  <span v-else class="app-shell__breadcrumb-current" :aria-current="crumb.isCurrent ? 'page' : undefined">
-                    <NIcon v-if="crumb.icon" size="16" aria-hidden="true">
-                      <component :is="crumb.icon" />
-                    </NIcon>
-                    <span>{{ crumb.label }}</span>
-                  </span>
-                </NBreadcrumbItem>
-              </NBreadcrumb>
-            </nav>
-          </NSpace>
-          <NSpace align="center" :wrap="false" class="app-shell__header-right">
-            <NText v-if="authStore.user" depth="3" class="app-shell__user">{{ authStore.user.email }}</NText>
-            <NButton tertiary type="error" @click="handleLogout">Logout</NButton>
-          </NSpace>
-        </NSpace>
-      </NLayoutHeader>
+      <AppHeaderBar
+        :breadcrumb-items="breadcrumbItems"
+        :is-mobile="isMobile"
+        :is-sidebar-collapsed="isSidebarCollapsed"
+        :user-email="authStore.user?.email ?? null"
+        @logout="handleLogout"
+        @open:mobile-menu="isMobileMenuOpen = true"
+        @toggle:sidebar="toggleDesktopSidebar"
+      />
 
       <NLayoutContent class="app-shell__content">
         <main id="app-main-content" class="app-shell__main">
@@ -551,85 +63,11 @@ watch(
       </NLayoutContent>
     </NLayout>
   </NLayout>
-
-  <NDrawer v-model:show="isMobileMenuOpen" placement="left" width="min(100vw, 360px)">
-    <NDrawerContent title="Navigation" closable>
-      <NSpace vertical size="large">
-        <NMenu :value="selectedKey" :indent="14" :options="menuOptions" :expanded-keys="expandedKeys"
-          @update:value="handleMenuSelect" @update:expanded-keys="handleExpandedKeys" />
-        <NButton type="error" secondary @click="handleLogout">Logout</NButton>
-      </NSpace>
-    </NDrawerContent>
-  </NDrawer>
 </template>
 
 <style scoped>
 .app-shell {
   min-height: 100vh;
-}
-
-.app-shell__sider {
-  border-right: 1px solid var(--n-border-color);
-}
-
-.app-shell__brand {
-  padding: 16px 12px 10px;
-}
-
-.app-shell__header {
-  align-items: center;
-  display: flex;
-  min-height: 64px;
-  padding: 8px 12px;
-}
-
-.app-shell__header-left {
-  flex: 1 1 auto;
-  min-width: 0;
-}
-
-.app-shell__header-right {
-  flex: 0 0 auto;
-}
-
-.app-shell__breadcrumb-wrap {
-  min-width: 0;
-  overflow: hidden;
-}
-
-.app-shell__breadcrumb {
-  min-width: 0;
-}
-
-.app-shell__breadcrumb-link,
-.app-shell__breadcrumb-current {
-  align-items: center;
-  display: inline-flex;
-  gap: 6px;
-  max-width: 32vw;
-}
-
-.app-shell__breadcrumb-link {
-  color: inherit;
-  text-decoration: none;
-}
-
-.app-shell__breadcrumb-link:hover {
-  text-decoration: underline;
-}
-
-.app-shell__breadcrumb-link span,
-.app-shell__breadcrumb-current span {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.app-shell__user {
-  max-width: 260px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .app-shell__menu-label {
@@ -657,22 +95,5 @@ watch(
 
 .app-shell__main {
   min-height: calc(100vh - 64px);
-}
-
-@media (max-width: 900px) {
-  .app-shell__user {
-    display: none;
-  }
-}
-
-@media (min-width: 901px) {
-  .app-shell__header {
-    padding: 0 16px;
-  }
-
-  .app-shell__breadcrumb-link,
-  .app-shell__breadcrumb-current {
-    max-width: 220px;
-  }
 }
 </style>

--- a/apps/ui/src/pages/DeviceDetailPage.vue
+++ b/apps/ui/src/pages/DeviceDetailPage.vue
@@ -1,39 +1,31 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
-import { useRoute, useRouter } from 'vue-router';
+import { computed, onMounted } from 'vue';
+import { useRoute } from 'vue-router';
 import {
-  NAlert,
-  NButton,
   NCard,
   NDataTable,
   NEmpty,
   NSpin,
-  NTag,
-  NText,
-  NTimeline,
-  NTimelineItem
+  NTag
 } from 'naive-ui';
 import type { DataTableColumns } from 'naive-ui';
 import type { FilmHolderSlot } from '@frollz2/schema';
-import PageShell from '../components/PageShell.vue';
+import DetailPageShell from '../components/DetailPageShell.vue';
+import DeviceLoadTimelineCard from '../components/device/DeviceLoadTimelineCard.vue';
 import EntityDetailHeaderCard from '../components/inventory/EntityDetailHeaderCard.vue';
 import InventorySplitLayout from '../components/inventory/InventorySplitLayout.vue';
 import { useReferenceStore } from '../stores/reference.js';
 import { useDeviceStore } from '../stores/devices.js';
 import { useUiFeedback } from '../composables/useUiFeedback.js';
 import { devicePrimaryLabel } from './device-dashboard.js';
-import { mapDeviceLoadEventsToTimeline } from './device-detail-timeline.js';
 
 const route = useRoute();
-const router = useRouter();
 const referenceStore = useReferenceStore();
 const deviceStore = useDeviceStore();
 const feedback = useUiFeedback();
 
 const deviceId = computed(() => Number(route.params.id));
 const selectedDevice = computed(() => deviceStore.currentDevice);
-const isCompactTimeline = ref(false);
-let timelineMediaQuery: MediaQueryList | null = null;
 
 const slotColumns: DataTableColumns<FilmHolderSlot> = [
   { title: 'Side', key: 'sideNumber', render: (row) => `#${row.sideNumber}` },
@@ -88,27 +80,7 @@ const detailItems = computed(() => {
   ];
 });
 
-const timelinePlacement = computed<'left' | 'right'>(() => (isCompactTimeline.value ? 'left' : 'right'));
-const timelineItems = computed(() => mapDeviceLoadEventsToTimeline(deviceStore.currentLoadEvents));
-
-function syncTimelinePlacement(eventOrQuery: MediaQueryList | MediaQueryListEvent): void {
-  isCompactTimeline.value = eventOrQuery.matches;
-}
-
-function goBack(): void {
-  if (window.history.length > 1) {
-    router.back();
-    return;
-  }
-
-  router.push('/devices');
-}
-
 onMounted(async () => {
-  timelineMediaQuery = window.matchMedia('(max-width: 768px)');
-  syncTimelinePlacement(timelineMediaQuery);
-  timelineMediaQuery.addEventListener('change', syncTimelinePlacement);
-
   try {
     if (!referenceStore.loaded) {
       await referenceStore.loadAll();
@@ -119,23 +91,15 @@ onMounted(async () => {
     feedback.error(feedback.toErrorMessage(error, 'Could not load device detail.'));
   }
 });
-
-onBeforeUnmount(() => {
-  timelineMediaQuery?.removeEventListener('change', syncTimelinePlacement);
-  timelineMediaQuery = null;
-});
 </script>
 
 <template>
-  <PageShell title="Device Detail" subtitle="Review device metadata, holder slot state, and film load timeline.">
-    <template #actions>
-      <NButton tertiary @click="goBack">Back</NButton>
-    </template>
-
-    <NAlert v-if="deviceStore.detailError" type="error" :show-icon="true" style="margin-bottom: 12px;">
-      {{ deviceStore.detailError }}
-    </NAlert>
-
+  <DetailPageShell
+    title="Device Detail"
+    subtitle="Review device metadata, holder slot state, and film load timeline."
+    fallback-path="/devices"
+    :error-message="deviceStore.detailError"
+  >
     <NSpin :show="deviceStore.isLoadingDetail">
       <InventorySplitLayout left-panel-title="Device details" right-panel-title="Film load timeline">
         <template #left>
@@ -168,71 +132,12 @@ onBeforeUnmount(() => {
         </template>
 
         <template #right>
-          <NCard>
-            <NTimeline v-if="timelineItems.length > 0" :item-placement="timelinePlacement" class="device-detail__timeline">
-              <NTimelineItem v-for="item in timelineItems" :key="item.eventId" class="device-detail__timeline-item">
-                <template #icon>
-                  <span class="device-detail__timeline-dot" :style="{ backgroundColor: item.dotColor }" />
-                </template>
-                <div class="device-detail__timeline-item-content">
-                  <NText :style="{ color: item.titleColor }" class="device-detail__timeline-title">{{ item.filmName }}</NText>
-                  <NText class="device-detail__timeline-emulsion">{{ item.emulsionName }}</NText>
-                  <NText v-if="item.stockLabel" depth="3" class="device-detail__timeline-stock">{{ item.stockLabel }}</NText>
-                  <NText depth="3" class="device-detail__timeline-item-date">{{ item.occurredLabel }}</NText>
-                  <NText v-if="item.removedLabel" depth="3" class="device-detail__timeline-item-date">Removed: {{ item.removedLabel }}</NText>
-                  <NText v-if="item.slotLabel" depth="3">{{ item.slotLabel }}</NText>
-                </div>
-              </NTimelineItem>
-            </NTimeline>
-            <NEmpty v-else-if="!deviceStore.isLoadingDetail" description="No load events yet for this device." />
-          </NCard>
+          <DeviceLoadTimelineCard
+            :events="deviceStore.currentLoadEvents"
+            :loading="deviceStore.isLoadingDetail"
+          />
         </template>
       </InventorySplitLayout>
     </NSpin>
-  </PageShell>
+  </DetailPageShell>
 </template>
-
-<style scoped>
-.device-detail__timeline {
-  margin-top: 0;
-}
-
-.device-detail__timeline-item {
-  padding-bottom: 8px;
-}
-
-.device-detail__timeline-title {
-  display: block;
-  font-weight: 600;
-  line-height: 1.2;
-  margin-bottom: 2px;
-}
-
-.device-detail__timeline-emulsion {
-  display: block;
-  line-height: 1.2;
-  margin-bottom: 2px;
-}
-
-.device-detail__timeline-stock {
-  display: block;
-  line-height: 1.2;
-  margin-bottom: 2px;
-}
-
-.device-detail__timeline-item-content {
-  width: 100%;
-}
-
-.device-detail__timeline-item-date {
-  display: block;
-  line-height: 1.2;
-}
-
-.device-detail__timeline-dot {
-  display: inline-block;
-  width: 10px;
-  height: 10px;
-  border-radius: 999px;
-}
-</style>

--- a/apps/ui/src/pages/DevicesPage.vue
+++ b/apps/ui/src/pages/DevicesPage.vue
@@ -1,31 +1,21 @@
 <script setup lang="ts">
-import { computed, onMounted, reactive, ref } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 import { useRoute } from 'vue-router';
 import {
   NAlert,
   NButton,
   NCard,
-  NDatePicker,
-  NDrawer,
-  NDrawerContent,
   NEmpty,
   NFlex,
-  NForm,
-  NFormItem,
-  NInput,
-  NSwitch,
-  NSelect,
   NTag,
   NText
 } from 'naive-ui';
-import type { CreateFilmDeviceRequest } from '@frollz2/schema';
-import { createIdempotencyKey } from '../composables/idempotency.js';
 import { useReferenceStore } from '../stores/reference.js';
 import { useDeviceStore } from '../stores/devices.js';
 import PageShell from '../components/PageShell.vue';
 import MiniDashboardLayout from '../components/MiniDashboardLayout.vue';
+import DeviceCreateDrawer from '../components/device/DeviceCreateDrawer.vue';
 import { useUiFeedback } from '../composables/useUiFeedback.js';
-import type { FormState } from '../composables/ui-state.js';
 
 const referenceStore = useReferenceStore();
 const deviceStore = useDeviceStore();
@@ -33,27 +23,6 @@ const feedback = useUiFeedback();
 const route = useRoute();
 
 const isCreateDrawerOpen = ref(false);
-const isCreatingDevice = ref(false);
-const pendingCreateKey = ref<string>(createIdempotencyKey());
-const cameraDateAcquiredTimestamp = ref<number | null>(null);
-const createState = ref<FormState>({ loading: false, fieldErrors: {}, formError: null });
-
-const createForm = reactive({
-  deviceTypeCode: null as string | null,
-  filmFormatId: null as number | null,
-  frameSize: '',
-  make: '',
-  model: '',
-  serialNumber: '',
-  loadMode: 'direct' as 'direct' | 'interchangeable_back' | 'film_holder',
-  canUnload: true,
-  cameraSystem: '',
-  name: '',
-  system: '',
-  brand: '',
-  slotCount: 1 as 1 | 2,
-  holderTypeId: null as number | null
-});
 
 const deviceTypeTypeByCode: Record<string, 'default' | 'info' | 'primary'> = {
   camera: 'primary',
@@ -61,57 +30,6 @@ const deviceTypeTypeByCode: Record<string, 'default' | 'info' | 'primary'> = {
   film_holder: 'default'
 };
 
-const deviceTypeOptions = computed(() =>
-  referenceStore.deviceTypes.map((entry) => ({ label: entry.label, value: entry.code }))
-);
-const filmFormatOptions = computed(() =>
-  referenceStore.filmFormats.map((entry) => ({ label: entry.label, value: entry.id }))
-);
-const selectedFormatCode = computed(() => {
-  if (!createForm.filmFormatId) {
-    return null;
-  }
-  return referenceStore.filmFormats.find((entry) => entry.id === createForm.filmFormatId)?.code ?? null;
-});
-const frameSizeOptions = computed(() => {
-  const code = selectedFormatCode.value;
-  if (!code) {
-    return [];
-  }
-
-  if (code === '35mm') {
-    return [
-      { label: 'Full Frame', value: 'full_frame' },
-      { label: 'Half Frame', value: 'half_frame' }
-    ];
-  }
-
-  if (code === '120' || code === '220') {
-    return ['645', '6x6', '6x7', '6x8', '6x9', '6x12', '6x17'].map((value) => ({ label: value, value }));
-  }
-
-  if (code === '4x5' || code === '8x10' || code === '2x3') {
-    return [{ label: code, value: code }];
-  }
-
-  if (code === 'InstaxMini' || code === 'InstaxWide' || code === 'InstaxSquare') {
-    return [{ label: 'Instax', value: 'instax' }];
-  }
-
-  return [];
-});
-const holderTypeOptions = computed(() =>
-  referenceStore.holderTypes.map((entry) => ({ label: entry.label, value: entry.id }))
-);
-const cameraLoadModeOptions = computed(() => [
-  { label: 'Direct', value: 'direct' },
-  { label: 'Interchangeable back', value: 'interchangeable_back' },
-  { label: 'Film holder', value: 'film_holder' }
-]);
-const holderSlotCountOptions = computed(() => [
-  { label: '1 slot', value: 1 },
-  { label: '2 slots', value: 2 }
-]);
 const lockedDeviceType = computed(() =>
   typeof route.meta.deviceTypeFilter === 'string' ? route.meta.deviceTypeFilter : null
 );
@@ -151,55 +69,6 @@ const pageSubtitle = computed(() =>
     : 'Manage cameras, interchangeable backs, and holders in a compact dashboard.'
 );
 
-function validateCreateForm(): Record<string, string> {
-  const errors: Record<string, string> = {};
-
-  if (!createForm.deviceTypeCode) {
-    errors.deviceTypeCode = 'Device type is required.';
-  }
-  if (!createForm.filmFormatId) {
-    errors.filmFormatId = 'Film format is required.';
-  }
-  if (!createForm.frameSize) {
-    errors.frameSize = 'Frame size is required.';
-  }
-
-  if (createForm.deviceTypeCode === 'camera') {
-    if (!createForm.make.trim()) {
-      errors.make = 'Camera make is required.';
-    }
-    if (!createForm.model.trim()) {
-      errors.model = 'Camera model is required.';
-    }
-    if (createForm.loadMode === 'interchangeable_back' && !createForm.cameraSystem.trim()) {
-      errors.cameraSystem = 'Camera system is required for interchangeable back cameras.';
-    }
-  }
-
-  if (createForm.deviceTypeCode === 'interchangeable_back') {
-    if (!createForm.name.trim()) {
-      errors.name = 'Back name is required.';
-    }
-    if (!createForm.system.trim()) {
-      errors.system = 'System is required.';
-    }
-  }
-
-  if (createForm.deviceTypeCode === 'film_holder') {
-    if (!createForm.name.trim()) {
-      errors.name = 'Holder name is required.';
-    }
-    if (!createForm.brand.trim()) {
-      errors.brand = 'Brand is required.';
-    }
-    if (!createForm.holderTypeId) {
-      errors.holderTypeId = 'Holder type is required.';
-    }
-  }
-
-  return errors;
-}
-
 function deviceDetail(deviceId: number): string {
   const device = filteredDevices.value.find((entry) => entry.id === deviceId);
   if (!device) {
@@ -215,26 +84,6 @@ function deviceDetail(deviceId: number): string {
   }
 
   return `${device.name} · ${device.brand} · ${device.holderTypeCode}`;
-}
-
-function resetCreateForm(): void {
-  createForm.deviceTypeCode = null;
-  createForm.filmFormatId = null;
-  createForm.frameSize = '';
-  createForm.make = '';
-  createForm.model = '';
-  createForm.serialNumber = '';
-  createForm.loadMode = 'direct';
-  createForm.canUnload = true;
-  createForm.cameraSystem = '';
-  createForm.name = '';
-  createForm.system = '';
-  createForm.brand = '';
-  createForm.slotCount = 1;
-  createForm.holderTypeId = null;
-  cameraDateAcquiredTimestamp.value = null;
-  createState.value.fieldErrors = {};
-  createState.value.formError = null;
 }
 
 async function refresh(): Promise<void> {
@@ -257,81 +106,7 @@ onMounted(async () => {
 });
 
 function openCreateDrawer(): void {
-  pendingCreateKey.value = createIdempotencyKey();
   isCreateDrawerOpen.value = true;
-}
-
-async function submitCreateDevice(): Promise<void> {
-  if (isCreatingDevice.value) {
-    return;
-  }
-
-  createState.value.fieldErrors = validateCreateForm();
-  if (Object.keys(createState.value.fieldErrors).length > 0) {
-    createState.value.formError = 'Please complete required fields.';
-    return;
-  }
-
-  const deviceType = referenceStore.deviceTypes.find((entry) => entry.code === createForm.deviceTypeCode);
-  if (!deviceType) {
-    createState.value.formError = 'Device type is not available.';
-    return;
-  }
-
-  let payload: CreateFilmDeviceRequest;
-
-  if (createForm.deviceTypeCode === 'camera') {
-    payload = {
-      deviceTypeCode: 'camera',
-      deviceTypeId: deviceType.id,
-      filmFormatId: createForm.filmFormatId as number,
-      frameSize: createForm.frameSize as CreateFilmDeviceRequest['frameSize'],
-      make: createForm.make.trim(),
-      model: createForm.model.trim(),
-      loadMode: createForm.loadMode,
-      canUnload: createForm.canUnload,
-      cameraSystem: createForm.cameraSystem.trim() || null,
-      serialNumber: createForm.serialNumber || null,
-      dateAcquired: cameraDateAcquiredTimestamp.value ? new Date(cameraDateAcquiredTimestamp.value).toISOString() : null
-    };
-  } else if (createForm.deviceTypeCode === 'interchangeable_back') {
-    payload = {
-      deviceTypeCode: 'interchangeable_back',
-      deviceTypeId: deviceType.id,
-      filmFormatId: createForm.filmFormatId as number,
-      frameSize: createForm.frameSize as CreateFilmDeviceRequest['frameSize'],
-      name: createForm.name.trim(),
-      system: createForm.system.trim()
-    };
-  } else {
-    payload = {
-      deviceTypeCode: 'film_holder',
-      deviceTypeId: deviceType.id,
-      filmFormatId: createForm.filmFormatId as number,
-      frameSize: createForm.frameSize as CreateFilmDeviceRequest['frameSize'],
-      name: createForm.name.trim(),
-      brand: createForm.brand.trim(),
-      slotCount: createForm.slotCount,
-      holderTypeId: createForm.holderTypeId as number
-    };
-  }
-
-  isCreatingDevice.value = true;
-  createState.value.loading = true;
-  createState.value.formError = null;
-
-  try {
-    await deviceStore.createDevice(payload, pendingCreateKey.value);
-    isCreateDrawerOpen.value = false;
-    pendingCreateKey.value = createIdempotencyKey();
-    resetCreateForm();
-    feedback.success('Device added successfully.');
-  } catch (error) {
-    createState.value.formError = feedback.toErrorMessage(error, 'Could not create device.');
-  } finally {
-    isCreatingDevice.value = false;
-    createState.value.loading = false;
-  }
 }
 </script>
 
@@ -383,174 +158,5 @@ async function submitCreateDevice(): Promise<void> {
     </MiniDashboardLayout>
   </PageShell>
 
-  <NDrawer :show="isCreateDrawerOpen" placement="right" width="min(100vw, 440px)" @update:show="(value) => { isCreateDrawerOpen = value; }">
-    <NDrawerContent title="Add device" closable>
-      <NForm label-placement="top" @submit.prevent="submitCreateDevice">
-        <NAlert v-if="createState.formError" type="error" :show-icon="true" style="margin-bottom: 10px;">
-          {{ createState.formError }}
-        </NAlert>
-
-        <NFormItem
-          label="Device type"
-          required
-          :label-props="{ for: 'device-create-type-input' }"
-          :feedback="createState.fieldErrors.deviceTypeCode || ''"
-        >
-          <NSelect
-            :value="createForm.deviceTypeCode"
-            :options="deviceTypeOptions"
-            :input-props="{ id: 'device-create-type-input', name: 'deviceTypeCode' }"
-            @update:value="(value) => { createForm.deviceTypeCode = value; }"
-          />
-        </NFormItem>
-        <NFormItem
-          label="Film format"
-          required
-          :label-props="{ for: 'device-create-format-input' }"
-          :feedback="createState.fieldErrors.filmFormatId || ''"
-        >
-          <NSelect
-            :value="createForm.filmFormatId"
-            :options="filmFormatOptions"
-            :input-props="{ id: 'device-create-format-input', name: 'filmFormatId' }"
-            @update:value="(value) => { createForm.filmFormatId = value; }"
-          />
-        </NFormItem>
-        <NFormItem
-          label="Frame size"
-          required
-          :label-props="{ for: 'device-create-frame-size-input' }"
-          :feedback="createState.fieldErrors.frameSize || ''"
-        >
-          <NSelect
-            :value="createForm.frameSize"
-            :options="frameSizeOptions"
-            placeholder="Select frame size"
-            :input-props="{ id: 'device-create-frame-size-input', name: 'frameSize' }"
-            @update:value="(value) => { createForm.frameSize = value; }"
-          />
-        </NFormItem>
-
-        <template v-if="createForm.deviceTypeCode === 'camera'">
-          <NFormItem label="Make" required :label-props="{ for: 'device-create-make-input' }" :feedback="createState.fieldErrors.make || ''">
-            <NInput
-              :value="createForm.make"
-              :input-props="{ id: 'device-create-make-input', name: 'make' }"
-              @update:value="(value) => { createForm.make = value; }"
-            />
-          </NFormItem>
-          <NFormItem label="Model" required :label-props="{ for: 'device-create-model-input' }" :feedback="createState.fieldErrors.model || ''">
-            <NInput
-              :value="createForm.model"
-              :input-props="{ id: 'device-create-model-input', name: 'model' }"
-              @update:value="(value) => { createForm.model = value; }"
-            />
-          </NFormItem>
-          <NFormItem label="Serial number" :label-props="{ for: 'device-create-serial-input' }">
-            <NInput
-              :value="createForm.serialNumber"
-              :input-props="{ id: 'device-create-serial-input', name: 'serialNumber' }"
-              @update:value="(value) => { createForm.serialNumber = value; }"
-            />
-          </NFormItem>
-          <NFormItem label="Load mode" :label-props="{ for: 'device-create-load-mode-input' }">
-            <NSelect
-              :value="createForm.loadMode"
-              :options="cameraLoadModeOptions"
-              :input-props="{ id: 'device-create-load-mode-input', name: 'loadMode' }"
-              @update:value="(value) => { createForm.loadMode = value; }"
-            />
-          </NFormItem>
-          <NFormItem label="Can unload film">
-            <NSwitch
-              :value="createForm.canUnload"
-              @update:value="(value) => { createForm.canUnload = value; }"
-            />
-          </NFormItem>
-          <NFormItem
-            v-if="createForm.loadMode === 'interchangeable_back'"
-            label="Camera system"
-            :label-props="{ for: 'device-create-camera-system-input' }"
-          >
-            <NInput
-              :value="createForm.cameraSystem"
-              :input-props="{ id: 'device-create-camera-system-input', name: 'cameraSystem' }"
-              @update:value="(value) => { createForm.cameraSystem = value; }"
-            />
-          </NFormItem>
-          <NFormItem label="Date acquired" :label-props="{ for: 'device-create-date-acquired-input' }">
-            <NDatePicker
-              :value="cameraDateAcquiredTimestamp"
-              type="datetime"
-              clearable
-              :input-props="{ id: 'device-create-date-acquired-input', name: 'dateAcquired' }"
-              @update:value="(value) => { cameraDateAcquiredTimestamp = value; }"
-            />
-          </NFormItem>
-        </template>
-
-        <template v-if="createForm.deviceTypeCode === 'interchangeable_back'">
-          <NFormItem label="Name" required :label-props="{ for: 'device-create-back-name-input' }" :feedback="createState.fieldErrors.name || ''">
-            <NInput
-              :value="createForm.name"
-              :input-props="{ id: 'device-create-back-name-input', name: 'name' }"
-              @update:value="(value) => { createForm.name = value; }"
-            />
-          </NFormItem>
-          <NFormItem label="System" required :label-props="{ for: 'device-create-system-input' }" :feedback="createState.fieldErrors.system || ''">
-            <NInput
-              :value="createForm.system"
-              :input-props="{ id: 'device-create-system-input', name: 'system' }"
-              @update:value="(value) => { createForm.system = value; }"
-            />
-          </NFormItem>
-        </template>
-
-        <template v-if="createForm.deviceTypeCode === 'film_holder'">
-          <NFormItem label="Name" required :label-props="{ for: 'device-create-holder-name-input' }" :feedback="createState.fieldErrors.name || ''">
-            <NInput
-              :value="createForm.name"
-              :input-props="{ id: 'device-create-holder-name-input', name: 'name' }"
-              @update:value="(value) => { createForm.name = value; }"
-            />
-          </NFormItem>
-          <NFormItem label="Brand" required :label-props="{ for: 'device-create-holder-brand-input' }" :feedback="createState.fieldErrors.brand || ''">
-            <NInput
-              :value="createForm.brand"
-              :input-props="{ id: 'device-create-holder-brand-input', name: 'brand' }"
-              @update:value="(value) => { createForm.brand = value; }"
-            />
-          </NFormItem>
-          <NFormItem
-            label="Holder type"
-            required
-            :label-props="{ for: 'device-create-holder-type-input' }"
-            :feedback="createState.fieldErrors.holderTypeId || ''"
-          >
-            <NSelect
-              :value="createForm.holderTypeId"
-              :options="holderTypeOptions"
-              :input-props="{ id: 'device-create-holder-type-input', name: 'holderTypeId' }"
-              @update:value="(value) => { createForm.holderTypeId = value; }"
-            />
-          </NFormItem>
-          <NFormItem label="Slot count" :label-props="{ for: 'device-create-holder-slot-count-input' }">
-            <NSelect
-              :value="createForm.slotCount"
-              :options="holderSlotCountOptions"
-              :input-props="{ id: 'device-create-holder-slot-count-input', name: 'slotCount' }"
-              @update:value="(value) => { createForm.slotCount = value; }"
-            />
-          </NFormItem>
-        </template>
-
-        <NFlex justify="end">
-          <NButton tertiary @click="isCreateDrawerOpen = false">Cancel</NButton>
-          <NButton type="primary" attr-type="submit" :loading="isCreatingDevice" :disabled="isCreatingDevice">
-            Create device
-          </NButton>
-        </NFlex>
-      </NForm>
-    </NDrawerContent>
-  </NDrawer>
+  <DeviceCreateDrawer v-model:show="isCreateDrawerOpen" />
 </template>

--- a/apps/ui/src/pages/DevicesPage.vue
+++ b/apps/ui/src/pages/DevicesPage.vue
@@ -4,18 +4,17 @@ import { useRoute } from 'vue-router';
 import {
   NAlert,
   NButton,
-  NCard,
-  NEmpty,
-  NFlex,
-  NTag,
-  NText
+  NCard
 } from 'naive-ui';
 import { useReferenceStore } from '../stores/reference.js';
 import { useDeviceStore } from '../stores/devices.js';
 import PageShell from '../components/PageShell.vue';
 import MiniDashboardLayout from '../components/MiniDashboardLayout.vue';
 import DeviceCreateDrawer from '../components/device/DeviceCreateDrawer.vue';
+import RecentDevicesCard from '../components/device/RecentDevicesCard.vue';
+import KpiCardGrid from '../components/inventory/KpiCardGrid.vue';
 import { useUiFeedback } from '../composables/useUiFeedback.js';
+import { buildDeviceKpis, filterDevicesByTypeCode } from './device-dashboard.js';
 
 const referenceStore = useReferenceStore();
 const deviceStore = useDeviceStore();
@@ -33,58 +32,16 @@ const deviceTypeTypeByCode: Record<string, 'default' | 'info' | 'primary'> = {
 const lockedDeviceType = computed(() =>
   typeof route.meta.deviceTypeFilter === 'string' ? route.meta.deviceTypeFilter : null
 );
-const filteredDevices = computed(() =>
-  lockedDeviceType.value
-    ? deviceStore.devices.filter((device) => device.deviceTypeCode === lockedDeviceType.value)
-    : deviceStore.devices
-);
+const filteredDevices = computed(() => filterDevicesByTypeCode(deviceStore.devices, lockedDeviceType.value));
 const recentDevices = computed(() => filteredDevices.value.slice(-10));
 
-const stats = computed(() => {
-  const total = filteredDevices.value.length;
-
-  return [
-    { label: 'Total visible devices', value: total, helper: 'Current route scope' },
-    {
-      label: 'Cameras',
-      value: filteredDevices.value.filter((device) => device.deviceTypeCode === 'camera').length,
-      helper: 'Body-level capture devices'
-    },
-    {
-      label: 'Interchangeable backs',
-      value: filteredDevices.value.filter((device) => device.deviceTypeCode === 'interchangeable_back').length,
-      helper: 'Modular backs and magazines'
-    },
-    {
-      label: 'Film holders',
-      value: filteredDevices.value.filter((device) => device.deviceTypeCode === 'film_holder').length,
-      helper: 'Sheet and holder systems'
-    }
-  ];
-});
+const stats = computed(() => buildDeviceKpis(filteredDevices.value));
 
 const pageSubtitle = computed(() =>
   lockedDeviceType.value
     ? 'Dashboard filtered by device category selected in navigation.'
     : 'Manage cameras, interchangeable backs, and holders in a compact dashboard.'
 );
-
-function deviceDetail(deviceId: number): string {
-  const device = filteredDevices.value.find((entry) => entry.id === deviceId);
-  if (!device) {
-    return '-';
-  }
-
-  if (device.deviceTypeCode === 'camera') {
-    return `${device.make} ${device.model}`;
-  }
-
-  if (device.deviceTypeCode === 'interchangeable_back') {
-    return `${device.name} · ${device.system}`;
-  }
-
-  return `${device.name} · ${device.brand} · ${device.holderTypeCode}`;
-}
 
 async function refresh(): Promise<void> {
   try {
@@ -123,37 +80,16 @@ function openCreateDrawer(): void {
 
     <MiniDashboardLayout left-panel-title="Recently added devices" right-panel-title="Device statistics">
       <template #left>
-        <NCard :loading="deviceStore.isLoading">
-          <NEmpty
-            v-if="!deviceStore.isLoading && recentDevices.length === 0"
-            description="No devices found."
-          />
-          <NFlex v-else vertical size="small">
-            <NCard v-for="device in recentDevices" :key="device.id" size="small" embedded>
-              <NFlex justify="space-between" align="center" :wrap="false">
-                <NTag size="small" :type="deviceTypeTypeByCode[device.deviceTypeCode] ?? 'default'">
-                  {{ device.deviceTypeCode.replace('_', ' ') }}
-                </NTag>
-                <NText depth="3">
-                  {{ referenceStore.filmFormats.find((format) => format.id === device.filmFormatId)?.code ?? device.filmFormatId }}
-                  ·
-                  {{ device.frameSize }}
-                </NText>
-              </NFlex>
-              <NText strong>{{ deviceDetail(device.id) }}</NText>
-            </NCard>
-          </NFlex>
-        </NCard>
+        <RecentDevicesCard
+          :devices="recentDevices"
+          :film-formats="referenceStore.filmFormats"
+          :loading="deviceStore.isLoading"
+          :tag-type-by-code="deviceTypeTypeByCode"
+        />
       </template>
 
       <template #right>
-        <NCard v-for="card in stats" :key="card.label" size="small">
-          <NFlex vertical size="small">
-            <NText depth="3">{{ card.label }}</NText>
-            <NText style="font-size: 1.45rem; font-weight: 700;">{{ card.value }}</NText>
-            <NText depth="3">{{ card.helper }}</NText>
-          </NFlex>
-        </NCard>
+        <KpiCardGrid :cards="stats" />
       </template>
     </MiniDashboardLayout>
   </PageShell>

--- a/apps/ui/src/pages/DevicesSubPage.vue
+++ b/apps/ui/src/pages/DevicesSubPage.vue
@@ -1,15 +1,15 @@
 <script setup lang="ts">
 import { computed, h, onMounted, ref } from 'vue';
 import { useRoute } from 'vue-router';
-import { NAlert, NCard, NInput, NTag } from 'naive-ui';
+import { NAlert, NInput, NTag } from 'naive-ui';
 import type { DataTableColumns } from 'naive-ui';
 import type { FilmDevice } from '@frollz2/schema';
 import AppRouteTextLink from '../components/AppRouteTextLink.vue';
 import { useReferenceStore } from '../stores/reference.js';
 import { useDeviceStore } from '../stores/devices.js';
 import PageShell from '../components/PageShell.vue';
+import EntityTableCard from '../components/inventory/EntityTableCard.vue';
 import InventorySplitLayout from '../components/inventory/InventorySplitLayout.vue';
-import EntityTablePanel from '../components/inventory/EntityTablePanel.vue';
 import KpiCardGrid from '../components/inventory/KpiCardGrid.vue';
 import { usePagedEntityTable } from '../composables/usePagedEntityTable.js';
 import { useUiFeedback } from '../composables/useUiFeedback.js';
@@ -115,32 +115,30 @@ onMounted(async () => {
 
     <InventorySplitLayout left-panel-title="Devices in this category" right-panel-title="Category KPIs">
       <template #left>
-        <NCard>
-          <EntityTablePanel
-            :columns="columns"
-            :data="tableState.pagedRows.value"
-            :loading="deviceStore.isLoading"
-            :row-key="(row) => row.id"
-            :page="tableState.page.value"
-            :page-size="tableState.pageSize.value"
-            :item-count="tableState.totalRows.value"
-            :page-sizes="tableState.pageSizes"
-            empty-description="No devices match the current filters."
-            table-test-id="devices-child-table"
-            pagination-test-id="devices-child-pagination"
-            @update:page="(value) => { tableState.page.value = value; }"
-            @update:page-size="(value) => { tableState.pageSize.value = value; }"
-          >
-            <template #filters>
-              <NInput
-                v-model:value="searchTerm"
-                clearable
-                placeholder="Search make, model, system, holder"
-                data-testid="devices-child-search"
-              />
-            </template>
-          </EntityTablePanel>
-        </NCard>
+        <EntityTableCard
+          :columns="columns"
+          :data="tableState.pagedRows.value"
+          :loading="deviceStore.isLoading"
+          :row-key="(row) => row.id"
+          :page="tableState.page.value"
+          :page-size="tableState.pageSize.value"
+          :item-count="tableState.totalRows.value"
+          :page-sizes="tableState.pageSizes"
+          empty-description="No devices match the current filters."
+          table-test-id="devices-child-table"
+          pagination-test-id="devices-child-pagination"
+          @update:page="(value) => { tableState.page.value = value; }"
+          @update:page-size="(value) => { tableState.pageSize.value = value; }"
+        >
+          <template #filters>
+            <NInput
+              v-model:value="searchTerm"
+              clearable
+              placeholder="Search make, model, system, holder"
+              data-testid="devices-child-search"
+            />
+          </template>
+        </EntityTableCard>
       </template>
 
       <template #right>

--- a/apps/ui/src/pages/DevicesSubPage.vue
+++ b/apps/ui/src/pages/DevicesSubPage.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
 import { computed, h, onMounted, ref } from 'vue';
-import { RouterLink, useRoute } from 'vue-router';
+import { useRoute } from 'vue-router';
 import { NAlert, NCard, NInput, NTag } from 'naive-ui';
 import type { DataTableColumns } from 'naive-ui';
 import type { FilmDevice } from '@frollz2/schema';
+import AppRouteTextLink from '../components/AppRouteTextLink.vue';
 import { useReferenceStore } from '../stores/reference.js';
 import { useDeviceStore } from '../stores/devices.js';
 import PageShell from '../components/PageShell.vue';
@@ -59,17 +60,11 @@ const columns = computed<DataTableColumns<FilmDevice>>(() => [
     title: 'Device',
     key: 'name',
     render: (row) => h(
-      RouterLink,
+      AppRouteTextLink,
       {
         to: `/devices/${row.id}`,
-        class: 'device-table__link',
-        style: {
-          color: 'var(--n-primary-color)',
-          fontWeight: 600,
-          textDecorationColor: 'var(--n-primary-color)'
-        }
+        label: devicePrimaryLabel(row)
       },
-      { default: () => devicePrimaryLabel(row) }
     )
   },
   {
@@ -154,24 +149,3 @@ onMounted(async () => {
     </InventorySplitLayout>
   </PageShell>
 </template>
-
-<style scoped>
-.device-table__link {
-  color: var(--n-primary-color);
-  text-decoration: none;
-}
-
-.device-table__link:hover {
-  text-decoration: underline;
-}
-
-.device-table__link:visited {
-  color: var(--n-primary-color);
-}
-
-.device-table__link:focus-visible {
-  border-radius: 4px;
-  outline: 2px solid var(--n-primary-color);
-  outline-offset: 2px;
-}
-</style>

--- a/apps/ui/src/pages/EmulsionDetailPage.vue
+++ b/apps/ui/src/pages/EmulsionDetailPage.vue
@@ -1,14 +1,13 @@
 <script setup lang="ts">
 import { computed, onMounted } from 'vue';
-import { useRoute, useRouter } from 'vue-router';
-import { NAlert, NButton, NEmpty } from 'naive-ui';
-import PageShell from '../components/PageShell.vue';
+import { useRoute } from 'vue-router';
+import { NEmpty, NSpin } from 'naive-ui';
+import DetailPageShell from '../components/DetailPageShell.vue';
 import EntityDetailHeaderCard from '../components/inventory/EntityDetailHeaderCard.vue';
 import { useReferenceStore } from '../stores/reference.js';
 import { useUiFeedback } from '../composables/useUiFeedback.js';
 
 const route = useRoute();
-const router = useRouter();
 const referenceStore = useReferenceStore();
 const feedback = useUiFeedback();
 
@@ -33,15 +32,6 @@ const detailItems = computed(() => {
   ];
 });
 
-function goBack(): void {
-  if (window.history.length > 1) {
-    router.back();
-    return;
-  }
-
-  router.push('/emulsions');
-}
-
 onMounted(async () => {
   try {
     if (!referenceStore.loaded) {
@@ -56,27 +46,26 @@ onMounted(async () => {
 </script>
 
 <template>
-  <PageShell title="Emulsion Detail" subtitle="Read-only reference detail for this stock.">
-    <template #actions>
-      <NButton tertiary @click="goBack">Back</NButton>
-    </template>
+  <DetailPageShell
+    title="Emulsion Detail"
+    subtitle="Read-only reference detail for this stock."
+    fallback-path="/emulsions"
+    :error-message="referenceStore.emulsionDetailError"
+  >
+    <NSpin :show="referenceStore.isLoadingEmulsionDetail">
+      <EntityDetailHeaderCard
+        v-if="selectedEmulsion"
+        :title="`${selectedEmulsion.manufacturer} ${selectedEmulsion.brand}`"
+        :subtitle="`ISO ${selectedEmulsion.isoSpeed}`"
+        :tag-label="selectedEmulsion.developmentProcess.label"
+        tag-type="info"
+        :details="detailItems"
+      />
 
-    <NAlert v-if="referenceStore.emulsionDetailError" type="error" :show-icon="true">
-      {{ referenceStore.emulsionDetailError }}
-    </NAlert>
-
-    <EntityDetailHeaderCard
-      v-if="selectedEmulsion"
-      :title="`${selectedEmulsion.manufacturer} ${selectedEmulsion.brand}`"
-      :subtitle="`ISO ${selectedEmulsion.isoSpeed}`"
-      :tag-label="selectedEmulsion.developmentProcess.label"
-      tag-type="info"
-      :details="detailItems"
-    />
-
-    <NEmpty
-      v-if="!referenceStore.isLoadingEmulsionDetail && !selectedEmulsion"
-      description="Emulsion not found."
-    />
-  </PageShell>
+      <NEmpty
+        v-if="!referenceStore.isLoadingEmulsionDetail && !selectedEmulsion"
+        description="Emulsion not found."
+      />
+    </NSpin>
+  </DetailPageShell>
 </template>

--- a/apps/ui/src/pages/EmulsionsPage.vue
+++ b/apps/ui/src/pages/EmulsionsPage.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import { computed, onMounted } from 'vue';
 import { useRoute } from 'vue-router';
-import { NAlert, NCard, NEmpty, NFlex, NTag, NText } from 'naive-ui';
+import { NAlert } from 'naive-ui';
 import { useReferenceStore } from '../stores/reference.js';
 import PageShell from '../components/PageShell.vue';
 import MiniDashboardLayout from '../components/MiniDashboardLayout.vue';
+import KpiCardGrid from '../components/inventory/KpiCardGrid.vue';
+import RecentEmulsionsCard from '../components/emulsion/RecentEmulsionsCard.vue';
 import { useUiFeedback } from '../composables/useUiFeedback.js';
 
 const referenceStore = useReferenceStore();
@@ -63,34 +65,11 @@ onMounted(async () => {
 
     <MiniDashboardLayout left-panel-title="Recently added emulsions" right-panel-title="Emulsion statistics">
       <template #left>
-        <NCard :loading="referenceStore.isLoading">
-          <NEmpty
-            v-if="!referenceStore.isLoading && recentEmulsions.length === 0"
-            description="No emulsions are available."
-          />
-          <NFlex v-else vertical size="small">
-            <NCard v-for="emulsion in recentEmulsions" :key="emulsion.id" size="small" embedded>
-              <NFlex justify="space-between" align="center" :wrap="false">
-                <NText strong>{{ emulsion.manufacturer }} {{ emulsion.brand }}</NText>
-                <NTag size="small" type="primary">ISO {{ emulsion.isoSpeed }}</NTag>
-              </NFlex>
-              <NText depth="3">{{ emulsion.developmentProcess.label }} · {{ emulsion.balance }}</NText>
-              <NText depth="3">
-                Formats: {{ emulsion.filmFormats.map((format) => format.code).join(', ') || 'None' }}
-              </NText>
-            </NCard>
-          </NFlex>
-        </NCard>
+        <RecentEmulsionsCard :emulsions="recentEmulsions" :loading="referenceStore.isLoading" />
       </template>
 
       <template #right>
-        <NCard v-for="card in stats" :key="card.label" size="small">
-          <NFlex vertical size="small">
-            <NText depth="3">{{ card.label }}</NText>
-            <NText style="font-size: 1.45rem; font-weight: 700;">{{ card.value }}</NText>
-            <NText depth="3">{{ card.helper }}</NText>
-          </NFlex>
-        </NCard>
+        <KpiCardGrid :cards="stats" />
       </template>
     </MiniDashboardLayout>
   </PageShell>

--- a/apps/ui/src/pages/EmulsionsSubPage.vue
+++ b/apps/ui/src/pages/EmulsionsSubPage.vue
@@ -1,14 +1,14 @@
 <script setup lang="ts">
 import { computed, h, onMounted, ref } from 'vue';
 import { useRoute } from 'vue-router';
-import { NAlert, NCard, NInput, NTag } from 'naive-ui';
+import { NAlert, NInput, NTag } from 'naive-ui';
 import type { DataTableColumns } from 'naive-ui';
 import type { Emulsion } from '@frollz2/schema';
 import AppRouteTextLink from '../components/AppRouteTextLink.vue';
 import { useReferenceStore } from '../stores/reference.js';
 import PageShell from '../components/PageShell.vue';
+import EntityTableCard from '../components/inventory/EntityTableCard.vue';
 import InventorySplitLayout from '../components/inventory/InventorySplitLayout.vue';
-import EntityTablePanel from '../components/inventory/EntityTablePanel.vue';
 import KpiCardGrid from '../components/inventory/KpiCardGrid.vue';
 import { usePagedEntityTable } from '../composables/usePagedEntityTable.js';
 import { useUiFeedback } from '../composables/useUiFeedback.js';
@@ -98,32 +98,30 @@ onMounted(async () => {
 
     <InventorySplitLayout left-panel-title="Emulsions in this process" right-panel-title="Process KPIs">
       <template #left>
-        <NCard>
-          <EntityTablePanel
-            :columns="columns"
-            :data="tableState.pagedRows.value"
-            :loading="referenceStore.isLoading"
-            :row-key="(row) => row.id"
-            :page="tableState.page.value"
-            :page-size="tableState.pageSize.value"
-            :item-count="tableState.totalRows.value"
-            :page-sizes="tableState.pageSizes"
-            empty-description="No emulsions match the current filters."
-            table-test-id="emulsions-child-table"
-            pagination-test-id="emulsions-child-pagination"
-            @update:page="(value) => { tableState.page.value = value; }"
-            @update:page-size="(value) => { tableState.pageSize.value = value; }"
-          >
-            <template #filters>
-              <NInput
-                v-model:value="searchTerm"
-                clearable
-                placeholder="Search emulsion, process, ISO, or format"
-                data-testid="emulsions-child-search"
-              />
-            </template>
-          </EntityTablePanel>
-        </NCard>
+        <EntityTableCard
+          :columns="columns"
+          :data="tableState.pagedRows.value"
+          :loading="referenceStore.isLoading"
+          :row-key="(row) => row.id"
+          :page="tableState.page.value"
+          :page-size="tableState.pageSize.value"
+          :item-count="tableState.totalRows.value"
+          :page-sizes="tableState.pageSizes"
+          empty-description="No emulsions match the current filters."
+          table-test-id="emulsions-child-table"
+          pagination-test-id="emulsions-child-pagination"
+          @update:page="(value) => { tableState.page.value = value; }"
+          @update:page-size="(value) => { tableState.pageSize.value = value; }"
+        >
+          <template #filters>
+            <NInput
+              v-model:value="searchTerm"
+              clearable
+              placeholder="Search emulsion, process, ISO, or format"
+              data-testid="emulsions-child-search"
+            />
+          </template>
+        </EntityTableCard>
       </template>
 
       <template #right>

--- a/apps/ui/src/pages/EmulsionsSubPage.vue
+++ b/apps/ui/src/pages/EmulsionsSubPage.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
 import { computed, h, onMounted, ref } from 'vue';
-import { RouterLink, useRoute } from 'vue-router';
+import { useRoute } from 'vue-router';
 import { NAlert, NCard, NInput, NTag } from 'naive-ui';
 import type { DataTableColumns } from 'naive-ui';
 import type { Emulsion } from '@frollz2/schema';
+import AppRouteTextLink from '../components/AppRouteTextLink.vue';
 import { useReferenceStore } from '../stores/reference.js';
 import PageShell from '../components/PageShell.vue';
 import InventorySplitLayout from '../components/inventory/InventorySplitLayout.vue';
@@ -54,17 +55,11 @@ const columns = computed<DataTableColumns<Emulsion>>(() => [
     title: 'Emulsion',
     key: 'brand',
     render: (row) => h(
-      RouterLink,
+      AppRouteTextLink,
       {
         to: `/emulsions/${row.id}`,
-        class: 'emulsion-table__link',
-        style: {
-          color: 'var(--n-primary-color)',
-          fontWeight: 600,
-          textDecorationColor: 'var(--n-primary-color)'
-        }
+        label: `${row.manufacturer} ${row.brand}`
       },
-      { default: () => `${row.manufacturer} ${row.brand}` }
     )
   },
   {
@@ -137,24 +132,3 @@ onMounted(async () => {
     </InventorySplitLayout>
   </PageShell>
 </template>
-
-<style scoped>
-.emulsion-table__link {
-  color: var(--n-primary-color);
-  text-decoration: none;
-}
-
-.emulsion-table__link:hover {
-  text-decoration: underline;
-}
-
-.emulsion-table__link:visited {
-  color: var(--n-primary-color);
-}
-
-.emulsion-table__link:focus-visible {
-  border-radius: 4px;
-  outline: 2px solid var(--n-primary-color);
-  outline-offset: 2px;
-}
-</style>

--- a/apps/ui/src/pages/FilmDetailPage.vue
+++ b/apps/ui/src/pages/FilmDetailPage.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue';
-import { useRoute, useRouter } from 'vue-router';
+import { useRoute } from 'vue-router';
 import { NAlert, NButton, NEmpty, NSpin } from 'naive-ui';
 import type { CreateFilmJourneyEventRequest } from '@frollz2/schema';
 import { filmTransitionMap } from '@frollz2/schema';
+import DetailPageShell from '../components/DetailPageShell.vue';
 import { useFilmStore } from '../stores/film.js';
 import { useReferenceStore } from '../stores/reference.js';
 import { useDeviceStore } from '../stores/devices.js';
-import PageShell from '../components/PageShell.vue';
 import EntityDetailHeaderCard from '../components/inventory/EntityDetailHeaderCard.vue';
 import InventorySplitLayout from '../components/inventory/InventorySplitLayout.vue';
 import FilmEventDrawer from '../components/film/FilmEventDrawer.vue';
@@ -15,7 +15,6 @@ import FilmTimelineCard from '../components/film/FilmTimelineCard.vue';
 import { useUiFeedback } from '../composables/useUiFeedback.js';
 
 const route = useRoute();
-const router = useRouter();
 const filmStore = useFilmStore();
 const referenceStore = useReferenceStore();
 const deviceStore = useDeviceStore();
@@ -58,15 +57,6 @@ function formatDateTime(value: string): string {
   }).format(parsed);
 }
 
-function goBack(): void {
-  if (window.history.length > 1) {
-    router.back();
-    return;
-  }
-
-  router.push('/film');
-}
-
 function openEventDrawer(): void {
   isEventDrawerOpen.value = true;
 }
@@ -91,16 +81,17 @@ onMounted(async () => {
 </script>
 
 <template>
-  <PageShell title="Film Detail" subtitle="Review state history and add the next transition.">
+  <DetailPageShell
+    title="Film Detail"
+    subtitle="Review state history and add the next transition."
+    fallback-path="/film"
+    :error-message="filmStore.detailError"
+  >
     <template #actions>
-      <NButton tertiary @click="goBack">Back</NButton>
       <NButton type="primary" @click="openEventDrawer">Add transition event</NButton>
     </template>
 
-    <NAlert v-if="filmStore.detailError" type="error" :show-icon="true" style="margin-bottom: 12px;">
-      {{ filmStore.detailError }}
-    </NAlert>
-    <NAlert v-else-if="selectedFilm && !((filmTransitionMap.get(isLargeFormatFilm ? 'purchased' : selectedFilm.currentStateCode) ?? []).length > 0)" type="warning" :show-icon="true" style="margin-bottom: 12px;">
+    <NAlert v-if="selectedFilm && !filmStore.detailError && !((filmTransitionMap.get(isLargeFormatFilm ? 'purchased' : selectedFilm.currentStateCode) ?? []).length > 0)" type="warning" :show-icon="true" style="margin-bottom: 12px;">
       No forward transitions are available from the current state.
     </NAlert>
 
@@ -126,7 +117,7 @@ onMounted(async () => {
         </template>
       </InventorySplitLayout>
     </NSpin>
-  </PageShell>
+  </DetailPageShell>
 
   <FilmEventDrawer
     v-model:show="isEventDrawerOpen"

--- a/apps/ui/src/pages/FilmDetailPage.vue
+++ b/apps/ui/src/pages/FilmDetailPage.vue
@@ -1,38 +1,18 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, reactive, ref } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
-import {
-  NAlert,
-  NButton,
-  NCard,
-  NDatePicker,
-  NDrawer,
-  NDrawerContent,
-  NEmpty,
-  NFlex,
-  NForm,
-  NFormItem,
-  NInput,
-  NInputNumber,
-  NSelect,
-  NSpin,
-  NTimeline,
-  NTimelineItem,
-  NText
-} from 'naive-ui';
-import type { CreateFilmJourneyEventRequest, CreateFrameJourneyEventRequest, FilmJourneyEvent } from '@frollz2/schema';
+import { NAlert, NButton, NEmpty, NSpin } from 'naive-ui';
+import type { CreateFilmJourneyEventRequest } from '@frollz2/schema';
 import { filmTransitionMap } from '@frollz2/schema';
-import { createIdempotencyKey } from '../composables/idempotency.js';
 import { useFilmStore } from '../stores/film.js';
 import { useReferenceStore } from '../stores/reference.js';
 import { useDeviceStore } from '../stores/devices.js';
 import PageShell from '../components/PageShell.vue';
 import EntityDetailHeaderCard from '../components/inventory/EntityDetailHeaderCard.vue';
 import InventorySplitLayout from '../components/inventory/InventorySplitLayout.vue';
+import FilmEventDrawer from '../components/film/FilmEventDrawer.vue';
+import FilmTimelineCard from '../components/film/FilmTimelineCard.vue';
 import { useUiFeedback } from '../composables/useUiFeedback.js';
-import type { FormState } from '../composables/ui-state.js';
-
-type FilmStateCode = CreateFilmJourneyEventRequest['filmStateCode'];
 
 const route = useRoute();
 const router = useRouter();
@@ -43,99 +23,12 @@ const feedback = useUiFeedback();
 
 const filmId = computed(() => Number(route.params.id));
 const isEventDrawerOpen = ref(false);
-const isSavingEvent = ref(false);
-const pendingEventKey = ref<string>(createIdempotencyKey());
-const occurredAtTimestamp = ref<number | null>(Date.now());
-
-const eventForm = reactive<{
-  filmStateCode: FilmStateCode | null;
-  notes: string;
-  storageLocationId: number | null;
-  filmFrameId: number | null;
-  deviceId: number | null;
-  slotSideNumber: number | null;
-  intendedPushPull: number | null;
-  labName: string;
-  labContact: string;
-  actualPushPull: number | null;
-  scannerOrSoftware: string;
-  scanLink: string;
-}>({
-  filmStateCode: null,
-  notes: '',
-  storageLocationId: null,
-  filmFrameId: null,
-  deviceId: null,
-  slotSideNumber: null,
-  intendedPushPull: null,
-  labName: '',
-  labContact: '',
-  actualPushPull: null,
-  scannerOrSoftware: '',
-  scanLink: ''
-});
-
-const eventState = ref<FormState>({
-  loading: false,
-  fieldErrors: {},
-  formError: null
-});
-
-const stateTypeByCode: Record<string, 'default' | 'info' | 'primary' | 'warning' | 'success'> = {
-  purchased: 'default',
-  stored: 'info',
-  loaded: 'primary',
-  exposed: 'warning',
-  removed: 'warning',
-  sent_for_dev: 'info',
-  developed: 'success',
-  scanned: 'success',
-  archived: 'default'
-};
-
-const tagColorByType: Record<
-  'default' | 'info' | 'primary' | 'warning' | 'success',
-  { color: string; borderColor: string; textColor: string; dotColor: string }
-> = {
-  default: {
-    color: '#f4f4f5',
-    borderColor: '#e0e0e6',
-    textColor: '#606266',
-    dotColor: '#8c8c8c'
-  },
-  info: {
-    color: '#e6f4ff',
-    borderColor: '#8fc9ff',
-    textColor: '#005980',
-    dotColor: '#2080f0'
-  },
-  primary: {
-    color: '#eef3ff',
-    borderColor: '#9fb5ff',
-    textColor: '#1b3f96',
-    dotColor: '#4d6bfe'
-  },
-  warning: {
-    color: '#fff8e6',
-    borderColor: '#ffd06b',
-    textColor: '#8a4d00',
-    dotColor: '#f0a020'
-  },
-  success: {
-    color: '#eaf8ef',
-    borderColor: '#8bd9a8',
-    textColor: '#165f31',
-    dotColor: '#18a058'
-  }
-};
 
 const selectedFilm = computed(() => filmStore.currentFilm);
 const isLargeFormatFilm = computed(() => {
   const code = selectedFilm.value?.filmFormat.code;
   return code === '4x5' || code === '8x10' || code === '2x3';
 });
-const isCompactTimeline = ref(false);
-let timelineMediaQuery: MediaQueryList | null = null;
 
 const detailItems = computed(() => {
   if (!selectedFilm.value) {
@@ -153,133 +46,6 @@ const detailItems = computed(() => {
     { label: 'Film ID', value: String(selectedFilm.value.id) }
   ];
 });
-const transitions = computed<Array<{ label: string; value: FilmStateCode }>>(() => {
-  if (isLargeFormatFilm.value) {
-    const selectedFrame = filmStore.currentFrames.find((frame) => frame.id === eventForm.filmFrameId) ?? null;
-    const current = selectedFrame?.currentStateCode ?? 'purchased';
-    const allowed = filmTransitionMap.get(current) ?? [];
-    return referenceStore.filmStates
-      .filter((state) => allowed.includes(state.code))
-      .map((state) => ({ label: state.label, value: state.code as FilmStateCode }));
-  }
-
-  const current = selectedFilm.value?.currentStateCode;
-  if (!current) {
-    return [];
-  }
-
-  const allowed = filmTransitionMap.get(current) ?? [];
-  return referenceStore.filmStates
-    .filter((state) => allowed.includes(state.code))
-    .map((state) => ({ label: state.label, value: state.code as FilmStateCode }));
-});
-
-const storageLocationOptions = computed(() =>
-  referenceStore.storageLocations.map((location) => ({ label: location.label, value: location.id }))
-);
-
-const deviceOptions = computed(() =>
-  deviceStore.devices
-    .filter((device) => {
-      if (!selectedFilm.value || device.filmFormatId !== selectedFilm.value.filmFormatId) {
-        return false;
-      }
-
-      if (device.deviceTypeCode === 'camera') {
-        return device.loadMode === 'direct';
-      }
-
-      return true;
-    })
-    .map((device) => ({
-      label: humanizeDevice(device),
-      value: device.id
-    }))
-);
-
-const selectedLoadDevice = computed(() =>
-  eventForm.filmStateCode === 'loaded' && eventForm.deviceId
-    ? deviceStore.devices.find((device) => device.id === eventForm.deviceId) ?? null
-    : null
-);
-
-const holderSlotOptions = computed(() => {
-  if (!selectedLoadDevice.value || selectedLoadDevice.value.deviceTypeCode !== 'film_holder') {
-    return [];
-  }
-
-  return Array.from({ length: selectedLoadDevice.value.slotCount }, (_, index) => {
-    const slotNumber = index + 1;
-    return { label: `Slot ${slotNumber}`, value: slotNumber };
-  });
-});
-
-const availableFrameOptions = computed(() =>
-  filmStore.currentFrames
-    .filter((frame) => isLargeFormatFilm.value || frame.firstLoadedAt === null)
-    .map((frame) => ({
-      label: `Frame #${frame.frameNumber}${isLargeFormatFilm.value ? ` (${humanizeCode(frame.currentStateCode)})` : ''}`,
-      value: frame.id
-    }))
-);
-
-const timelinePlacement = computed<'left' | 'right'>(() => (isCompactTimeline.value ? 'left' : 'right'));
-
-const timelineEvents = computed(() =>
-  [...filmStore.currentEvents]
-    .sort((left, right) => {
-      const leftOccurredAt = parseOccurredAt(left.occurredAt);
-      const rightOccurredAt = parseOccurredAt(right.occurredAt);
-      if (leftOccurredAt !== rightOccurredAt) {
-        return rightOccurredAt - leftOccurredAt;
-      }
-
-      return right.id - left.id;
-    })
-    .map((event) => ({
-      id: event.id,
-      stateLabel: humanizeCode(event.filmStateCode),
-      occurredLabel: formatDateTime(event.occurredAt),
-      detailFields: eventDataEntries(event),
-      notes: normalizeOptionalText(event.notes),
-      dotColor: tagColorByType[stateTypeByCode[event.filmStateCode] ?? 'default'].dotColor
-    }))
-);
-
-function parseOccurredAt(value: string): number {
-  const parsed = Date.parse(value);
-  return Number.isNaN(parsed) ? Number.MIN_SAFE_INTEGER : parsed;
-}
-
-function humanizeCode(value: string): string {
-  return value
-    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
-    .replace(/_/g, ' ')
-    .replace(/\b\w/g, (match) => match.toUpperCase());
-}
-
-function humanizeDevice(device: Record<string, unknown> & { deviceTypeCode: string }): string {
-  if (device.deviceTypeCode === 'camera') {
-    return `${String(device.make ?? '')} ${String(device.model ?? '')}`.trim();
-  }
-  if (device.deviceTypeCode === 'interchangeable_back') {
-    return `${String(device.name ?? '')} ${String(device.system ?? '')}`.trim();
-  }
-  return `${String(device.name ?? '')} ${String(device.brand ?? '')}`.trim();
-}
-
-function normalizeOptionalText(value: string | null | undefined): string | null {
-  if (!value) {
-    return null;
-  }
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : null;
-}
-
-function syncTimelinePlacement(eventOrQuery: MediaQueryList | MediaQueryListEvent): void {
-  isCompactTimeline.value = eventOrQuery.matches;
-}
-
 function formatDateTime(value: string): string {
   const parsed = Date.parse(value);
   if (Number.isNaN(parsed)) {
@@ -292,82 +58,6 @@ function formatDateTime(value: string): string {
   }).format(parsed);
 }
 
-function eventDataSummary(event: FilmJourneyEvent): string {
-  const entries = eventDataEntries(event).map((entry) => `${entry.label}: ${entry.value}`);
-
-  return entries.length > 0 ? entries.join(' | ') : '-';
-}
-
-function eventDataEntries(event: FilmJourneyEvent): Array<{ label: string; value: string }> {
-  const loadTargetType = typeof event.eventData['loadTargetType'] === 'string' ? event.eventData['loadTargetType'] : null;
-  if (loadTargetType) {
-    const deviceId = (
-      typeof event.eventData['cameraId'] === 'number'
-        ? event.eventData['cameraId']
-        : typeof event.eventData['interchangeableBackId'] === 'number'
-          ? event.eventData['interchangeableBackId']
-          : typeof event.eventData['filmHolderId'] === 'number'
-            ? event.eventData['filmHolderId']
-            : null
-    );
-    const slotNumber = typeof event.eventData['slotNumber'] === 'number' ? event.eventData['slotNumber'] : null;
-    const device = deviceId ? deviceStore.devices.find((entry) => entry.id === deviceId) : null;
-
-    const entries: Array<{ label: string; value: string }> = [];
-    if (deviceId) {
-      entries.push({
-        label: 'Loaded Target',
-        value: device ? humanizeDevice(device) : String(deviceId)
-      });
-    }
-    if (slotNumber) {
-      entries.push({ label: 'Holder Slot', value: String(slotNumber) });
-    }
-
-    const passthrough = Object.entries(event.eventData)
-      .filter(([key]) => !['loadTargetType', 'cameraId', 'interchangeableBackId', 'filmHolderId', 'slotNumber'].includes(key))
-      .map(([key, value]) => toReadableEventField(key, value))
-      .filter((entry): entry is { label: string; value: string } => entry !== null);
-
-    return [...entries, ...passthrough];
-  }
-
-  return Object.entries(event.eventData)
-    .map(([key, value]) => toReadableEventField(key, value))
-    .filter((entry): entry is { label: string; value: string } => entry !== null);
-}
-
-function toReadableEventField(key: string, value: unknown): { label: string; value: string } | null {
-  if (value === null || value === '') {
-    return null;
-  }
-
-  if (isDeviceReferenceKey(key) && typeof value === 'number') {
-    const device = deviceStore.devices.find((entry) => entry.id === value);
-    return {
-      label: 'Device',
-      value: device ? humanizeDevice(device) : String(value)
-    };
-  }
-
-  if (key === 'storageLocationId' && typeof value === 'number') {
-    const location = referenceStore.storageLocations.find((entry) => entry.id === value);
-    return {
-      label: 'Storage Location',
-      value: location?.label ?? String(value)
-    };
-  }
-
-  return {
-    label: humanizeCode(key),
-    value: String(value)
-  };
-}
-
-function isDeviceReferenceKey(key: string): boolean {
-  return /(?:device|receiver)Id$/i.test(key);
-}
-
 function goBack(): void {
   if (window.history.length > 1) {
     router.back();
@@ -377,206 +67,11 @@ function goBack(): void {
   router.push('/film');
 }
 
-function onChangeFilmState(code: string | null): void {
-  eventForm.filmStateCode = code as FilmStateCode | null;
-  eventForm.storageLocationId = null;
-  eventForm.filmFrameId = null;
-  eventForm.deviceId = null;
-  eventForm.slotSideNumber = null;
-  eventForm.intendedPushPull = null;
-  eventForm.labName = '';
-  eventForm.labContact = '';
-  eventForm.actualPushPull = null;
-  eventForm.scannerOrSoftware = '';
-  eventForm.scanLink = '';
-  eventState.value.fieldErrors = {};
-  eventState.value.formError = null;
-}
-
-function onChangeDevice(value: number | null): void {
-  eventForm.deviceId = value;
-  if (!value) {
-    eventForm.slotSideNumber = null;
-    return;
-  }
-
-  const selectedDevice = deviceStore.devices.find((entry) => entry.id === value);
-  if (selectedDevice?.deviceTypeCode === 'film_holder') {
-    if (
-      typeof eventForm.slotSideNumber !== 'number'
-      || eventForm.slotSideNumber < 1
-      || eventForm.slotSideNumber > selectedDevice.slotCount
-    ) {
-      eventForm.slotSideNumber = 1;
-    }
-    return;
-  }
-
-  eventForm.slotSideNumber = null;
-}
-
-function validateEventForm(): Record<string, string> {
-  const errors: Record<string, string> = {};
-
-  if (!eventForm.filmStateCode) {
-    errors.filmStateCode = 'Choose a target state.';
-  }
-
-  if (!occurredAtTimestamp.value) {
-    errors.occurredAt = 'Occurred date and time is required.';
-  }
-
-  if (eventForm.filmStateCode === 'stored' && !eventForm.storageLocationId) {
-    errors.storageLocationId = 'Select a storage location.';
-  }
-
-  if (eventForm.filmStateCode === 'loaded' && !eventForm.deviceId) {
-    errors.deviceId = 'Select a device.';
-  }
-  if (isLargeFormatFilm.value && !eventForm.filmFrameId) {
-    errors.filmFrameId = 'Select a frame.';
-  }
-  if (eventForm.filmStateCode === 'loaded' && eventForm.deviceId) {
-    const selectedDevice = deviceStore.devices.find((entry) => entry.id === eventForm.deviceId);
-    if (!selectedDevice) {
-      errors.deviceId = 'Select a valid device.';
-    }
-    if (selectedDevice?.deviceTypeCode === 'film_holder') {
-      if (typeof eventForm.slotSideNumber !== 'number' || !Number.isInteger(eventForm.slotSideNumber)) {
-        errors.slotSideNumber = 'Select a holder slot.';
-      } else if (eventForm.slotSideNumber < 1 || eventForm.slotSideNumber > selectedDevice.slotCount) {
-        errors.slotSideNumber = `Slot must be between 1 and ${selectedDevice.slotCount}.`;
-      }
-    }
-  }
-
-  return errors;
-}
-
-function buildEventData(): Record<string, unknown> {
-  switch (eventForm.filmStateCode) {
-    case 'stored': {
-      const location = referenceStore.storageLocations.find((entry) => entry.id === eventForm.storageLocationId);
-      return {
-        storageLocationId: eventForm.storageLocationId,
-        storageLocationCode: location?.code ?? ''
-      };
-    }
-    case 'loaded':
-      {
-        const selectedDevice = deviceStore.devices.find((entry) => entry.id === eventForm.deviceId);
-
-        if (!selectedDevice) {
-          return {};
-        }
-
-        if (selectedDevice.deviceTypeCode === 'camera') {
-          return {
-            loadTargetType: 'camera_direct',
-            ...(isLargeFormatFilm.value ? { filmFrameId: eventForm.filmFrameId } : {}),
-            cameraId: selectedDevice.id,
-            intendedPushPull: eventForm.intendedPushPull
-          };
-        }
-
-        if (selectedDevice.deviceTypeCode === 'interchangeable_back') {
-          return {
-            loadTargetType: 'interchangeable_back',
-            ...(isLargeFormatFilm.value ? { filmFrameId: eventForm.filmFrameId } : {}),
-            interchangeableBackId: selectedDevice.id,
-            intendedPushPull: eventForm.intendedPushPull
-          };
-        }
-
-        return {
-          loadTargetType: 'film_holder_slot',
-          ...(isLargeFormatFilm.value ? { filmFrameId: eventForm.filmFrameId } : {}),
-          filmHolderId: selectedDevice.id,
-          slotNumber: Number(eventForm.slotSideNumber ?? 1),
-          intendedPushPull: eventForm.intendedPushPull
-        };
-      }
-    case 'sent_for_dev':
-      return {
-        labName: eventForm.labName || null,
-        labContact: eventForm.labContact || null,
-        actualPushPull: eventForm.actualPushPull
-      };
-    case 'developed':
-      return {
-        labName: eventForm.labName || null,
-        actualPushPull: eventForm.actualPushPull
-      };
-    case 'scanned':
-      return {
-        scannerOrSoftware: eventForm.scannerOrSoftware || null,
-        scanLink: eventForm.scanLink || null
-      };
-    default:
-      return {};
-  }
-}
-
 function openEventDrawer(): void {
-  pendingEventKey.value = createIdempotencyKey();
   isEventDrawerOpen.value = true;
 }
 
-async function submitEvent(): Promise<void> {
-  if (isSavingEvent.value || !selectedFilm.value) {
-    return;
-  }
-
-  eventState.value.fieldErrors = validateEventForm();
-  if (Object.keys(eventState.value.fieldErrors).length > 0) {
-    eventState.value.formError = 'Please complete required fields before saving.';
-    return;
-  }
-
-  const payloadBase = {
-    occurredAt: new Date(occurredAtTimestamp.value as number).toISOString(),
-    notes: eventForm.notes || undefined,
-    eventData: buildEventData()
-  };
-
-  isSavingEvent.value = true;
-  eventState.value.loading = true;
-  eventState.value.formError = null;
-
-  try {
-    if (isLargeFormatFilm.value) {
-      const frameId = eventForm.filmFrameId;
-      if (!frameId) {
-        throw new Error('Select a frame');
-      }
-      const payload: CreateFrameJourneyEventRequest = {
-        frameStateCode: eventForm.filmStateCode as CreateFrameJourneyEventRequest['frameStateCode'],
-        ...payloadBase
-      };
-      await filmStore.addFrameEvent(selectedFilm.value.id, frameId, payload, pendingEventKey.value);
-    } else {
-      const payload: CreateFilmJourneyEventRequest = {
-        filmStateCode: eventForm.filmStateCode as FilmStateCode,
-        ...payloadBase
-      };
-      await filmStore.addEvent(selectedFilm.value.id, payload, pendingEventKey.value);
-    }
-    isEventDrawerOpen.value = false;
-    pendingEventKey.value = createIdempotencyKey();
-    feedback.success('Event saved. Timeline updated.');
-  } catch (error) {
-    eventState.value.formError = feedback.toErrorMessage(error, 'Could not save this event.');
-  } finally {
-    isSavingEvent.value = false;
-    eventState.value.loading = false;
-  }
-}
-
 onMounted(async () => {
-  timelineMediaQuery = window.matchMedia('(max-width: 768px)');
-  syncTimelinePlacement(timelineMediaQuery);
-  timelineMediaQuery.addEventListener('change', syncTimelinePlacement);
-
   try {
     if (!referenceStore.loaded) {
       await referenceStore.loadAll();
@@ -584,18 +79,14 @@ onMounted(async () => {
     await deviceStore.loadDevices();
     await filmStore.loadFilm(filmId.value);
 
-    if (route.query.openEvent === '1' && transitions.value.length > 0) {
-      pendingEventKey.value = createIdempotencyKey();
+    const initialStateCode = isLargeFormatFilm.value ? 'purchased' : selectedFilm.value?.currentStateCode ?? null;
+    const hasAvailableTransitions = initialStateCode ? (filmTransitionMap.get(initialStateCode) ?? []).length > 0 : false;
+    if (route.query.openEvent === '1' && hasAvailableTransitions) {
       isEventDrawerOpen.value = true;
     }
   } catch (error) {
     feedback.error(feedback.toErrorMessage(error, 'Could not load film detail.'));
   }
-});
-
-onBeforeUnmount(() => {
-  timelineMediaQuery?.removeEventListener('change', syncTimelinePlacement);
-  timelineMediaQuery = null;
 });
 </script>
 
@@ -609,7 +100,7 @@ onBeforeUnmount(() => {
     <NAlert v-if="filmStore.detailError" type="error" :show-icon="true" style="margin-bottom: 12px;">
       {{ filmStore.detailError }}
     </NAlert>
-    <NAlert v-else-if="selectedFilm && transitions.length === 0" type="warning" :show-icon="true" style="margin-bottom: 12px;">
+    <NAlert v-else-if="selectedFilm && !((filmTransitionMap.get(isLargeFormatFilm ? 'purchased' : selectedFilm.currentStateCode) ?? []).length > 0)" type="warning" :show-icon="true" style="margin-bottom: 12px;">
       No forward transitions are available from the current state.
     </NAlert>
 
@@ -626,253 +117,22 @@ onBeforeUnmount(() => {
         </template>
 
         <template #right>
-          <NCard>
-            <NTimeline v-if="timelineEvents.length > 0" :item-placement="timelinePlacement" class="film-detail__timeline">
-              <NTimelineItem v-for="event in timelineEvents" :key="event.id" :title="event.stateLabel" class="film-detail__timeline-item">
-                <template #icon>
-                  <span class="film-detail__timeline-dot" :style="{ backgroundColor: event.dotColor }" />
-                </template>
-                <div class="film-detail__timeline-item-content">
-                  <NText depth="3" class="film-detail__timeline-item-date">{{ event.occurredLabel }}</NText>
-                  <NText v-if="event.notes" class="film-detail__timeline-item-notes">Notes: {{ event.notes }}</NText>
-                  <NText v-for="field in event.detailFields" :key="`${event.id}-${field.label}`" depth="3">
-                    {{ field.label }}: {{ field.value }}
-                  </NText>
-                </div>
-              </NTimelineItem>
-            </NTimeline>
-            <NEmpty v-else-if="!filmStore.isDetailLoading" description="No events yet for this film." />
-          </NCard>
+          <FilmTimelineCard
+            :events="filmStore.currentEvents"
+            :devices="deviceStore.devices"
+            :loading="filmStore.isDetailLoading"
+            :storage-locations="referenceStore.storageLocations"
+          />
         </template>
       </InventorySplitLayout>
     </NSpin>
   </PageShell>
 
-  <NDrawer :show="isEventDrawerOpen" placement="right" width="min(100vw, 460px)" @update:show="(value) => { isEventDrawerOpen = value; }">
-    <NDrawerContent title="Add journey event" closable>
-      <NForm label-placement="top" @submit.prevent="submitEvent">
-        <NAlert v-if="eventState.formError" type="error" :show-icon="true" style="margin-bottom: 10px;">
-          {{ eventState.formError }}
-        </NAlert>
-
-        <NFormItem
-          label="Target state"
-          required
-          :label-props="{ for: 'event-target-state-input' }"
-          :feedback="eventState.fieldErrors.filmStateCode || ''"
-        >
-          <NSelect
-            :value="eventForm.filmStateCode"
-            :options="transitions"
-            placeholder="Select next state"
-            data-testid="event-target-state"
-            :input-props="{ id: 'event-target-state-input', name: 'filmStateCode' }"
-            @update:value="onChangeFilmState"
-          />
-        </NFormItem>
-
-        <NFormItem
-          label="Occurred at"
-          required
-          :label-props="{ for: 'event-occurred-at-input' }"
-          :feedback="eventState.fieldErrors.occurredAt || ''"
-        >
-          <NDatePicker
-            :value="occurredAtTimestamp"
-            type="datetime"
-            :input-props="{ id: 'event-occurred-at-input', name: 'occurredAt' }"
-            @update:value="(value) => { occurredAtTimestamp = value; }"
-          />
-        </NFormItem>
-
-        <NFormItem label="Notes" :label-props="{ for: 'event-notes-input' }">
-          <NInput
-            :value="eventForm.notes"
-            type="textarea"
-            placeholder="Optional context"
-            :input-props="{ id: 'event-notes-input', name: 'notes' }"
-            @update:value="(value) => { eventForm.notes = value; }"
-          />
-        </NFormItem>
-
-        <NText depth="3">
-          Fields below change based on the transition state, so only relevant inputs are shown.
-        </NText>
-
-        <NFormItem
-          v-if="eventForm.filmStateCode === 'stored'"
-          label="Storage location"
-          required
-          :label-props="{ for: 'event-storage-location-input' }"
-          :feedback="eventState.fieldErrors.storageLocationId || ''"
-        >
-          <NSelect
-            :value="eventForm.storageLocationId"
-            :options="storageLocationOptions"
-            placeholder="Select location"
-            data-testid="event-storage-location"
-            :input-props="{ id: 'event-storage-location-input', name: 'storageLocationId' }"
-            @update:value="(value) => { eventForm.storageLocationId = value; }"
-          />
-        </NFormItem>
-
-        <NFormItem
-          v-if="isLargeFormatFilm && eventForm.filmStateCode"
-          label="Frame"
-          required
-          :label-props="{ for: 'event-film-unit-input' }"
-          :feedback="eventState.fieldErrors.filmFrameId || ''"
-        >
-          <NSelect
-            :value="eventForm.filmFrameId"
-            :options="availableFrameOptions"
-            placeholder="Select frame"
-            :input-props="{ id: 'event-film-unit-input', name: 'filmFrameId' }"
-            @update:value="(value) => { eventForm.filmFrameId = value; }"
-          />
-        </NFormItem>
-
-        <template v-if="eventForm.filmStateCode === 'loaded'">
-          <NFormItem
-            label="Device"
-            required
-            :label-props="{ for: 'event-device-input' }"
-            :feedback="eventState.fieldErrors.deviceId || ''"
-          >
-            <NSelect
-              :value="eventForm.deviceId"
-              :options="deviceOptions"
-              placeholder="Select device"
-              :input-props="{ id: 'event-device-input', name: 'deviceId' }"
-              @update:value="onChangeDevice"
-            />
-          </NFormItem>
-          <NFormItem
-            v-if="selectedLoadDevice?.deviceTypeCode === 'film_holder'"
-            label="Holder slot"
-            required
-            :label-props="{ for: 'event-slot-side-input' }"
-            :feedback="eventState.fieldErrors.slotSideNumber || ''"
-          >
-            <NSelect
-              :value="eventForm.slotSideNumber"
-              :options="holderSlotOptions"
-              placeholder="Select holder slot"
-              :input-props="{ id: 'event-slot-side-input', name: 'slotSideNumber' }"
-              @update:value="(value) => { eventForm.slotSideNumber = value; }"
-            />
-          </NFormItem>
-          <NFormItem label="Intended push/pull" :label-props="{ for: 'event-intended-push-pull-input' }">
-            <NInputNumber
-              :value="eventForm.intendedPushPull"
-              :input-props="{ id: 'event-intended-push-pull-input', name: 'intendedPushPull' }"
-              @update:value="(value) => { eventForm.intendedPushPull = value; }"
-            />
-          </NFormItem>
-        </template>
-
-        <template v-if="eventForm.filmStateCode === 'sent_for_dev'">
-          <NFormItem label="Lab name" :label-props="{ for: 'event-lab-name-sent-input' }">
-            <NInput
-              :value="eventForm.labName"
-              :input-props="{ id: 'event-lab-name-sent-input', name: 'labName' }"
-              @update:value="(value) => { eventForm.labName = value; }"
-            />
-          </NFormItem>
-          <NFormItem label="Lab contact" :label-props="{ for: 'event-lab-contact-input' }">
-            <NInput
-              :value="eventForm.labContact"
-              :input-props="{ id: 'event-lab-contact-input', name: 'labContact' }"
-              @update:value="(value) => { eventForm.labContact = value; }"
-            />
-          </NFormItem>
-          <NFormItem label="Actual push/pull" :label-props="{ for: 'event-actual-push-pull-sent-input' }">
-            <NInputNumber
-              :value="eventForm.actualPushPull"
-              :input-props="{ id: 'event-actual-push-pull-sent-input', name: 'actualPushPull' }"
-              @update:value="(value) => { eventForm.actualPushPull = value; }"
-            />
-          </NFormItem>
-        </template>
-
-        <template v-if="eventForm.filmStateCode === 'developed'">
-          <NFormItem label="Lab name" :label-props="{ for: 'event-lab-name-developed-input' }">
-            <NInput
-              :value="eventForm.labName"
-              :input-props="{ id: 'event-lab-name-developed-input', name: 'labName' }"
-              @update:value="(value) => { eventForm.labName = value; }"
-            />
-          </NFormItem>
-          <NFormItem label="Actual push/pull" :label-props="{ for: 'event-actual-push-pull-developed-input' }">
-            <NInputNumber
-              :value="eventForm.actualPushPull"
-              :input-props="{ id: 'event-actual-push-pull-developed-input', name: 'actualPushPull' }"
-              @update:value="(value) => { eventForm.actualPushPull = value; }"
-            />
-          </NFormItem>
-        </template>
-
-        <template v-if="eventForm.filmStateCode === 'scanned'">
-          <NFormItem label="Scanner or software" :label-props="{ for: 'event-scanner-software-input' }">
-            <NInput
-              :value="eventForm.scannerOrSoftware"
-              :input-props="{ id: 'event-scanner-software-input', name: 'scannerOrSoftware' }"
-              @update:value="(value) => { eventForm.scannerOrSoftware = value; }"
-            />
-          </NFormItem>
-          <NFormItem label="Scan link" :label-props="{ for: 'event-scan-link-input' }">
-            <NInput
-              :value="eventForm.scanLink"
-              :input-props="{ id: 'event-scan-link-input', name: 'scanLink' }"
-              @update:value="(value) => { eventForm.scanLink = value; }"
-            />
-          </NFormItem>
-        </template>
-
-        <NFlex justify="end">
-          <NButton tertiary @click="isEventDrawerOpen = false">Cancel</NButton>
-          <NButton type="primary" attr-type="submit" :loading="isSavingEvent" :disabled="isSavingEvent">
-            Save event
-          </NButton>
-        </NFlex>
-      </NForm>
-    </NDrawerContent>
-  </NDrawer>
+  <FilmEventDrawer
+    v-model:show="isEventDrawerOpen"
+    :film-id="selectedFilm?.id ?? null"
+    :current-state-code="selectedFilm?.currentStateCode ?? null"
+    :film-format-id="selectedFilm?.filmFormatId ?? null"
+    :is-large-format-film="isLargeFormatFilm"
+  />
 </template>
-
-<style scoped>
-.film-detail__timeline {
-  margin-top: 0;
-}
-
-.film-detail__timeline-item {
-  padding-bottom: 8px;
-}
-
-.film-detail__timeline-item-content {
-  width: 100%;
-}
-
-.film-detail__timeline-item-notes {
-  display: block;
-  margin: 4px 0;
-}
-
-.film-detail__timeline-item-date {
-  display: block;
-  margin-bottom: 4px;
-}
-
-.film-detail__timeline-dot {
-  display: inline-block;
-  width: 10px;
-  height: 10px;
-  border-radius: 999px;
-}
-
-@media (max-width: 768px) {
-  .film-detail__timeline-item-content {
-    width: 100%;
-  }
-}
-</style>

--- a/apps/ui/src/pages/FilmPage.vue
+++ b/apps/ui/src/pages/FilmPage.vue
@@ -1,19 +1,17 @@
 <script setup lang="ts">
 import { computed, h, onMounted, ref } from 'vue';
-import { RouterLink, useRoute, useRouter } from 'vue-router';
+import { useRoute } from 'vue-router';
 import {
   NAlert,
   NButton,
   NCard,
-  NEmpty,
-  NFlex,
   NInput,
   NSelect,
-  NTag,
-  NText
+  NTag
 } from 'naive-ui';
 import type { DataTableColumns } from 'naive-ui';
 import type { FilmSummary } from '@frollz2/schema';
+import AppRouteTextLink from '../components/AppRouteTextLink.vue';
 import { useReferenceStore } from '../stores/reference.js';
 import { useFilmStore } from '../stores/film.js';
 import PageShell from '../components/PageShell.vue';
@@ -21,6 +19,7 @@ import InventorySplitLayout from '../components/inventory/InventorySplitLayout.v
 import EntityTablePanel from '../components/inventory/EntityTablePanel.vue';
 import KpiCardGrid from '../components/inventory/KpiCardGrid.vue';
 import FilmCreateDrawer from '../components/film/FilmCreateDrawer.vue';
+import RecentFilmsCard from '../components/film/RecentFilmsCard.vue';
 import { useUiFeedback } from '../composables/useUiFeedback.js';
 import { usePagedEntityTable } from '../composables/usePagedEntityTable.js';
 import {
@@ -38,7 +37,6 @@ type FilmStatsCard = {
 
 const referenceStore = useReferenceStore();
 const filmStore = useFilmStore();
-const router = useRouter();
 const route = useRoute();
 const feedback = useUiFeedback();
 
@@ -123,18 +121,12 @@ const childTableColumns = computed<DataTableColumns<FilmSummary>>(() => [
     title: 'Name',
     key: 'name',
     render: (row) => h(
-      RouterLink,
+      AppRouteTextLink,
       {
         to: `/film/${row.id}`,
-        class: 'film-table__name-link',
-        style: {
-          color: 'var(--n-primary-color)',
-          fontWeight: 600,
-          textDecorationColor: 'var(--n-primary-color)'
-        },
-        'data-testid': `film-row-link-${row.id}`
+        label: row.name,
+        testId: `film-row-link-${row.id}`
       },
-      { default: () => row.name }
     )
   },
   {
@@ -235,25 +227,7 @@ function openCreateDrawer(): void {
           </EntityTablePanel>
 
           <template v-else>
-            <NEmpty
-              v-if="!filmStore.isLoading && !filmStore.filmsError && recentFilms.length === 0"
-              description="No films are available yet."
-            />
-            <NFlex v-else vertical size="small">
-              <NCard v-for="film in recentFilms" :key="film.id" size="small" embedded>
-                <NFlex justify="space-between" align="center" :wrap="false">
-                  <NText strong>{{ film.name }}</NText>
-                  <NTag :type="stateTypeByCode[film.currentStateCode] ?? 'default'" size="small">
-                    {{ film.currentState.label }}
-                  </NTag>
-                </NFlex>
-                <NText depth="3">{{ film.emulsion.manufacturer }} {{ film.emulsion.brand }} · ISO {{ film.emulsion.isoSpeed }}</NText>
-                <NText depth="3">{{ film.filmFormat.code }} · {{ film.packageType.label }}</NText>
-                <NFlex justify="end">
-                  <NButton tertiary size="small" @click="router.push(`/film/${film.id}`)">Open timeline</NButton>
-                </NFlex>
-              </NCard>
-            </NFlex>
+            <RecentFilmsCard :films="recentFilms" :loading="filmStore.isLoading" :state-type-by-code="stateTypeByCode" />
           </template>
         </NCard>
       </template>
@@ -266,24 +240,3 @@ function openCreateDrawer(): void {
 
   <FilmCreateDrawer v-model:show="isCreateDrawerOpen" />
 </template>
-
-<style scoped>
-.film-table__name-link {
-  color: var(--n-primary-color);
-  text-decoration: none;
-}
-
-.film-table__name-link:hover {
-  text-decoration: underline;
-}
-
-.film-table__name-link:visited {
-  color: var(--n-primary-color);
-}
-
-.film-table__name-link:focus-visible {
-  border-radius: 4px;
-  outline: 2px solid var(--n-primary-color);
-  outline-offset: 2px;
-}
-</style>

--- a/apps/ui/src/pages/FilmPage.vue
+++ b/apps/ui/src/pages/FilmPage.vue
@@ -1,33 +1,27 @@
 <script setup lang="ts">
-import { computed, h, onMounted, reactive, ref } from 'vue';
+import { computed, h, onMounted, ref } from 'vue';
 import { RouterLink, useRoute, useRouter } from 'vue-router';
 import {
   NAlert,
   NButton,
   NCard,
-  NDatePicker,
-  NDrawer,
-  NDrawerContent,
   NEmpty,
   NFlex,
-  NForm,
-  NFormItem,
   NInput,
   NSelect,
   NTag,
   NText
 } from 'naive-ui';
 import type { DataTableColumns } from 'naive-ui';
-import type { FilmCreateRequest, FilmSummary } from '@frollz2/schema';
-import { createIdempotencyKey } from '../composables/idempotency.js';
+import type { FilmSummary } from '@frollz2/schema';
 import { useReferenceStore } from '../stores/reference.js';
 import { useFilmStore } from '../stores/film.js';
 import PageShell from '../components/PageShell.vue';
 import InventorySplitLayout from '../components/inventory/InventorySplitLayout.vue';
 import EntityTablePanel from '../components/inventory/EntityTablePanel.vue';
 import KpiCardGrid from '../components/inventory/KpiCardGrid.vue';
+import FilmCreateDrawer from '../components/film/FilmCreateDrawer.vue';
 import { useUiFeedback } from '../composables/useUiFeedback.js';
-import type { FormState } from '../composables/ui-state.js';
 import { usePagedEntityTable } from '../composables/usePagedEntityTable.js';
 import {
   buildChildKpis,
@@ -49,29 +43,8 @@ const route = useRoute();
 const feedback = useUiFeedback();
 
 const isCreateDrawerOpen = ref(false);
-const isCreatingFilm = ref(false);
-const pendingCreateKey = ref<string>(createIdempotencyKey());
-const expirationTimestamp = ref<number | null>(null);
 const childStateFilter = ref<string | null>(null);
 const childSearchTerm = ref('');
-
-const createForm = reactive<{
-  name: string;
-  emulsionId: number | null;
-  filmFormatId: number | null;
-  packageTypeId: number | null;
-}>({
-  name: '',
-  emulsionId: null,
-  filmFormatId: null,
-  packageTypeId: null
-});
-
-const createState = ref<FormState>({
-  loading: false,
-  fieldErrors: {},
-  formError: null
-});
 
 const stateTypeByCode: Record<string, 'default' | 'info' | 'primary' | 'warning' | 'success'> = {
   purchased: 'default',
@@ -183,43 +156,6 @@ const childTableColumns = computed<DataTableColumns<FilmSummary>>(() => [
   }
 ]);
 
-const emulsionOptions = computed(() =>
-  referenceStore.emulsions.map((emulsion) => ({
-    label: `${emulsion.manufacturer} ${emulsion.brand} ${emulsion.isoSpeed}`,
-    value: emulsion.id
-  }))
-);
-const formatOptions = computed(() =>
-  referenceStore.filmFormats.map((format) => ({ label: format.label, value: format.id }))
-);
-const packageTypeOptions = computed(() => {
-  if (!createForm.filmFormatId) {
-    return [];
-  }
-
-  return referenceStore.packageTypesByFormat(createForm.filmFormatId).map((packageType) => ({
-    label: packageType.label,
-    value: packageType.id
-  }));
-});
-
-const createFieldErrors = computed<Record<string, string>>(() => {
-  const nextErrors: Record<string, string> = {};
-  if (!createForm.name.trim()) {
-    nextErrors.name = 'Film name is required.';
-  }
-  if (!createForm.emulsionId) {
-    nextErrors.emulsionId = 'Select an emulsion.';
-  }
-  if (!createForm.filmFormatId) {
-    nextErrors.filmFormatId = 'Select a film format.';
-  }
-  if (!createForm.packageTypeId) {
-    nextErrors.packageTypeId = 'Select a package type.';
-  }
-  return nextErrors;
-});
-
 async function refresh(): Promise<void> {
   try {
     await filmStore.loadFilms();
@@ -243,56 +179,8 @@ function onChildStateFilterChange(value: string | null): void {
   childStateFilter.value = value === '__all__' ? null : value;
 }
 
-function resetCreateForm(): void {
-  createForm.name = '';
-  createForm.emulsionId = null;
-  createForm.filmFormatId = null;
-  createForm.packageTypeId = null;
-  expirationTimestamp.value = null;
-  createState.value.fieldErrors = {};
-  createState.value.formError = null;
-}
-
 function openCreateDrawer(): void {
-  pendingCreateKey.value = createIdempotencyKey();
   isCreateDrawerOpen.value = true;
-}
-
-async function submitCreateFilm(): Promise<void> {
-  if (isCreatingFilm.value) {
-    return;
-  }
-
-  createState.value.fieldErrors = createFieldErrors.value;
-  if (Object.keys(createState.value.fieldErrors).length > 0) {
-    createState.value.formError = 'Please complete all required fields.';
-    return;
-  }
-
-  const payload: FilmCreateRequest = {
-    name: createForm.name.trim(),
-    emulsionId: createForm.emulsionId as number,
-    filmFormatId: createForm.filmFormatId as number,
-    packageTypeId: createForm.packageTypeId as number,
-    expirationDate: expirationTimestamp.value ? new Date(expirationTimestamp.value).toISOString() : null
-  };
-
-  isCreatingFilm.value = true;
-  createState.value.loading = true;
-  createState.value.formError = null;
-
-  try {
-    await filmStore.createFilm(payload, pendingCreateKey.value);
-    isCreateDrawerOpen.value = false;
-    pendingCreateKey.value = createIdempotencyKey();
-    resetCreateForm();
-    feedback.success('Film created successfully.');
-  } catch (error) {
-    createState.value.formError = feedback.toErrorMessage(error, 'Could not create film.');
-  } finally {
-    isCreatingFilm.value = false;
-    createState.value.loading = false;
-  }
 }
 </script>
 
@@ -376,89 +264,7 @@ async function submitCreateFilm(): Promise<void> {
     </InventorySplitLayout>
   </PageShell>
 
-  <NDrawer v-model:show="isCreateDrawerOpen" placement="right" width="min(100vw, 420px)">
-    <NDrawerContent title="Add film" closable>
-      <NForm label-placement="top" @submit.prevent="submitCreateFilm">
-        <NAlert v-if="createState.formError" type="error" :show-icon="true" style="margin-bottom: 10px;">
-          {{ createState.formError }}
-        </NAlert>
-
-        <NFormItem
-          label="Name"
-          required
-          :label-props="{ for: 'film-create-name-input' }"
-          :feedback="createState.fieldErrors.name || ''"
-        >
-          <NInput
-            v-model:value="createForm.name"
-            placeholder="Film label"
-            :input-props="{ id: 'film-create-name-input', name: 'name' }"
-          />
-        </NFormItem>
-        <NFormItem
-          label="Emulsion"
-          required
-          :label-props="{ for: 'film-create-emulsion-input' }"
-          :feedback="createState.fieldErrors.emulsionId || ''"
-        >
-          <NSelect
-            v-model:value="createForm.emulsionId"
-            :options="emulsionOptions"
-            filterable
-            placeholder="Select emulsion"
-            data-testid="create-film-emulsion"
-            :input-props="{ id: 'film-create-emulsion-input', name: 'emulsionId' }"
-          />
-        </NFormItem>
-        <NFormItem
-          label="Film format"
-          required
-          :label-props="{ for: 'film-create-format-input' }"
-          :feedback="createState.fieldErrors.filmFormatId || ''"
-        >
-          <NSelect
-            v-model:value="createForm.filmFormatId"
-            :options="formatOptions"
-            placeholder="Select format"
-            data-testid="create-film-format"
-            :input-props="{ id: 'film-create-format-input', name: 'filmFormatId' }"
-            @update:value="createForm.packageTypeId = null"
-          />
-        </NFormItem>
-        <NFormItem
-          label="Package type"
-          required
-          :label-props="{ for: 'film-create-package-input' }"
-          :feedback="createState.fieldErrors.packageTypeId || ''"
-        >
-          <NSelect
-            v-model:value="createForm.packageTypeId"
-            :options="packageTypeOptions"
-            placeholder="Select package"
-            data-testid="create-film-package"
-            :input-props="{ id: 'film-create-package-input', name: 'packageTypeId' }"
-          />
-        </NFormItem>
-        <NFormItem label="Expiration date" :label-props="{ for: 'film-create-expiration-input' }">
-          <NDatePicker
-            v-model:value="expirationTimestamp"
-            type="datetime"
-            clearable
-            :input-props="{ id: 'film-create-expiration-input', name: 'expirationDate' }"
-          />
-        </NFormItem>
-        <NFlex justify="space-between" align="center">
-          <NText depth="3">Required fields are marked with an asterisk.</NText>
-          <NFlex>
-            <NButton tertiary @click="isCreateDrawerOpen = false">Cancel</NButton>
-            <NButton type="primary" attr-type="submit" :loading="isCreatingFilm" :disabled="isCreatingFilm">
-              Create film
-            </NButton>
-          </NFlex>
-        </NFlex>
-      </NForm>
-    </NDrawerContent>
-  </NDrawer>
+  <FilmCreateDrawer v-model:show="isCreateDrawerOpen" />
 </template>
 
 <style scoped>

--- a/apps/ui/src/pages/FilmPage.vue
+++ b/apps/ui/src/pages/FilmPage.vue
@@ -4,7 +4,6 @@ import { useRoute } from 'vue-router';
 import {
   NAlert,
   NButton,
-  NCard,
   NInput,
   NSelect,
   NTag
@@ -15,8 +14,8 @@ import AppRouteTextLink from '../components/AppRouteTextLink.vue';
 import { useReferenceStore } from '../stores/reference.js';
 import { useFilmStore } from '../stores/film.js';
 import PageShell from '../components/PageShell.vue';
+import EntityTableCard from '../components/inventory/EntityTableCard.vue';
 import InventorySplitLayout from '../components/inventory/InventorySplitLayout.vue';
-import EntityTablePanel from '../components/inventory/EntityTablePanel.vue';
 import KpiCardGrid from '../components/inventory/KpiCardGrid.vue';
 import FilmCreateDrawer from '../components/film/FilmCreateDrawer.vue';
 import RecentFilmsCard from '../components/film/RecentFilmsCard.vue';
@@ -188,48 +187,51 @@ function openCreateDrawer(): void {
       :right-panel-title="isLockedBreakout ? 'Format KPIs' : 'Film statistics'"
     >
       <template #left>
-        <NCard :loading="filmStore.isLoading">
-          <NAlert v-if="filmStore.filmsError" type="error" :show-icon="true" style="margin-bottom: 10px;">
-            {{ filmStore.filmsError }}
-          </NAlert>
-
-          <EntityTablePanel
-            v-if="isLockedBreakout"
-            :columns="childTableColumns"
-            :data="childTableState.pagedRows.value"
-            :loading="filmStore.isLoading"
-            :row-key="(row) => row.id"
-            :page="childTableState.page.value"
-            :page-size="childTableState.pageSize.value"
-            :item-count="childTableState.totalRows.value"
-            :page-sizes="childTableState.pageSizes"
-            empty-description="No films match the current filters."
-            table-test-id="film-child-table"
-            pagination-test-id="film-child-pagination"
-            @update:page="(value) => { childTableState.page.value = value; }"
-            @update:page-size="(value) => { childTableState.pageSize.value = value; }"
-          >
-            <template #filters>
-              <NSelect
-                :value="childStateFilter ?? '__all__'"
-                :options="childStateFilterOptions"
-                style="min-width: 200px;"
-                data-testid="film-child-state-filter"
-                @update:value="onChildStateFilterChange"
-              />
-              <NInput
-                v-model:value="childSearchTerm"
-                clearable
-                placeholder="Search by film or emulsion"
-                data-testid="film-child-search"
-              />
-            </template>
-          </EntityTablePanel>
-
-          <template v-else>
-            <RecentFilmsCard :films="recentFilms" :loading="filmStore.isLoading" :state-type-by-code="stateTypeByCode" />
+        <EntityTableCard
+          v-if="isLockedBreakout"
+          :columns="childTableColumns"
+          :data="childTableState.pagedRows.value"
+          :loading="filmStore.isLoading"
+          :row-key="(row) => row.id"
+          :page="childTableState.page.value"
+          :page-size="childTableState.pageSize.value"
+          :item-count="childTableState.totalRows.value"
+          :page-sizes="childTableState.pageSizes"
+          empty-description="No films match the current filters."
+          table-test-id="film-child-table"
+          pagination-test-id="film-child-pagination"
+          @update:page="(value) => { childTableState.page.value = value; }"
+          @update:page-size="(value) => { childTableState.pageSize.value = value; }"
+        >
+          <template #before>
+            <NAlert v-if="filmStore.filmsError" type="error" :show-icon="true" style="margin-bottom: 10px;">
+              {{ filmStore.filmsError }}
+            </NAlert>
           </template>
-        </NCard>
+
+          <template #filters>
+            <NSelect
+              :value="childStateFilter ?? '__all__'"
+              :options="childStateFilterOptions"
+              style="min-width: 200px;"
+              data-testid="film-child-state-filter"
+              @update:value="onChildStateFilterChange"
+            />
+            <NInput
+              v-model:value="childSearchTerm"
+              clearable
+              placeholder="Search by film or emulsion"
+              data-testid="film-child-search"
+            />
+          </template>
+        </EntityTableCard>
+
+        <RecentFilmsCard
+          v-else
+          :films="recentFilms"
+          :loading="filmStore.isLoading"
+          :state-type-by-code="stateTypeByCode"
+        />
       </template>
 
       <template #right>

--- a/apps/ui/src/pages/device-dashboard.ts
+++ b/apps/ui/src/pages/device-dashboard.ts
@@ -25,9 +25,7 @@ export function filterAndSortDevicesForChildTable(devices: FilmDevice[], searchT
     const searchable = [
       device.deviceTypeCode,
       device.frameSize,
-      device.deviceTypeCode === 'camera' ? `${device.make} ${device.model} ${device.serialNumber ?? ''}` : '',
-      device.deviceTypeCode === 'interchangeable_back' ? `${device.name} ${device.system}` : '',
-      device.deviceTypeCode === 'film_holder' ? `${device.name} ${device.brand} ${device.holderTypeCode}` : ''
+      getDeviceSearchLabel(device)
     ]
       .join(' ')
       .toLowerCase();
@@ -69,4 +67,20 @@ export function devicePrimaryLabel(device: FilmDevice): string {
   }
 
   return `${device.name} ${device.brand}`;
+}
+
+function getDeviceSearchLabel(device: FilmDevice): string {
+  if (device.deviceTypeCode === 'camera') {
+    return `${device.make} ${device.model} ${device.serialNumber ?? ''}`;
+  }
+
+  if (device.deviceTypeCode === 'interchangeable_back') {
+    return `${device.name} ${device.system}`;
+  }
+
+  if (device.deviceTypeCode === 'film_holder') {
+    return `${device.name} ${device.brand} ${device.holderTypeCode}`;
+  }
+
+  return '';
 }

--- a/apps/ui/src/stores/film.ts
+++ b/apps/ui/src/stores/film.ts
@@ -22,6 +22,26 @@ import {
 import { useApi } from '../composables/useApi.js';
 import { readApiData } from '../composables/api-envelope.js';
 
+function buildFilmListUrl(query: FilmListQuery): string {
+  const searchParams = new URLSearchParams();
+
+  if (query.stateCode) {
+    searchParams.set('stateCode', query.stateCode);
+  }
+  if (query.filmFormatId) {
+    searchParams.set('filmFormatId', String(query.filmFormatId));
+  }
+  if (query.emulsionId) {
+    searchParams.set('emulsionId', String(query.emulsionId));
+  }
+
+  if (searchParams.size === 0) {
+    return '/api/v1/film';
+  }
+
+  return `/api/v1/film?${searchParams.toString()}`;
+}
+
 export const useFilmStore = defineStore('film', () => {
   const { request } = useApi();
   const films = ref<FilmSummary[]>([]);
@@ -42,23 +62,11 @@ export const useFilmStore = defineStore('film', () => {
       return loadFilmsInFlight;
     }
 
-    const searchParams = new URLSearchParams();
-
-    if (query.stateCode) {
-      searchParams.set('stateCode', query.stateCode);
-    }
-    if (query.filmFormatId) {
-      searchParams.set('filmFormatId', String(query.filmFormatId));
-    }
-    if (query.emulsionId) {
-      searchParams.set('emulsionId', String(query.emulsionId));
-    }
-
     isLoading.value = true;
     filmsError.value = null;
     loadFilmsInFlight = (async () => {
       try {
-        const response = await request(`/api/v1/film${searchParams.size > 0 ? `?${searchParams.toString()}` : ''}`);
+        const response = await request(buildFilmListUrl(query));
         films.value = filmSummarySchema.array().parse(await readApiData(response));
       } catch (error) {
         filmsError.value = error instanceof Error ? error.message : 'Failed to load films';


### PR DESCRIPTION
## Summary
- Simplify film repository signatures with shared schema types and explicit return annotations
- Replace the remaining nested ternary in film frame generation with clear branching
- Extract reusable helpers for device search labels, film list URL building, and Playwright test stubs
- Keep behavior unchanged while improving readability and consistency across touched files

## Testing
- `pnpm lint` passed
- `pnpm check-types` passed
- `pnpm test` passed