### PR TITLE
fix(ui): fixing submit then refresh race condition

### DIFF
--- a/apps/ui/src/stores/devices.ts
+++ b/apps/ui/src/stores/devices.ts
@@ -97,8 +97,16 @@ export const useDeviceStore = defineStore('device', () => {
     }
 
     const response = await request('/api/v1/devices', init);
-    currentDevice.value = filmDeviceSchema.parse(await readApiData(response));
-    await loadDevices();
+    const created = filmDeviceSchema.parse(await readApiData(response));
+    currentDevice.value = created;
+    try {
+      await loadDevices();
+    } catch {
+      const existing = devices.value.some((item) => item.id === created.id);
+      if (!existing) {
+        devices.value = [...devices.value, created];
+      }
+    }
   }
 
   async function updateDevice(id: number, input: UpdateFilmDeviceRequest): Promise<void> {
@@ -106,8 +114,13 @@ export const useDeviceStore = defineStore('device', () => {
       method: 'PATCH',
       body: JSON.stringify(input)
     });
-    currentDevice.value = filmDeviceSchema.parse(await readApiData(response));
-    await loadDevices();
+    const updated = filmDeviceSchema.parse(await readApiData(response));
+    currentDevice.value = updated;
+    try {
+      await loadDevices();
+    } catch {
+      devices.value = devices.value.map((item) => (item.id === id ? updated : item));
+    }
   }
 
   async function deleteDevice(id: number): Promise<void> {
@@ -115,7 +128,11 @@ export const useDeviceStore = defineStore('device', () => {
     currentDevice.value = null;
     currentSlots.value = [];
     currentLoadEvents.value = [];
-    await loadDevices();
+    try {
+      await loadDevices();
+    } catch {
+      devices.value = devices.value.filter((item) => item.id !== id);
+    }
   }
 
   return {

--- a/apps/ui/src/stores/emulsions.ts
+++ b/apps/ui/src/stores/emulsions.ts
@@ -91,7 +91,14 @@ export const useEmulsionStore = defineStore('emulsions', () => {
 
     const response = await request('/api/v1/emulsions', init);
     const created = emulsionSchema.parse(await readApiData(response));
-    await loadAll(true);
+    try {
+      await loadAll(true);
+    } catch {
+      const existing = emulsions.value.some((item) => item.id === created.id);
+      if (!existing) {
+        emulsions.value = [...emulsions.value, created];
+      }
+    }
 
     return created;
   }
@@ -104,7 +111,11 @@ export const useEmulsionStore = defineStore('emulsions', () => {
     });
     const updated = emulsionSchema.parse(await readApiData(response));
     currentEmulsion.value = updated;
-    await loadAll(true);
+    try {
+      await loadAll(true);
+    } catch {
+      emulsions.value = emulsions.value.map((item) => (item.id === id ? updated : item));
+    }
     return updated;
   }
 
@@ -113,7 +124,11 @@ export const useEmulsionStore = defineStore('emulsions', () => {
     if (currentEmulsion.value?.id === id) {
       currentEmulsion.value = null;
     }
-    await loadAll(true);
+    try {
+      await loadAll(true);
+    } catch {
+      emulsions.value = emulsions.value.filter((item) => item.id !== id);
+    }
   }
 
   return {

--- a/apps/ui/src/stores/film.ts
+++ b/apps/ui/src/stores/film.ts
@@ -128,7 +128,11 @@ export const useFilmStore = defineStore('film', () => {
 
     const response = await request('/api/v1/film/lots', init);
     filmLotDetailSchema.parse(await readApiData(response));
-    await loadFilms();
+    try {
+      await loadFilms();
+    } catch {
+      // Preserve create success; list refresh can be retried by caller/page lifecycle.
+    }
   }
 
   async function updateFilm(id: number, input: FilmUpdateRequest): Promise<void> {
@@ -136,8 +140,18 @@ export const useFilmStore = defineStore('film', () => {
       method: 'PATCH',
       body: JSON.stringify(input)
     });
-    filmSummarySchema.parse(await readApiData(response));
-    await loadFilms();
+    const updated = filmSummarySchema.parse(await readApiData(response));
+    try {
+      await loadFilms();
+    } catch {
+      films.value = films.value.map((item) => (item.id === id ? updated : item));
+      if (currentFilm.value?.id === id) {
+        currentFilm.value = {
+          ...currentFilm.value,
+          ...updated
+        };
+      }
+    }
   }
 
   async function addEvent(id: number, input: CreateFilmJourneyEventRequest, idempotencyKey?: string): Promise<void> {
@@ -150,8 +164,12 @@ export const useFilmStore = defineStore('film', () => {
     }
 
     const response = await request(`/api/v1/film/${id}/events`, init);
-    filmJourneyEventSchema.parse(await readApiData(response));
-    await loadFilm(id);
+    const created = filmJourneyEventSchema.parse(await readApiData(response));
+    try {
+      await loadFilm(id);
+    } catch {
+      currentEvents.value = [...currentEvents.value, created];
+    }
   }
 
   async function addFrameEvent(
@@ -169,8 +187,12 @@ export const useFilmStore = defineStore('film', () => {
     }
 
     const response = await request(`/api/v1/film/${id}/frames/${frameId}/events`, init);
-    frameJourneyEventSchema.parse(await readApiData(response));
-    await loadFilm(id);
+    const created = frameJourneyEventSchema.parse(await readApiData(response));
+    try {
+      await loadFilm(id);
+    } catch {
+      currentFrameEvents.value = [...currentFrameEvents.value, created];
+    }
   }
 
   return {


### PR DESCRIPTION
Submitting a create or update in Device, Film, or Emulsions entered a race condition that could cause the UI to report a failure but refresh of the page would show that the creation succeeded.

## What does this PR do?

<!-- Brief description of the change and why it was needed. -->

## How was it tested?

<!-- Describe how you verified the change works. -->

## Checklist

- [ ] Tests added or updated
- [ ] All tests pass (`npm test` in `frollz-api/` and `frollz-ui/`)
- [ ] Lint passes (`npm run lint` in both)
- [ ] No `console.log` left in committed code
- [ ] PR targets the `development` branch (not `main`)
