### PR TITLE
feat(typeahead): implemented typeahead 

### DIFF
--- a/apps/api/src/domain/__tests__/reference-value.utils.spec.ts
+++ b/apps/api/src/domain/__tests__/reference-value.utils.spec.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeReferenceValue, sanitizeReferenceValue } from '../reference/reference-value.utils.js';
+
+describe('reference value normalization', () => {
+  it('normalizes case and internal whitespace for dedupe', () => {
+    expect(normalizeReferenceValue('  KODAK   Portra  ')).toBe('kodak portra');
+  });
+
+  it('preserves display casing while trimming/collapsing whitespace', () => {
+    expect(sanitizeReferenceValue('  Kodak   Portra  ')).toBe('Kodak Portra');
+  });
+});

--- a/apps/api/src/domain/reference/reference-value.utils.ts
+++ b/apps/api/src/domain/reference/reference-value.utils.ts
@@ -1,0 +1,7 @@
+export function normalizeReferenceValue(value: string): string {
+  return value.trim().replace(/\s+/g, ' ').toLowerCase();
+}
+
+export function sanitizeReferenceValue(value: string): string {
+  return value.trim().replace(/\s+/g, ' ');
+}

--- a/apps/api/src/infrastructure/entities/index.ts
+++ b/apps/api/src/infrastructure/entities/index.ts
@@ -11,3 +11,4 @@ export * from './frame-journey-event.entity.js';
 export * from './device.entities.js';
 export * from './device-mount.entity.js';
 export * from './film-holder-slot.entity.js';
+export * from './reference-value.entity.js';

--- a/apps/api/src/infrastructure/entities/reference-value.entity.ts
+++ b/apps/api/src/infrastructure/entities/reference-value.entity.ts
@@ -1,0 +1,26 @@
+import { Entity, Index, ManyToOne, Property, Unique } from '@mikro-orm/decorators/legacy';
+import { AutoIncrementEntity } from './base.entity.js';
+import { UserEntity } from './user.entity.js';
+
+@Entity({ tableName: 'reference_value' })
+@Unique({ properties: ['user', 'kind', 'normalizedValue'] })
+@Index({ properties: ['user', 'kind', 'usageCount', 'lastUsedAt'] })
+export class ReferenceValueEntity extends AutoIncrementEntity {
+  @ManyToOne(() => UserEntity, { fieldName: 'user_id' })
+  user!: UserEntity;
+
+  @Property({ type: 'text' })
+  kind!: string;
+
+  @Property({ type: 'text' })
+  value!: string;
+
+  @Property({ type: 'text', fieldName: 'normalized_value' })
+  normalizedValue!: string;
+
+  @Property({ type: 'integer', fieldName: 'usage_count' })
+  usageCount!: number;
+
+  @Property({ type: 'text', fieldName: 'last_used_at' })
+  lastUsedAt!: string;
+}

--- a/apps/api/src/infrastructure/migrations-postgres/Migration20260429000000.ts
+++ b/apps/api/src/infrastructure/migrations-postgres/Migration20260429000000.ts
@@ -1,0 +1,14 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260429000000 extends Migration {
+  override async up(): Promise<void> {
+    this.addSql('create table "reference_value" ("id" serial primary key, "user_id" int not null, "kind" text not null, "value" text not null, "normalized_value" text not null, "usage_count" int not null, "last_used_at" text not null);');
+    this.addSql('alter table "reference_value" add constraint "reference_value_user_id_foreign" foreign key ("user_id") references "user" ("id") on update cascade;');
+    this.addSql('create unique index "reference_value_user_id_kind_normalized_value_unique" on "reference_value" ("user_id", "kind", "normalized_value");');
+    this.addSql('create index "reference_value_user_id_kind_usage_count_last_used_at_index" on "reference_value" ("user_id", "kind", "usage_count", "last_used_at");');
+  }
+
+  override async down(): Promise<void> {
+    this.addSql('drop table if exists "reference_value" cascade;');
+  }
+}

--- a/apps/api/src/infrastructure/migrations-postgres/Migration20260429010000.ts
+++ b/apps/api/src/infrastructure/migrations-postgres/Migration20260429010000.ts
@@ -1,0 +1,136 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260429010000 extends Migration {
+  override async up(): Promise<void> {
+    // Emulsion-derived values should be user-scoped via film lots, not global emulsion catalog rows.
+    this.addSql(`
+      INSERT INTO "reference_value" ("user_id", "kind", "value", "normalized_value", "usage_count", "last_used_at")
+      SELECT
+        fl."user_id",
+        'manufacturer',
+        MIN(BTRIM(e."manufacturer")) AS value,
+        LOWER(BTRIM(e."manufacturer")) AS normalized_value,
+        COUNT(*)::int AS usage_count,
+        now()::text AS last_used_at
+      FROM "film_lot" fl
+      JOIN "emulsion" e ON e."id" = fl."emulsion_id"
+      WHERE BTRIM(COALESCE(e."manufacturer", '')) <> ''
+      GROUP BY fl."user_id", LOWER(BTRIM(e."manufacturer"))
+      ON CONFLICT ("user_id", "kind", "normalized_value") DO NOTHING;
+    `);
+
+    this.addSql(`
+      INSERT INTO "reference_value" ("user_id", "kind", "value", "normalized_value", "usage_count", "last_used_at")
+      SELECT
+        fl."user_id",
+        'brand',
+        MIN(BTRIM(e."brand")) AS value,
+        LOWER(BTRIM(e."brand")) AS normalized_value,
+        COUNT(*)::int AS usage_count,
+        now()::text AS last_used_at
+      FROM "film_lot" fl
+      JOIN "emulsion" e ON e."id" = fl."emulsion_id"
+      WHERE BTRIM(COALESCE(e."brand", '')) <> ''
+      GROUP BY fl."user_id", LOWER(BTRIM(e."brand"))
+      ON CONFLICT ("user_id", "kind", "normalized_value") DO NOTHING;
+    `);
+
+    this.addSql(`
+      INSERT INTO "reference_value" ("user_id", "kind", "value", "normalized_value", "usage_count", "last_used_at")
+      SELECT
+        fd."user_id",
+        'device_make',
+        MIN(BTRIM(c."make")) AS value,
+        LOWER(BTRIM(c."make")) AS normalized_value,
+        COUNT(*)::int AS usage_count,
+        now()::text AS last_used_at
+      FROM "film_device" fd
+      JOIN "camera" c ON c."film_device_id" = fd."id"
+      WHERE BTRIM(COALESCE(c."make", '')) <> ''
+      GROUP BY fd."user_id", LOWER(BTRIM(c."make"))
+      ON CONFLICT ("user_id", "kind", "normalized_value") DO NOTHING;
+    `);
+
+    this.addSql(`
+      INSERT INTO "reference_value" ("user_id", "kind", "value", "normalized_value", "usage_count", "last_used_at")
+      SELECT
+        fd."user_id",
+        'device_model',
+        MIN(BTRIM(c."model")) AS value,
+        LOWER(BTRIM(c."model")) AS normalized_value,
+        COUNT(*)::int AS usage_count,
+        now()::text AS last_used_at
+      FROM "film_device" fd
+      JOIN "camera" c ON c."film_device_id" = fd."id"
+      WHERE BTRIM(COALESCE(c."model", '')) <> ''
+      GROUP BY fd."user_id", LOWER(BTRIM(c."model"))
+      ON CONFLICT ("user_id", "kind", "normalized_value") DO NOTHING;
+    `);
+
+    this.addSql(`
+      INSERT INTO "reference_value" ("user_id", "kind", "value", "normalized_value", "usage_count", "last_used_at")
+      SELECT
+        fd."user_id",
+        'device_system',
+        MIN(BTRIM(ib."system")) AS value,
+        LOWER(BTRIM(ib."system")) AS normalized_value,
+        COUNT(*)::int AS usage_count,
+        now()::text AS last_used_at
+      FROM "film_device" fd
+      JOIN "interchangeable_back" ib ON ib."film_device_id" = fd."id"
+      WHERE BTRIM(COALESCE(ib."system", '')) <> ''
+      GROUP BY fd."user_id", LOWER(BTRIM(ib."system"))
+      ON CONFLICT ("user_id", "kind", "normalized_value") DO NOTHING;
+    `);
+
+    this.addSql(`
+      INSERT INTO "reference_value" ("user_id", "kind", "value", "normalized_value", "usage_count", "last_used_at")
+      SELECT
+        fd."user_id",
+        'brand',
+        MIN(BTRIM(fh."brand")) AS value,
+        LOWER(BTRIM(fh."brand")) AS normalized_value,
+        COUNT(*)::int AS usage_count,
+        now()::text AS last_used_at
+      FROM "film_device" fd
+      JOIN "film_holder" fh ON fh."film_device_id" = fd."id"
+      WHERE BTRIM(COALESCE(fh."brand", '')) <> ''
+      GROUP BY fd."user_id", LOWER(BTRIM(fh."brand"))
+      ON CONFLICT ("user_id", "kind", "normalized_value") DO NOTHING;
+    `);
+
+    this.addSql(`
+      INSERT INTO "reference_value" ("user_id", "kind", "value", "normalized_value", "usage_count", "last_used_at")
+      SELECT
+        fje."user_id",
+        'lab_name',
+        MIN(BTRIM(fje."event_data"->>'labName')) AS value,
+        LOWER(BTRIM(fje."event_data"->>'labName')) AS normalized_value,
+        COUNT(*)::int AS usage_count,
+        now()::text AS last_used_at
+      FROM "film_journey_event" fje
+      WHERE BTRIM(COALESCE(fje."event_data"->>'labName', '')) <> ''
+      GROUP BY fje."user_id", LOWER(BTRIM(fje."event_data"->>'labName'))
+      ON CONFLICT ("user_id", "kind", "normalized_value") DO NOTHING;
+    `);
+
+    this.addSql(`
+      INSERT INTO "reference_value" ("user_id", "kind", "value", "normalized_value", "usage_count", "last_used_at")
+      SELECT
+        fje."user_id",
+        'lab_contact',
+        MIN(BTRIM(fje."event_data"->>'labContact')) AS value,
+        LOWER(BTRIM(fje."event_data"->>'labContact')) AS normalized_value,
+        COUNT(*)::int AS usage_count,
+        now()::text AS last_used_at
+      FROM "film_journey_event" fje
+      WHERE BTRIM(COALESCE(fje."event_data"->>'labContact', '')) <> ''
+      GROUP BY fje."user_id", LOWER(BTRIM(fje."event_data"->>'labContact'))
+      ON CONFLICT ("user_id", "kind", "normalized_value") DO NOTHING;
+    `);
+  }
+
+  override async down(): Promise<void> {
+    // One-time backfill migration; no rollback needed.
+  }
+}

--- a/apps/api/src/infrastructure/migrations/Migration20260429000000.ts
+++ b/apps/api/src/infrastructure/migrations/Migration20260429000000.ts
@@ -1,0 +1,13 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260429000000 extends Migration {
+  override async up(): Promise<void> {
+    this.addSql('create table `reference_value` (`id` integer not null primary key autoincrement, `user_id` integer not null, `kind` text not null, `value` text not null, `normalized_value` text not null, `usage_count` integer not null, `last_used_at` text not null, constraint `reference_value_user_id_foreign` foreign key(`user_id`) references `user`(`id`) on update cascade);');
+    this.addSql('create unique index `reference_value_user_id_kind_normalized_value_unique` on `reference_value` (`user_id`, `kind`, `normalized_value`);');
+    this.addSql('create index `reference_value_user_id_kind_usage_count_last_used_at_index` on `reference_value` (`user_id`, `kind`, `usage_count`, `last_used_at`);');
+  }
+
+  override async down(): Promise<void> {
+    this.addSql('drop table if exists `reference_value`;');
+  }
+}

--- a/apps/api/src/infrastructure/migrations/Migration20260429010000.ts
+++ b/apps/api/src/infrastructure/migrations/Migration20260429010000.ts
@@ -1,0 +1,128 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260429010000 extends Migration {
+  override async up(): Promise<void> {
+    // Emulsion-derived values should be user-scoped via film lots, not global emulsion catalog rows.
+    this.addSql(`
+      INSERT OR IGNORE INTO reference_value (user_id, kind, value, normalized_value, usage_count, last_used_at)
+      SELECT
+        fl.user_id,
+        'manufacturer',
+        MIN(TRIM(e.manufacturer)) AS value,
+        LOWER(TRIM(e.manufacturer)) AS normalized_value,
+        COUNT(*) AS usage_count,
+        datetime('now') AS last_used_at
+      FROM film_lot fl
+      JOIN emulsion e ON e.id = fl.emulsion_id
+      WHERE TRIM(COALESCE(e.manufacturer, '')) <> ''
+      GROUP BY fl.user_id, LOWER(TRIM(e.manufacturer));
+    `);
+
+    this.addSql(`
+      INSERT OR IGNORE INTO reference_value (user_id, kind, value, normalized_value, usage_count, last_used_at)
+      SELECT
+        fl.user_id,
+        'brand',
+        MIN(TRIM(e.brand)) AS value,
+        LOWER(TRIM(e.brand)) AS normalized_value,
+        COUNT(*) AS usage_count,
+        datetime('now') AS last_used_at
+      FROM film_lot fl
+      JOIN emulsion e ON e.id = fl.emulsion_id
+      WHERE TRIM(COALESCE(e.brand, '')) <> ''
+      GROUP BY fl.user_id, LOWER(TRIM(e.brand));
+    `);
+
+    this.addSql(`
+      INSERT OR IGNORE INTO reference_value (user_id, kind, value, normalized_value, usage_count, last_used_at)
+      SELECT
+        fd.user_id,
+        'device_make',
+        MIN(TRIM(c.make)) AS value,
+        LOWER(TRIM(c.make)) AS normalized_value,
+        COUNT(*) AS usage_count,
+        datetime('now') AS last_used_at
+      FROM film_device fd
+      JOIN camera c ON c.film_device_id = fd.id
+      WHERE TRIM(COALESCE(c.make, '')) <> ''
+      GROUP BY fd.user_id, LOWER(TRIM(c.make));
+    `);
+
+    this.addSql(`
+      INSERT OR IGNORE INTO reference_value (user_id, kind, value, normalized_value, usage_count, last_used_at)
+      SELECT
+        fd.user_id,
+        'device_model',
+        MIN(TRIM(c.model)) AS value,
+        LOWER(TRIM(c.model)) AS normalized_value,
+        COUNT(*) AS usage_count,
+        datetime('now') AS last_used_at
+      FROM film_device fd
+      JOIN camera c ON c.film_device_id = fd.id
+      WHERE TRIM(COALESCE(c.model, '')) <> ''
+      GROUP BY fd.user_id, LOWER(TRIM(c.model));
+    `);
+
+    this.addSql(`
+      INSERT OR IGNORE INTO reference_value (user_id, kind, value, normalized_value, usage_count, last_used_at)
+      SELECT
+        fd.user_id,
+        'device_system',
+        MIN(TRIM(ib.system)) AS value,
+        LOWER(TRIM(ib.system)) AS normalized_value,
+        COUNT(*) AS usage_count,
+        datetime('now') AS last_used_at
+      FROM film_device fd
+      JOIN interchangeable_back ib ON ib.film_device_id = fd.id
+      WHERE TRIM(COALESCE(ib.system, '')) <> ''
+      GROUP BY fd.user_id, LOWER(TRIM(ib.system));
+    `);
+
+    this.addSql(`
+      INSERT OR IGNORE INTO reference_value (user_id, kind, value, normalized_value, usage_count, last_used_at)
+      SELECT
+        fd.user_id,
+        'brand',
+        MIN(TRIM(fh.brand)) AS value,
+        LOWER(TRIM(fh.brand)) AS normalized_value,
+        COUNT(*) AS usage_count,
+        datetime('now') AS last_used_at
+      FROM film_device fd
+      JOIN film_holder fh ON fh.film_device_id = fd.id
+      WHERE TRIM(COALESCE(fh.brand, '')) <> ''
+      GROUP BY fd.user_id, LOWER(TRIM(fh.brand));
+    `);
+
+    this.addSql(`
+      INSERT OR IGNORE INTO reference_value (user_id, kind, value, normalized_value, usage_count, last_used_at)
+      SELECT
+        fje.user_id,
+        'lab_name',
+        MIN(TRIM(json_extract(fje.event_data, '$.labName'))) AS value,
+        LOWER(TRIM(json_extract(fje.event_data, '$.labName'))) AS normalized_value,
+        COUNT(*) AS usage_count,
+        datetime('now') AS last_used_at
+      FROM film_journey_event fje
+      WHERE TRIM(COALESCE(json_extract(fje.event_data, '$.labName'), '')) <> ''
+      GROUP BY fje.user_id, LOWER(TRIM(json_extract(fje.event_data, '$.labName')));
+    `);
+
+    this.addSql(`
+      INSERT OR IGNORE INTO reference_value (user_id, kind, value, normalized_value, usage_count, last_used_at)
+      SELECT
+        fje.user_id,
+        'lab_contact',
+        MIN(TRIM(json_extract(fje.event_data, '$.labContact'))) AS value,
+        LOWER(TRIM(json_extract(fje.event_data, '$.labContact'))) AS normalized_value,
+        COUNT(*) AS usage_count,
+        datetime('now') AS last_used_at
+      FROM film_journey_event fje
+      WHERE TRIM(COALESCE(json_extract(fje.event_data, '$.labContact'), '')) <> ''
+      GROUP BY fje.user_id, LOWER(TRIM(json_extract(fje.event_data, '$.labContact')));
+    `);
+  }
+
+  override async down(): Promise<void> {
+    // One-time backfill migration; no rollback needed.
+  }
+}

--- a/apps/api/src/infrastructure/mikro-orm.config.ts
+++ b/apps/api/src/infrastructure/mikro-orm.config.ts
@@ -28,7 +28,8 @@ import {
   RefreshTokenEntity,
   SlotStateEntity,
   StorageLocationEntity,
-  UserEntity
+  UserEntity,
+  ReferenceValueEntity
 } from './entities/index.js';
 
 loadEnvFiles();
@@ -56,7 +57,8 @@ const entities = [
   CameraEntity,
   FilmHolderEntity,
   FilmHolderSlotEntity,
-  InterchangeableBackEntity
+  InterchangeableBackEntity,
+  ReferenceValueEntity
 ];
 
 const infrastructureDir = dirname(fileURLToPath(import.meta.url));

--- a/apps/api/src/infrastructure/repositories/mikro-orm-reference.repository.ts
+++ b/apps/api/src/infrastructure/repositories/mikro-orm-reference.repository.ts
@@ -1,6 +1,18 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { EntityManager } from '@mikro-orm/core';
-import type { DevelopmentProcess, FilmFormat, FilmState, HolderType, PackageType, DeviceType, SlotState, StorageLocation } from '@frollz2/schema';
+import type {
+  DevelopmentProcess,
+  DeviceType,
+  FilmFormat,
+  FilmState,
+  HolderType,
+  ListReferenceValuesQuery,
+  PackageType,
+  ReferenceValue,
+  SlotState,
+  StorageLocation,
+  UpsertReferenceValueInput
+} from '@frollz2/schema';
 import { ReferenceRepository } from './reference.repository.js';
 import {
   DevelopmentProcessEntity,
@@ -10,9 +22,13 @@ import {
   PackageTypeEntity,
   DeviceTypeEntity,
   SlotStateEntity,
-  StorageLocationEntity
+  StorageLocationEntity,
+  ReferenceValueEntity,
+  UserEntity
 } from '../entities/index.js';
 import { mapReferenceTables } from '../mappers/index.js';
+import { normalizeReferenceValue, sanitizeReferenceValue } from '../../domain/reference/reference-value.utils.js';
+import { nowIso } from '../../common/utils/time.js';
 
 @Injectable()
 export class MikroOrmReferenceRepository extends ReferenceRepository {
@@ -115,6 +131,74 @@ export class MikroOrmReferenceRepository extends ReferenceRepository {
       code: entity.code as HolderType['code'],
       label: entity.label
     }));
+  }
+
+  async listReferenceValues(userId: number, query: ListReferenceValuesQuery): Promise<ReferenceValue[]> {
+    const normalizedQuery = normalizeReferenceValue(query.q ?? '');
+    const values = await this.entityManager.find(
+      ReferenceValueEntity,
+      {
+        user: userId,
+        kind: query.kind,
+        ...(normalizedQuery.length > 0 ? { normalizedValue: { $like: `${normalizedQuery}%` } } : {})
+      },
+      {
+        orderBy: [{ usageCount: 'desc' }, { lastUsedAt: 'desc' }, { id: 'desc' }],
+        limit: query.limit
+      }
+    );
+
+    return values.map((entity) => ({
+      id: entity.id,
+      userId,
+      kind: entity.kind as ReferenceValue['kind'],
+      value: entity.value,
+      normalizedValue: entity.normalizedValue,
+      usageCount: entity.usageCount,
+      lastUsedAt: entity.lastUsedAt
+    }));
+  }
+
+  async upsertReferenceValues(userId: number, values: UpsertReferenceValueInput[]): Promise<void> {
+    if (values.length === 0) {
+      return;
+    }
+
+    const at = nowIso();
+    await this.entityManager.transactional(async (em) => {
+      for (const item of values) {
+        const value = sanitizeReferenceValue(item.value);
+        if (!value) {
+          continue;
+        }
+
+        const normalizedValue = normalizeReferenceValue(value);
+        const existing = await em.findOne(ReferenceValueEntity, {
+          user: userId,
+          kind: item.kind,
+          normalizedValue
+        });
+
+        if (existing) {
+          existing.usageCount += 1;
+          existing.lastUsedAt = at;
+          existing.value = value;
+          em.persist(existing);
+          continue;
+        }
+
+        const referenceValue = em.create(ReferenceValueEntity, {
+          user: em.getReference(UserEntity, userId),
+          kind: item.kind,
+          value,
+          normalizedValue,
+          usageCount: 1,
+          lastUsedAt: at
+        });
+        em.persist(referenceValue);
+      }
+      await em.flush();
+    });
   }
 
 }

--- a/apps/api/src/infrastructure/repositories/reference.repository.ts
+++ b/apps/api/src/infrastructure/repositories/reference.repository.ts
@@ -3,7 +3,10 @@ import type {
   FilmFormat,
   FilmState,
   HolderType,
+  ListReferenceValuesQuery,
   PackageType,
+  ReferenceValue,
+  UpsertReferenceValueInput,
   DeviceType,
   ReferenceTables,
   SlotState,
@@ -21,4 +24,6 @@ export abstract class ReferenceRepository {
   abstract listSlotStates(): Promise<SlotState[]>;
   abstract listDeviceTypes(): Promise<DeviceType[]>;
   abstract listHolderTypes(): Promise<HolderType[]>;
+  abstract listReferenceValues(userId: number, query: ListReferenceValuesQuery): Promise<ReferenceValue[]>;
+  abstract upsertReferenceValues(userId: number, values: UpsertReferenceValueInput[]): Promise<void>;
 }

--- a/apps/api/src/modules/devices/devices.module.ts
+++ b/apps/api/src/modules/devices/devices.module.ts
@@ -6,8 +6,10 @@ import { DeviceRepository } from '../../infrastructure/repositories/device.repos
 import { FilmRepository } from '../../infrastructure/repositories/film.repository.js';
 import { MikroOrmDeviceRepository } from '../../infrastructure/repositories/mikro-orm-device.repository.js';
 import { MikroOrmFilmRepository } from '../../infrastructure/repositories/mikro-orm-film.repository.js';
+import { ReferenceModule } from '../reference/reference.module.js';
 
 @Module({
+  imports: [ReferenceModule],
   controllers: [DevicesController],
   providers: [
     DevicesService,

--- a/apps/api/src/modules/devices/devices.service.ts
+++ b/apps/api/src/modules/devices/devices.service.ts
@@ -15,13 +15,15 @@ import { DomainError } from '../../domain/errors.js';
 import { FilmFormatEntity } from '../../infrastructure/entities/index.js';
 import { FilmRepository } from '../../infrastructure/repositories/film.repository.js';
 import { DeviceRepository } from '../../infrastructure/repositories/device.repository.js';
+import { ReferenceService } from '../reference/reference.service.js';
 
 @Injectable()
 export class DevicesService {
   constructor(
     @Inject(DeviceRepository) private readonly deviceRepository: DeviceRepository,
     @Inject(FilmRepository) private readonly filmRepository: FilmRepository,
-    @Inject(EntityManager) private readonly entityManager: EntityManager
+    @Inject(EntityManager) private readonly entityManager: EntityManager,
+    @Inject(ReferenceService) private readonly referenceService: ReferenceService
   ) { }
 
   list(userId: number): Promise<FilmDevice[]> {
@@ -40,7 +42,9 @@ export class DevicesService {
 
   async create(userId: number, input: CreateFilmDeviceRequest): Promise<FilmDevice> {
     await this.assertFrameSizeMatchesFormat(input.filmFormatId, input.frameSize);
-    return this.deviceRepository.create(userId, input);
+    const device = await this.deviceRepository.create(userId, input);
+    await this.upsertReferenceValues(userId, input as Record<string, unknown>);
+    return device;
   }
 
   async update(userId: number, deviceId: number, input: UpdateFilmDeviceRequest): Promise<FilmDevice> {
@@ -57,6 +61,8 @@ export class DevicesService {
     if (!device) {
       throw new DomainError('NOT_FOUND', 'Device not found');
     }
+
+    await this.upsertReferenceValues(userId, input as Record<string, unknown>);
 
     return device;
   }
@@ -168,6 +174,30 @@ export class DevicesService {
 
     if (!isFrameSizeValidForFormatCode(format.code, frameSize)) {
       throw new DomainError('DOMAIN_ERROR', `Frame size ${frameSize} is not valid for ${format.code}`);
+    }
+  }
+
+  private async upsertReferenceValues(userId: number, input: Record<string, unknown>): Promise<void> {
+    const items: Array<{ kind: 'device_make' | 'device_model' | 'brand' | 'device_system'; value: string }> = [];
+
+    if (typeof input.make === 'string') {
+      items.push({ kind: 'device_make' as const, value: input.make });
+    }
+    if (typeof input.model === 'string') {
+      items.push({ kind: 'device_model' as const, value: input.model });
+    }
+    if (typeof input.brand === 'string') {
+      items.push({ kind: 'brand' as const, value: input.brand });
+    }
+    const systemValue = typeof input.system === 'string'
+      ? input.system
+      : (typeof input.cameraSystem === 'string' ? input.cameraSystem : null);
+    if (systemValue) {
+      items.push({ kind: 'device_system' as const, value: systemValue });
+    }
+
+    if (items.length > 0) {
+      await this.referenceService.upsertReferenceValues(userId, items);
     }
   }
 }

--- a/apps/api/src/modules/emulsions/emulsions.controller.ts
+++ b/apps/api/src/modules/emulsions/emulsions.controller.ts
@@ -42,7 +42,7 @@ export class EmulsionsController {
       key: idempotencyKey,
       scope: 'emulsions.create',
       requestPayload: body,
-      handler: () => this.emulsionsService.create(body)
+      handler: () => this.emulsionsService.create(user.userId, body)
     });
   }
 
@@ -50,10 +50,11 @@ export class EmulsionsController {
   @ApiOperation({ summary: 'Update an emulsion' })
   @ApiResponse({ status: 200, description: 'Emulsion updated' })
   update(
+    @CurrentUser() user: AuthenticatedUser,
     @Param('id', ParseIntPipe) id: number,
     @Body(new ZodSchemaPipe(updateEmulsionRequestSchema)) body: typeof updateEmulsionRequestSchema['_output']
   ) {
-    return this.emulsionsService.update(id, body);
+    return this.emulsionsService.update(user.userId, id, body);
   }
 
   @Delete(':id')

--- a/apps/api/src/modules/emulsions/emulsions.module.ts
+++ b/apps/api/src/modules/emulsions/emulsions.module.ts
@@ -4,8 +4,10 @@ import { EmulsionRepository } from '../../infrastructure/repositories/emulsion.r
 import { MikroOrmEmulsionRepository } from '../../infrastructure/repositories/mikro-orm-emulsion.repository.js';
 import { EmulsionsController } from './emulsions.controller.js';
 import { EmulsionsService } from './emulsions.service.js';
+import { ReferenceModule } from '../reference/reference.module.js';
 
 @Module({
+  imports: [ReferenceModule],
   controllers: [EmulsionsController],
   providers: [EmulsionsService, IdempotencyService, { provide: EmulsionRepository, useClass: MikroOrmEmulsionRepository }],
   exports: [EmulsionsService]

--- a/apps/api/src/modules/emulsions/emulsions.service.spec.ts
+++ b/apps/api/src/modules/emulsions/emulsions.service.spec.ts
@@ -11,10 +11,11 @@ describe('EmulsionsService', () => {
       delete: vi.fn(),
       isInUse: vi.fn()
     };
-    const service = new EmulsionsService(repo as never);
+    const referenceService = { upsertReferenceValues: vi.fn() };
+    const service = new EmulsionsService(repo as never, referenceService as never);
 
     await expect(
-      service.update(123, {
+      service.update(1, 123, {
         manufacturer: 'A',
         brand: 'B',
         isoSpeed: 100,
@@ -33,7 +34,8 @@ describe('EmulsionsService', () => {
       delete: vi.fn(),
       isInUse: vi.fn().mockResolvedValue(true)
     };
-    const service = new EmulsionsService(repo as never);
+    const referenceService = { upsertReferenceValues: vi.fn() };
+    const service = new EmulsionsService(repo as never, referenceService as never);
 
     await expect(service.delete(99)).rejects.toMatchObject({ code: 'CONFLICT' });
     expect(repo.delete).not.toHaveBeenCalled();

--- a/apps/api/src/modules/emulsions/emulsions.service.ts
+++ b/apps/api/src/modules/emulsions/emulsions.service.ts
@@ -2,10 +2,14 @@ import { Inject, Injectable } from '@nestjs/common';
 import type { CreateEmulsionRequest, Emulsion, UpdateEmulsionRequest } from '@frollz2/schema';
 import { DomainError } from '../../domain/errors.js';
 import { EmulsionRepository } from '../../infrastructure/repositories/emulsion.repository.js';
+import { ReferenceService } from '../reference/reference.service.js';
 
 @Injectable()
 export class EmulsionsService {
-  constructor(@Inject(EmulsionRepository) private readonly emulsionRepository: EmulsionRepository) { }
+  constructor(
+    @Inject(EmulsionRepository) private readonly emulsionRepository: EmulsionRepository,
+    @Inject(ReferenceService) private readonly referenceService: ReferenceService
+  ) { }
 
   list(): Promise<Emulsion[]> {
     return this.emulsionRepository.list();
@@ -19,15 +23,24 @@ export class EmulsionsService {
     return emulsion;
   }
 
-  create(input: CreateEmulsionRequest): Promise<Emulsion> {
-    return this.emulsionRepository.create(input);
+  async create(userId: number, input: CreateEmulsionRequest): Promise<Emulsion> {
+    const emulsion = await this.emulsionRepository.create(input);
+    await this.referenceService.upsertReferenceValues(userId, [
+      { kind: 'manufacturer', value: input.manufacturer },
+      { kind: 'brand', value: input.brand }
+    ]);
+    return emulsion;
   }
 
-  async update(id: number, input: UpdateEmulsionRequest): Promise<Emulsion> {
+  async update(userId: number, id: number, input: UpdateEmulsionRequest): Promise<Emulsion> {
     const emulsion = await this.emulsionRepository.update(id, input);
     if (!emulsion) {
       throw new DomainError('NOT_FOUND', 'Emulsion not found');
     }
+    await this.referenceService.upsertReferenceValues(userId, [
+      { kind: 'manufacturer', value: input.manufacturer },
+      { kind: 'brand', value: input.brand }
+    ]);
     return emulsion;
   }
 

--- a/apps/api/src/modules/film/film.module.ts
+++ b/apps/api/src/modules/film/film.module.ts
@@ -6,8 +6,10 @@ import { FilmRepository } from '../../infrastructure/repositories/film.repositor
 import { MikroOrmFilmRepository } from '../../infrastructure/repositories/mikro-orm-film.repository.js';
 import { FilmLotRepository } from '../../infrastructure/repositories/film-lot.repository.js';
 import { MikroOrmFilmLotRepository } from '../../infrastructure/repositories/mikro-orm-film-lot.repository.js';
+import { ReferenceModule } from '../reference/reference.module.js';
 
 @Module({
+  imports: [ReferenceModule],
   controllers: [FilmController],
   providers: [
     FilmService,

--- a/apps/api/src/modules/film/film.service.ts
+++ b/apps/api/src/modules/film/film.service.ts
@@ -11,6 +11,7 @@ import type {
   FilmLotCreateRequest,
   FilmLotDetail,
   FilmSummary,
+  UpsertReferenceValueInput,
   FilmUpdateRequest,
   FrameJourneyEvent,
   FrameSizeCode
@@ -37,6 +38,7 @@ import {
 } from '../../infrastructure/entities/index.js';
 import { mapFilmJourneyEventEntity, parseLoadedEventData, type NormalizedLoadedEventData } from '../../infrastructure/mappers/index.js';
 import { nowIso } from '../../common/utils/time.js';
+import { ReferenceService } from '../reference/reference.service.js';
 
 type NormalizedLoadedFrameEventData = NormalizedLoadedEventData & { filmFrameId: number };
 
@@ -45,7 +47,8 @@ export class FilmService {
   constructor(
     @Inject(FilmRepository) private readonly filmRepository: FilmRepository,
     @Inject(FilmLotRepository) private readonly filmLotRepository: FilmLotRepository,
-    @Inject(EntityManager) private readonly entityManager: EntityManager
+    @Inject(EntityManager) private readonly entityManager: EntityManager,
+    @Inject(ReferenceService) private readonly referenceService: ReferenceService
   ) { }
 
   list(userId: number, query: FilmListQuery): Promise<FilmListResponse> {
@@ -226,6 +229,10 @@ export class FilmService {
       transactionalEntityManager.persist([film, event]);
       await transactionalEntityManager.flush();
 
+      if (input.filmStateCode === 'sent_for_dev' || input.filmStateCode === 'developed') {
+        await this.referenceService.upsertReferenceValues(userId, this.extractLabReferenceValues(input.eventData));
+      }
+
       const persistedEvent = await transactionalEntityManager.findOneOrFail(
         FilmJourneyEventEntity,
         { id: event.id },
@@ -362,6 +369,20 @@ export class FilmService {
       { film: filmId, user: userId },
       { orderBy: { occurredAt: 'desc', id: 'desc' }, populate: ['film', 'user', 'filmState'] }
     );
+  }
+
+  private extractLabReferenceValues(eventData: Record<string, unknown>): UpsertReferenceValueInput[] {
+    const items: UpsertReferenceValueInput[] = [];
+
+    if (typeof eventData.labName === 'string' && eventData.labName.trim().length > 0) {
+      items.push({ kind: 'lab_name', value: eventData.labName });
+    }
+
+    if (typeof eventData.labContact === 'string' && eventData.labContact.trim().length > 0) {
+      items.push({ kind: 'lab_contact', value: eventData.labContact });
+    }
+
+    return items;
   }
 
   private async applyLoadedEventSideEffects(

--- a/apps/api/src/modules/reference/reference.controller.ts
+++ b/apps/api/src/modules/reference/reference.controller.ts
@@ -1,5 +1,9 @@
-import { Controller, Get, Inject } from '@nestjs/common';
+import { Body, Controller, Get, Inject, Post, Query } from '@nestjs/common';
 import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { listReferenceValuesQuerySchema, upsertReferenceValuesRequestSchema } from '@frollz2/schema';
+import { ZodSchemaPipe } from '../../common/pipes/zod-schema.pipe.js';
+import { CurrentUser } from '../auth/current-user.decorator.js';
+import type { AuthenticatedUser } from '../auth/auth.types.js';
 import { ReferenceService } from './reference.service.js';
 
 @ApiTags('reference')
@@ -70,6 +74,27 @@ export class ReferenceController {
   @ApiResponse({ status: 200, description: 'Holder types' })
   listHolderTypes() {
     return this.referenceService.listHolderTypes();
+  }
+
+  @Get('values')
+  @ApiOperation({ summary: 'List ranked user reference values for a kind' })
+  @ApiResponse({ status: 200, description: 'Reference value suggestions' })
+  listValues(
+    @CurrentUser() user: AuthenticatedUser,
+    @Query(new ZodSchemaPipe(listReferenceValuesQuerySchema)) query: typeof listReferenceValuesQuerySchema['_output']
+  ) {
+    return this.referenceService.listReferenceValues(user.userId, query);
+  }
+
+  @Post('values/upsert-batch')
+  @ApiOperation({ summary: 'Upsert user reference values' })
+  @ApiResponse({ status: 201, description: 'Reference values upserted' })
+  async upsertBatch(
+    @CurrentUser() user: AuthenticatedUser,
+    @Body(new ZodSchemaPipe(upsertReferenceValuesRequestSchema)) body: typeof upsertReferenceValuesRequestSchema['_output']
+  ) {
+    await this.referenceService.upsertReferenceValues(user.userId, body.items);
+    return null;
   }
 
 }

--- a/apps/api/src/modules/reference/reference.service.ts
+++ b/apps/api/src/modules/reference/reference.service.ts
@@ -1,4 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
+import type { ListReferenceValuesQuery, UpsertReferenceValueInput } from '@frollz2/schema';
 import { ReferenceRepository } from '../../infrastructure/repositories/reference.repository.js';
 
 @Injectable()
@@ -39,6 +40,14 @@ export class ReferenceService {
 
   listHolderTypes() {
     return this.referenceRepository.listHolderTypes();
+  }
+
+  listReferenceValues(userId: number, query: ListReferenceValuesQuery) {
+    return this.referenceRepository.listReferenceValues(userId, query);
+  }
+
+  upsertReferenceValues(userId: number, values: UpsertReferenceValueInput[]) {
+    return this.referenceRepository.upsertReferenceValues(userId, values);
   }
 
 }

--- a/apps/ui/e2e/features/reference/shared-typeahead.feature
+++ b/apps/ui/e2e/features/reference/shared-typeahead.feature
@@ -1,0 +1,51 @@
+Feature: Shared Typeahead Dictionary
+  Users get ranked text suggestions while still being able to submit free text.
+
+  Background:
+    Given I am authenticated as "demo@example.com"
+
+  Scenario: Emulsion create shows manufacturer and brand suggestions
+    Given emulsion reference values exist for manufacturer "Kodak" and brand "Portra 400"
+    When I open the emulsion create form
+    And I type "Kod" into the emulsion manufacturer field
+    Then I see "Kodak" as an emulsion suggestion
+    When I type "Por" into the emulsion brand field
+    Then I see "Portra 400" as an emulsion suggestion
+
+  Scenario: Emulsion create accepts free text and upserts reference values
+    When I create an emulsion using free text manufacturer "Custom Maker" and brand "Custom Stock 800"
+    Then manufacturer suggestion query for "custom maker" returns "Custom Maker"
+    And brand suggestion query for "custom stock 800" returns "Custom Stock 800"
+
+  Scenario: Emulsion reference suggestions are ranked by usage count then recency
+    Given manufacturer "Ranked Maker" has been used 2 times in emulsion submissions
+    And manufacturer "Lower Maker" has been used 1 time in emulsion submissions
+    When I request manufacturer suggestions for prefix "m"
+    Then the first manufacturer suggestion should be "Ranked Maker"
+
+  Scenario: Device create shows suggestions for make model and system
+    Given device reference values exist for make "Nikon", model "F3", and system "V-System"
+    When I open the device create form
+    And I choose camera in the device create form
+    And I choose film format "35mm" in the device create form
+    And I type "Nik" into the device make field
+    Then I see "Nikon" as a device suggestion
+    When I type "F3" into the device model field
+    Then I see "F3" as a device suggestion
+    When I choose interchangeable back in the device create form
+    And I choose film format "120" in the device create form
+    And I type "V-S" into the device system field
+    Then I see "V-System" as a device suggestion
+
+  Scenario: Lab suggestions appear in sent for dev and developed forms and are user isolated
+    Given lab reference values exist for name "Indie Lab" and contact "hello@indielab.dev"
+    And another user has lab reference values for name "Other User Lab"
+    When I open film detail for "Typeahead Film Roll"
+    And I open the sent for dev event form
+    And I type "Ind" into the sent for dev lab name field
+    Then I see "Indie Lab" as a lab suggestion
+    And I do not see "Other User Lab" as a lab suggestion
+    When I submit sent for dev with lab name "Indie Lab" and lab contact "hello@indielab.dev"
+    And I open the developed event form
+    And I type "Ind" into the developed lab name field
+    Then I see "Indie Lab" as a lab suggestion

--- a/apps/ui/e2e/steps/reference-typeahead.steps.ts
+++ b/apps/ui/e2e/steps/reference-typeahead.steps.ts
@@ -1,0 +1,272 @@
+import { expect } from '@playwright/test';
+import type { Emulsion, ReferenceValue } from '@frollz2/schema';
+import {
+  Given,
+  Then,
+  When,
+  apiCall,
+  createCameraFixture,
+  createFilmLotFixture,
+  loadReferenceData,
+  loginAs
+} from './fixtures.js';
+
+async function createEmulsion(manufacturer: string, brand: string): Promise<Emulsion> {
+  const reference = await loadReferenceData();
+  const process = reference.developmentProcesses[0];
+  const format = reference.filmFormats.find((item) => item.code === '35mm') ?? reference.filmFormats[0];
+
+  return apiCall<Emulsion>('POST', 'emulsions', {
+    body: {
+      manufacturer,
+      brand,
+      isoSpeed: 200 + Math.floor(Math.random() * 500),
+      developmentProcessId: process.id,
+      filmFormatIds: [format.id]
+    }
+  });
+}
+
+async function createDeviceValues(make: string, model: string): Promise<void> {
+  const reference = await loadReferenceData();
+  const deviceType = reference.deviceTypes.find((item) => item.code === 'camera');
+  const format = reference.filmFormats.find((item) => item.code === '35mm') ?? reference.filmFormats[0];
+  if (!deviceType) {
+    throw new Error('Device type camera missing');
+  }
+
+  await apiCall('POST', 'devices', {
+    body: {
+      deviceTypeCode: 'camera',
+      deviceTypeId: deviceType.id,
+      filmFormatId: format.id,
+      frameSize: 'full_frame',
+      make,
+      model,
+      canUnload: true,
+      loadMode: 'direct'
+    }
+  });
+}
+
+async function createInterchangeableBackWithSystem(system: string): Promise<void> {
+  const reference = await loadReferenceData();
+  const deviceType = reference.deviceTypes.find((item) => item.code === 'interchangeable_back');
+  const format = reference.filmFormats.find((item) => item.code === '120') ?? reference.filmFormats[0];
+  if (!deviceType) {
+    throw new Error('Device type interchangeable_back missing');
+  }
+
+  await apiCall('POST', 'devices', {
+    body: {
+      deviceTypeCode: 'interchangeable_back',
+      deviceTypeId: deviceType.id,
+      filmFormatId: format.id,
+      frameSize: '6x6',
+      name: `Back ${Date.now()}`,
+      system
+    }
+  });
+}
+
+Given('emulsion reference values exist for manufacturer {string} and brand {string}', async ({ }, manufacturer: string, brand: string) => {
+  await createEmulsion(manufacturer, brand);
+});
+
+When('I open the emulsion create form', async ({ page }) => {
+  await page.goto('/emulsions');
+  await page.getByRole('button', { name: /add emulsion/i }).click();
+});
+
+When('I type {string} into the emulsion manufacturer field', async ({ page }, value: string) => {
+  await page.getByLabel('Manufacturer').fill(value);
+});
+
+When('I type {string} into the emulsion brand field', async ({ page }, value: string) => {
+  await page.getByLabel('Brand').fill(value);
+});
+
+Then('I see {string} as an emulsion suggestion', async ({ page }, value: string) => {
+  await expect(page.getByRole('option', { name: value, exact: false }).first()).toBeVisible();
+});
+
+When('I create an emulsion using free text manufacturer {string} and brand {string}', async ({ page }, manufacturer: string, brand: string) => {
+  const reference = await loadReferenceData();
+  const process = reference.developmentProcesses[0];
+  const format = reference.filmFormats.find((item) => item.code === '35mm') ?? reference.filmFormats[0];
+
+  await page.goto('/emulsions');
+  await page.getByRole('button', { name: /add emulsion/i }).click();
+  await page.getByLabel('Manufacturer').fill(manufacturer);
+  await page.getByLabel('Brand').fill(brand);
+  await page.getByLabel('ISO').fill('800');
+  await page.getByLabel('Development process').click();
+  await page.getByRole('option', { name: process.label, exact: true }).click();
+  await page.getByLabel('Film formats').click();
+  await page.getByRole('option', { name: format.label, exact: true }).click();
+  await page.getByRole('button', { name: /^create$/i }).click();
+  await expect(page.getByText(/emulsion created/i)).toBeVisible();
+});
+
+Then('manufacturer suggestion query for {string} returns {string}', async ({ }, query: string, expected: string) => {
+  const values = await apiCall<ReferenceValue[]>('GET', `reference/values?kind=manufacturer&q=${encodeURIComponent(query)}&limit=10`);
+  expect(values.some((item) => item.value === expected)).toBeTruthy();
+});
+
+Then('brand suggestion query for {string} returns {string}', async ({ }, query: string, expected: string) => {
+  const values = await apiCall<ReferenceValue[]>('GET', `reference/values?kind=brand&q=${encodeURIComponent(query)}&limit=10`);
+  expect(values.some((item) => item.value === expected)).toBeTruthy();
+});
+
+Given('manufacturer {string} has been used {int} times in emulsion submissions', async ({ }, manufacturer: string, times: number) => {
+  for (let i = 0; i < times; i += 1) {
+    await createEmulsion(manufacturer, `Ranked Stock ${manufacturer} ${i} ${Date.now()}`);
+  }
+});
+
+When('I request manufacturer suggestions for prefix {string}', async ({ }, prefix: string) => {
+  const values = await apiCall<ReferenceValue[]>('GET', `reference/values?kind=manufacturer&q=${encodeURIComponent(prefix)}&limit=10`);
+  (globalThis as { __lastManufacturerSuggestions?: ReferenceValue[] }).__lastManufacturerSuggestions = values;
+});
+
+Then('the first manufacturer suggestion should be {string}', async ({ }, expected: string) => {
+  const values = (globalThis as { __lastManufacturerSuggestions?: ReferenceValue[] }).__lastManufacturerSuggestions ?? [];
+  expect(values[0]?.value).toBe(expected);
+});
+
+Given('device reference values exist for make {string}, model {string}, and system {string}', async ({ }, make: string, model: string, system: string) => {
+  await createDeviceValues(make, model);
+  await createInterchangeableBackWithSystem(system);
+});
+
+When('I open the device create form', async ({ page }) => {
+  await page.goto('/devices');
+  await page.getByRole('button', { name: /add device/i }).click();
+});
+
+When('I choose camera in the device create form', async ({ page }) => {
+  await page.getByLabel('Device type').click();
+  await page.getByRole('option', { name: /camera/i }).click();
+});
+
+When('I choose interchangeable back in the device create form', async ({ page }) => {
+  await page.getByLabel('Device type').click();
+  await page.getByRole('option', { name: /interchangeable back/i }).click();
+});
+
+When('I choose film format {string} in the device create form', async ({ page }, formatLabel: string) => {
+  await page.getByLabel('Film format').click();
+  await page.getByRole('option', { name: formatLabel, exact: true }).click();
+});
+
+When('I type {string} into the device make field', async ({ page }, value: string) => {
+  await page.getByLabel('Make').fill(value);
+});
+
+When('I type {string} into the device model field', async ({ page }, value: string) => {
+  await page.getByLabel('Model').fill(value);
+});
+
+When('I type {string} into the device system field', async ({ page }, value: string) => {
+  await page.getByLabel('System').fill(value);
+});
+
+Then('I see {string} as a device suggestion', async ({ page }, value: string) => {
+  await expect(page.getByRole('option', { name: value, exact: false }).first()).toBeVisible();
+});
+
+Given('lab reference values exist for name {string} and contact {string}', async ({ }, labName: string, labContact: string) => {
+  await apiCall('POST', 'reference/values/upsert-batch', {
+    body: { items: [{ kind: 'lab_name', value: labName }, { kind: 'lab_contact', value: labContact }] }
+  });
+
+  const cameraId = await createCameraFixture({
+    make: `SeedCam${Date.now()}`,
+    model: 'T1',
+    filmFormatCode: '35mm',
+    frameSize: 'full_frame'
+  });
+
+  const filmId = await createFilmLotFixture({
+    filmName: 'Typeahead Film Roll',
+    filmFormatCode: '35mm',
+    packageLabelContains: '36',
+    emulsionMatcher: (name) => name.toLowerCase().includes('kodak portra')
+  });
+  const reference = await loadReferenceData();
+  const location = reference.storageLocations[0];
+  if (!location) {
+    throw new Error('Missing storage location');
+  }
+
+  await apiCall('POST', `film/${filmId}/events`, {
+    body: {
+      filmStateCode: 'stored',
+      occurredAt: new Date().toISOString(),
+      eventData: { storageLocationId: location.id, storageLocationCode: location.code }
+    }
+  });
+  await apiCall('POST', `film/${filmId}/events`, {
+    body: {
+      filmStateCode: 'loaded',
+      occurredAt: new Date().toISOString(),
+      eventData: { loadTargetType: 'camera_direct', cameraId, intendedPushPull: null }
+    }
+  });
+  await apiCall('POST', `film/${filmId}/events`, {
+    body: {
+      filmStateCode: 'exposed',
+      occurredAt: new Date().toISOString(),
+      eventData: {}
+    }
+  });
+  await apiCall('POST', `film/${filmId}/events`, {
+    body: {
+      filmStateCode: 'removed',
+      occurredAt: new Date().toISOString(),
+      eventData: {}
+    }
+  });
+});
+
+Given('another user has lab reference values for name {string}', async ({ }, labName: string) => {
+  await loginAs('other-user@example.com', 'password123', 'Other User');
+  await apiCall('POST', 'reference/values/upsert-batch', {
+    body: { items: [{ kind: 'lab_name', value: labName }] }
+  });
+  await loginAs();
+});
+
+When('I open the sent for dev event form', async ({ page }) => {
+  await page.getByLabel('Next state').click();
+  await page.getByRole('option', { name: /sent for dev/i }).click();
+  await page.getByLabel('Occurred at').fill(new Date().toISOString().slice(0, 19));
+});
+
+When('I type {string} into the sent for dev lab name field', async ({ page }, value: string) => {
+  await page.getByLabel('Lab name (optional)').fill(value);
+});
+
+Then('I see {string} as a lab suggestion', async ({ page }, value: string) => {
+  await expect(page.getByRole('option', { name: value, exact: false }).first()).toBeVisible();
+});
+
+Then('I do not see {string} as a lab suggestion', async ({ page }, value: string) => {
+  await expect(page.getByRole('option', { name: value, exact: false })).toHaveCount(0);
+});
+
+When('I submit sent for dev with lab name {string} and lab contact {string}', async ({ page }, labName: string, labContact: string) => {
+  await page.getByLabel('Lab name (optional)').fill(labName);
+  await page.getByLabel('Lab contact (optional)').fill(labContact);
+  await page.getByRole('button', { name: /add event/i }).click();
+});
+
+When('I open the developed event form', async ({ page }) => {
+  await page.getByLabel('Next state').click();
+  await page.getByRole('option', { name: /developed/i }).click();
+  await page.getByLabel('Occurred at').fill(new Date().toISOString().slice(0, 19));
+});
+
+When('I type {string} into the developed lab name field', async ({ page }, value: string) => {
+  await page.getByLabel('Lab name (optional)').fill(value);
+});

--- a/apps/ui/src/components/CreateDeviceDialog.vue
+++ b/apps/ui/src/components/CreateDeviceDialog.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
 import { computed, reactive, ref, watch } from 'vue';
 import type { QForm } from 'quasar';
-import { FRAME_SIZE_CODES, getFrameSizeCodesForFormatCode, type CreateFilmDeviceRequest } from '@frollz2/schema';
+import { FRAME_SIZE_CODES, getFrameSizeCodesForFormatCode, type CreateFilmDeviceRequest, type ReferenceValueKind } from '@frollz2/schema';
 import { useDeviceStore } from '../stores/devices.js';
 import { useReferenceStore } from '../stores/reference.js';
 import { useUiFeedback } from '../composables/useUiFeedback.js';
 import { createIdempotencyKey } from '../composables/idempotency.js';
+import { useReferenceValuesStore } from '../stores/reference-values.js';
 
 const props = defineProps<{
   modelValue: boolean;
@@ -19,6 +20,7 @@ const emit = defineEmits<{
 
 const deviceStore = useDeviceStore();
 const referenceStore = useReferenceStore();
+const referenceValuesStore = useReferenceValuesStore();
 const feedback = useUiFeedback();
 const isCreating = ref(false);
 const deviceForm = ref<QForm | null>(null);
@@ -77,6 +79,48 @@ const holderTypeOptions = computed(() =>
     value: type.id
   }))
 );
+
+type QSelectFilterUpdate = (callback: () => void) => void;
+
+const makeOptions = ref<string[]>([]);
+const modelOptions = ref<string[]>([]);
+const systemOptions = ref<string[]>([]);
+const brandOptions = ref<string[]>([]);
+
+async function fetchSuggestions(kind: ReferenceValueKind, term: string): Promise<string[]> {
+  try {
+    return await referenceValuesStore.loadSuggestions(kind, term);
+  } catch {
+    return referenceValuesStore.getSuggestions(kind);
+  }
+}
+
+function onFieldFilter(kind: ReferenceValueKind, target: 'make' | 'model' | 'system' | 'brand', value: string, update: QSelectFilterUpdate): void {
+  void fetchSuggestions(kind, value).then((items) => {
+    update(() => {
+      if (target === 'make') makeOptions.value = items;
+      if (target === 'model') modelOptions.value = items;
+      if (target === 'system') systemOptions.value = items;
+      if (target === 'brand') brandOptions.value = items;
+    });
+  });
+}
+
+function onMakeFilter(value: string, update: QSelectFilterUpdate): void {
+  onFieldFilter('device_make', 'make', value, update);
+}
+
+function onModelFilter(value: string, update: QSelectFilterUpdate): void {
+  onFieldFilter('device_model', 'model', value, update);
+}
+
+function onSystemFilter(value: string, update: QSelectFilterUpdate): void {
+  onFieldFilter('device_system', 'system', value, update);
+}
+
+function onBrandFilter(value: string, update: QSelectFilterUpdate): void {
+  onFieldFilter('brand', 'brand', value, update);
+}
 
 function reset(): void {
   createForm.deviceTypeCode = props.deviceTypeFilter ?? 'camera';
@@ -220,18 +264,78 @@ async function submit(): Promise<void> {
               label="Is this camera directly loadable?"
               :disable="isFieldDisabled"
             />
-            <q-input v-model="createForm.make" filled label="Make" :disable="isFieldDisabled" />
-            <q-input v-model="createForm.model" filled label="Model" :disable="isFieldDisabled" />
+            <q-select
+              :model-value="createForm.make"
+              filled
+              use-input
+              fill-input
+              hide-selected
+              hide-dropdown-icon
+              input-debounce="150"
+              :options="makeOptions"
+              label="Make"
+              new-value-mode="add-unique"
+              :disable="isFieldDisabled"
+              @update:model-value="createForm.make = String($event ?? '')"
+              @input-value="createForm.make = String($event ?? '')"
+              @filter="onMakeFilter"
+            />
+            <q-select
+              :model-value="createForm.model"
+              filled
+              use-input
+              fill-input
+              hide-selected
+              hide-dropdown-icon
+              input-debounce="150"
+              :options="modelOptions"
+              label="Model"
+              new-value-mode="add-unique"
+              :disable="isFieldDisabled"
+              @update:model-value="createForm.model = String($event ?? '')"
+              @input-value="createForm.model = String($event ?? '')"
+              @filter="onModelFilter"
+            />
           </template>
 
           <template v-else-if="createForm.deviceTypeCode === 'interchangeable_back'">
             <q-input v-model="createForm.name" filled label="Name" :disable="isFieldDisabled" />
-            <q-input v-model="createForm.system" filled label="System" :disable="isFieldDisabled" />
+            <q-select
+              :model-value="createForm.system"
+              filled
+              use-input
+              fill-input
+              hide-selected
+              hide-dropdown-icon
+              input-debounce="150"
+              :options="systemOptions"
+              label="System"
+              new-value-mode="add-unique"
+              :disable="isFieldDisabled"
+              @update:model-value="createForm.system = String($event ?? '')"
+              @input-value="createForm.system = String($event ?? '')"
+              @filter="onSystemFilter"
+            />
           </template>
 
           <template v-else>
             <q-input v-model="createForm.name" filled label="Holder name" :disable="isFieldDisabled" />
-            <q-input v-model="createForm.brand" filled label="Brand" :disable="isFieldDisabled" />
+            <q-select
+              :model-value="createForm.brand"
+              filled
+              use-input
+              fill-input
+              hide-selected
+              hide-dropdown-icon
+              input-debounce="150"
+              :options="brandOptions"
+              label="Brand"
+              new-value-mode="add-unique"
+              :disable="isFieldDisabled"
+              @update:model-value="createForm.brand = String($event ?? '')"
+              @input-value="createForm.brand = String($event ?? '')"
+              @filter="onBrandFilter"
+            />
             <q-select
               v-model="createForm.slotCount"
               filled

--- a/apps/ui/src/components/CreateEmulsionDialog.vue
+++ b/apps/ui/src/components/CreateEmulsionDialog.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
 import { computed, reactive, ref, watch } from 'vue';
-import { createEmulsionRequestSchema } from '@frollz2/schema';
+import { createEmulsionRequestSchema, type ReferenceValueKind } from '@frollz2/schema';
 import type { QForm } from 'quasar';
 import { createIdempotencyKey } from '../composables/idempotency.js';
 import { useUiFeedback } from '../composables/useUiFeedback.js';
 import { useEmulsionStore } from '../stores/emulsions.js';
 import { useReferenceStore } from '../stores/reference.js';
+import { useReferenceValuesStore } from '../stores/reference-values.js';
 
 const props = defineProps<{
   modelValue: boolean;
@@ -17,6 +18,7 @@ const emit = defineEmits<{
 }>();
 
 const referenceStore = useReferenceStore();
+const referenceValuesStore = useReferenceValuesStore();
 const emulsionStore = useEmulsionStore();
 const feedback = useUiFeedback();
 const isCreating = ref(false);
@@ -30,6 +32,9 @@ const form = reactive({
   developmentProcessId: null as number | null,
   filmFormatIds: [] as number[]
 });
+
+const manufacturerOptions = ref<string[]>([]);
+const brandOptions = ref<string[]>([]);
 
 const developmentProcessOptions = computed(() =>
   referenceStore.developmentProcesses.map((process) => ({
@@ -52,6 +57,30 @@ function reset(): void {
   form.developmentProcessId = null;
   form.filmFormatIds = [];
   idempotencyKey.value = createIdempotencyKey();
+}
+
+async function fetchSuggestions(kind: ReferenceValueKind, term: string): Promise<string[]> {
+  try {
+    return await referenceValuesStore.loadSuggestions(kind, term);
+  } catch {
+    return referenceValuesStore.getSuggestions(kind);
+  }
+}
+
+function onManufacturerFilter(value: string, update: (callback: () => void) => void): void {
+  void fetchSuggestions('manufacturer', value).then((items) => {
+    update(() => {
+      manufacturerOptions.value = items;
+    });
+  });
+}
+
+function onBrandFilter(value: string, update: (callback: () => void) => void): void {
+  void fetchSuggestions('brand', value).then((items) => {
+    update(() => {
+      brandOptions.value = items;
+    });
+  });
 }
 
 watch(() => props.modelValue, (open) => {
@@ -100,8 +129,38 @@ async function submit(): Promise<void> {
 
       <q-card-section>
         <q-form ref="emulsionForm" class="column q-gutter-md" data-testid="emulsion-create-form" @submit="submit">
-          <q-input v-model="form.manufacturer" filled label="Manufacturer" data-testid="emulsion-create-manufacturer" />
-          <q-input v-model="form.brand" filled label="Brand" data-testid="emulsion-create-brand" />
+          <q-select
+            :model-value="form.manufacturer"
+            filled
+            use-input
+            fill-input
+            hide-selected
+            hide-dropdown-icon
+            input-debounce="150"
+            :options="manufacturerOptions"
+            label="Manufacturer"
+            new-value-mode="add-unique"
+            data-testid="emulsion-create-manufacturer"
+            @update:model-value="form.manufacturer = String($event ?? '')"
+            @input-value="form.manufacturer = String($event ?? '')"
+            @filter="onManufacturerFilter"
+          />
+          <q-select
+            :model-value="form.brand"
+            filled
+            use-input
+            fill-input
+            hide-selected
+            hide-dropdown-icon
+            input-debounce="150"
+            :options="brandOptions"
+            label="Brand"
+            new-value-mode="add-unique"
+            data-testid="emulsion-create-brand"
+            @update:model-value="form.brand = String($event ?? '')"
+            @input-value="form.brand = String($event ?? '')"
+            @filter="onBrandFilter"
+          />
           <q-input
             v-model.number="form.isoSpeed"
             filled

--- a/apps/ui/src/components/film-event-forms/DevelopedEventForm.vue
+++ b/apps/ui/src/components/film-event-forms/DevelopedEventForm.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { reactive } from 'vue';
+import { reactive, ref } from 'vue';
 import { useRegleSchema } from '@regle/schemas';
-import type { CreateFilmJourneyEventRequest } from '@frollz2/schema';
+import type { CreateFilmJourneyEventRequest, ReferenceValueKind } from '@frollz2/schema';
 import { z } from 'zod';
+import { useReferenceValuesStore } from '../../stores/reference-values.js';
 
 interface Props {
   occurredAt: string;
@@ -13,6 +14,7 @@ interface Props {
 
 const props = defineProps<Props>();
 const emit = defineEmits<{ submit: [payload: CreateFilmJourneyEventRequest] }>();
+const referenceValuesStore = useReferenceValuesStore();
 
 const form = reactive({
   labName: '',
@@ -25,6 +27,28 @@ const developedSchema = z.object({
 });
 
 const { r$ } = useRegleSchema(form, developedSchema);
+const labNameOptions = ref<string[]>([]);
+type QSelectFilterUpdate = (callback: () => void) => void;
+
+async function fetchSuggestions(kind: ReferenceValueKind, term: string): Promise<string[]> {
+  try {
+    return await referenceValuesStore.loadSuggestions(kind, term);
+  } catch {
+    return referenceValuesStore.getSuggestions(kind);
+  }
+}
+
+function onFieldFilter(kind: ReferenceValueKind, value: string, update: QSelectFilterUpdate): void {
+  void fetchSuggestions(kind, value).then((items) => {
+    update(() => {
+      labNameOptions.value = items;
+    });
+  });
+}
+
+function onLabNameFilter(value: string, update: QSelectFilterUpdate): void {
+  onFieldFilter('lab_name', value, update);
+}
 
 async function handleSubmit(): Promise<void> {
   if (!props.occurredAt) return;
@@ -47,12 +71,22 @@ async function handleSubmit(): Promise<void> {
 <template>
   <q-form class="column q-gutter-md" @submit="handleSubmit">
     <div>
-      <q-input
-        v-model="r$.$value.labName"
+      <q-select
+        :model-value="r$.$value.labName"
         filled
+        use-input
+        fill-input
+        hide-selected
+        hide-dropdown-icon
+        input-debounce="150"
+        :options="labNameOptions"
         label="Lab name (optional)"
+        new-value-mode="add-unique"
         :error="r$.labName?.$error"
         :error-message="r$.labName?.$errors[0]"
+        @update:model-value="r$.$value.labName = String($event ?? '')"
+        @input-value="r$.$value.labName = String($event ?? '')"
+        @filter="onLabNameFilter"
       />
     </div>
 

--- a/apps/ui/src/components/film-event-forms/SentForDevEventForm.vue
+++ b/apps/ui/src/components/film-event-forms/SentForDevEventForm.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { reactive } from 'vue';
+import { reactive, ref } from 'vue';
 import { useRegleSchema } from '@regle/schemas';
-import type { CreateFilmJourneyEventRequest } from '@frollz2/schema';
+import type { CreateFilmJourneyEventRequest, ReferenceValueKind } from '@frollz2/schema';
 import { z } from 'zod';
+import { useReferenceValuesStore } from '../../stores/reference-values.js';
 
 interface Props {
   occurredAt: string;
@@ -13,6 +14,7 @@ interface Props {
 
 const props = defineProps<Props>();
 const emit = defineEmits<{ submit: [payload: CreateFilmJourneyEventRequest] }>();
+const referenceValuesStore = useReferenceValuesStore();
 
 const form = reactive({
   labName: '',
@@ -27,6 +29,34 @@ const sentForDevSchema = z.object({
 });
 
 const { r$ } = useRegleSchema(form, sentForDevSchema);
+const labNameOptions = ref<string[]>([]);
+const labContactOptions = ref<string[]>([]);
+type QSelectFilterUpdate = (callback: () => void) => void;
+
+async function fetchSuggestions(kind: ReferenceValueKind, term: string): Promise<string[]> {
+  try {
+    return await referenceValuesStore.loadSuggestions(kind, term);
+  } catch {
+    return referenceValuesStore.getSuggestions(kind);
+  }
+}
+
+function onFieldFilter(kind: ReferenceValueKind, target: 'name' | 'contact', value: string, update: QSelectFilterUpdate): void {
+  void fetchSuggestions(kind, value).then((items) => {
+    update(() => {
+      if (target === 'name') labNameOptions.value = items;
+      if (target === 'contact') labContactOptions.value = items;
+    });
+  });
+}
+
+function onLabNameFilter(value: string, update: QSelectFilterUpdate): void {
+  onFieldFilter('lab_name', 'name', value, update);
+}
+
+function onLabContactFilter(value: string, update: QSelectFilterUpdate): void {
+  onFieldFilter('lab_contact', 'contact', value, update);
+}
 
 async function handleSubmit(): Promise<void> {
   if (!props.occurredAt) return;
@@ -50,22 +80,42 @@ async function handleSubmit(): Promise<void> {
 <template>
   <q-form class="column q-gutter-md" @submit="handleSubmit">
     <div>
-      <q-input
-        v-model="r$.$value.labName"
+      <q-select
+        :model-value="r$.$value.labName"
         filled
+        use-input
+        fill-input
+        hide-selected
+        hide-dropdown-icon
+        input-debounce="150"
+        :options="labNameOptions"
         label="Lab name (optional)"
+        new-value-mode="add-unique"
         :error="r$.labName?.$error"
         :error-message="r$.labName?.$errors[0]"
+        @update:model-value="r$.$value.labName = String($event ?? '')"
+        @input-value="r$.$value.labName = String($event ?? '')"
+        @filter="onLabNameFilter"
       />
     </div>
 
     <div>
-      <q-input
-        v-model="r$.$value.labContact"
+      <q-select
+        :model-value="r$.$value.labContact"
         filled
+        use-input
+        fill-input
+        hide-selected
+        hide-dropdown-icon
+        input-debounce="150"
+        :options="labContactOptions"
         label="Lab contact (optional)"
+        new-value-mode="add-unique"
         :error="r$.labContact?.$error"
         :error-message="r$.labContact?.$errors[0]"
+        @update:model-value="r$.$value.labContact = String($event ?? '')"
+        @input-value="r$.$value.labContact = String($event ?? '')"
+        @filter="onLabContactFilter"
       />
     </div>
 

--- a/apps/ui/src/stores/reference-values.ts
+++ b/apps/ui/src/stores/reference-values.ts
@@ -1,0 +1,34 @@
+import { defineStore } from 'pinia';
+import { ref } from 'vue';
+import { listReferenceValuesQuerySchema, referenceValueSchema, type ReferenceValueKind } from '@frollz2/schema';
+import { useApi } from '../composables/useApi.js';
+import { readApiData } from '../composables/api-envelope.js';
+
+export const useReferenceValuesStore = defineStore('reference-values', () => {
+  const { request } = useApi();
+  const suggestionsByKind = ref<Record<string, string[]>>({});
+
+  async function loadSuggestions(kind: ReferenceValueKind, query = '', limit = 10): Promise<string[]> {
+    const parsed = listReferenceValuesQuerySchema.parse({ kind, q: query, limit });
+    const params = new URLSearchParams({
+      kind: parsed.kind,
+      q: parsed.q,
+      limit: String(parsed.limit)
+    });
+
+    const response = await request(`/api/v1/reference/values?${params.toString()}`);
+    const values = referenceValueSchema.array().parse(await readApiData(response));
+    const next = values.map((item) => item.value);
+    suggestionsByKind.value[kind] = next;
+    return next;
+  }
+
+  function getSuggestions(kind: ReferenceValueKind): string[] {
+    return suggestionsByKind.value[kind] ?? [];
+  }
+
+  return {
+    loadSuggestions,
+    getSuggestions
+  };
+});

--- a/packages/schema/src/reference.ts
+++ b/packages/schema/src/reference.ts
@@ -59,6 +59,43 @@ export const holderTypeSchema = z.object({
   label: labelSchema
 });
 
+export const referenceValueKindSchema = z.enum([
+  'manufacturer',
+  'brand',
+  'device_make',
+  'device_model',
+  'device_system',
+  'lab_name',
+  'lab_contact',
+  'supplier_name',
+  'supplier_channel'
+]);
+
+export const referenceValueSchema = z.object({
+  id: idSchema,
+  userId: idSchema,
+  kind: referenceValueKindSchema,
+  value: z.string().min(1),
+  normalizedValue: z.string().min(1),
+  usageCount: z.number().int().nonnegative(),
+  lastUsedAt: z.string().min(1)
+});
+
+export const listReferenceValuesQuerySchema = z.object({
+  kind: referenceValueKindSchema,
+  q: z.string().optional().default(''),
+  limit: z.coerce.number().int().min(1).max(50).optional().default(10)
+});
+
+export const upsertReferenceValueInputSchema = z.object({
+  kind: referenceValueKindSchema,
+  value: z.string().min(1)
+});
+
+export const upsertReferenceValuesRequestSchema = z.object({
+  items: z.array(upsertReferenceValueInputSchema).min(1).max(100)
+});
+
 export const emulsionSchema = z.object({
   id: idSchema,
   brand: z.string().min(1),
@@ -105,6 +142,11 @@ export type StorageLocation = z.infer<typeof storageLocationSchema>;
 export type SlotState = z.infer<typeof slotStateSchema>;
 export type DeviceType = z.infer<typeof deviceTypeSchema>;
 export type HolderType = z.infer<typeof holderTypeSchema>;
+export type ReferenceValueKind = z.infer<typeof referenceValueKindSchema>;
+export type ReferenceValue = z.infer<typeof referenceValueSchema>;
+export type ListReferenceValuesQuery = z.infer<typeof listReferenceValuesQuerySchema>;
+export type UpsertReferenceValueInput = z.infer<typeof upsertReferenceValueInputSchema>;
+export type UpsertReferenceValuesRequest = z.infer<typeof upsertReferenceValuesRequestSchema>;
 export type Emulsion = z.infer<typeof emulsionSchema>;
 export type CreateEmulsionRequest = z.infer<typeof createEmulsionRequestSchema>;
 export type UpdateEmulsionRequest = z.infer<typeof updateEmulsionRequestSchema>;


### PR DESCRIPTION
## What does this PR do?

Add capability to use type aheads for text form fields 
Adds backing table for references to keep track of statistics and mru logic 
  - This will add the logic back for statistics 
 
## How was it tested?

BDD, test, unit, actually doing it

## Checklist

- [ ] Tests added or updated
- [ ] All tests pass (`npm test` in `frollz-api/` and `frollz-ui/`)
- [ ] Lint passes (`npm run lint` in both)
- [ ] No `console.log` left in committed code
- [ ] PR targets the `development` branch (not `main`)
