### PR TITLE
fix(ui): made dates always autofill and convert to 8601 to api

### DIFF
--- a/apps/ui/src/components/FilmCreateDialog.vue
+++ b/apps/ui/src/components/FilmCreateDialog.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, reactive, ref, watch } from 'vue';
+import { currentDateLocal } from '../composables/dateDefaults.js';
 import type { QForm } from 'quasar';
 import { useRegleSchema } from '@regle/schemas';
 import type { FilmCreateForm } from '@frollz2/schema';
@@ -28,7 +29,7 @@ const form = reactive({
   emulsionId: undefined as number | undefined,
   filmFormatId: undefined as number | undefined,
   packageTypeId: undefined as number | undefined,
-  expirationDate: undefined as string | undefined,
+  expirationDate: currentDateLocal() as string | undefined,
   supplierName: '' as string,
   purchaseInfo: {
     supplierId: undefined as number | undefined,
@@ -36,7 +37,7 @@ const form = reactive({
     price: undefined as number | undefined,
     currencyCode: 'USD' as string,
     orderRef: '' as string,
-    obtainedDate: undefined as string | undefined
+    obtainedDate: currentDateLocal() as string | undefined
   },
   rating: undefined as number | undefined
 });
@@ -101,7 +102,7 @@ watch(
       form.emulsionId = undefined;
       form.filmFormatId = undefined;
       form.packageTypeId = undefined;
-      form.expirationDate = undefined;
+      form.expirationDate = currentDateLocal();
       form.supplierName = '';
       form.purchaseInfo = {
         supplierId: undefined,
@@ -109,7 +110,7 @@ watch(
         price: undefined,
         currencyCode: 'USD',
         orderRef: '',
-        obtainedDate: undefined
+        obtainedDate: currentDateLocal()
       };
       form.rating = undefined;
       const filters = props.lockedFormatFilters ?? [];

--- a/apps/ui/src/components/FilmEventForm.vue
+++ b/apps/ui/src/components/FilmEventForm.vue
@@ -3,6 +3,7 @@ import { computed, reactive, ref } from 'vue';
 import { useRoute } from 'vue-router';
 import type { CreateFilmJourneyEventRequest } from '@frollz2/schema';
 import { filmTransitionMap } from '@frollz2/schema';
+import { currentDateLocal, dateToISODateTime } from '../composables/dateDefaults.js';
 import { useFilmStore } from '../stores/film.js';
 import { useReferenceStore } from '../stores/reference.js';
 import { useUiFeedback } from '../composables/useUiFeedback.js';
@@ -40,7 +41,7 @@ const errorMessage = ref<string | null>(null);
 const idempotencyKey = ref(createIdempotencyKey());
 
 const form = reactive({
-  occurredAt: '',
+  occurredAt: currentDateLocal(),
   notes: '',
 });
 
@@ -74,16 +75,14 @@ async function handleSubFormSubmit(payload: EventPayload): Promise<void> {
   idempotencyKey.value = createIdempotencyKey();
 
   try {
-    // Convert datetime-local (e.g. "2026-04-27T12:20:30") to ISO 8601 with Z                                                                                                      
-    const occurredAtIso = `${payload.occurredAt}Z`;
     const enrichedPayload: CreateFilmJourneyEventRequest = {
       ...payload,
-      occurredAt: occurredAtIso,
+      occurredAt: dateToISODateTime(payload.occurredAt),
     };
 
     await filmStore.addEvent(filmId.value, enrichedPayload, idempotencyKey.value);
     feedback.success('Event added.');
-    form.occurredAt = '';
+    form.occurredAt = currentDateLocal();
     form.notes = '';
     selectedStateCode.value = null;
     emit('event-added');
@@ -108,7 +107,7 @@ async function handleSubFormSubmit(payload: EventPayload): Promise<void> {
 
     <div v-if="selectedStateCode" class="column q-gutter-md">
       <div>
-        <q-input v-model="form.occurredAt" filled type="datetime-local" label="Occurred at" required />
+        <q-input v-model="form.occurredAt" filled type="date" label="Occurred at" required />
       </div>
 
       <div>

--- a/apps/ui/src/composables/dateDefaults.ts
+++ b/apps/ui/src/composables/dateDefaults.ts
@@ -1,0 +1,13 @@
+function pad(n: number): string {
+  return String(n).padStart(2, '0');
+}
+
+export function currentDateLocal(): string {
+  const now = new Date();
+  return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`;
+}
+
+export function dateToISODateTime(dateStr: string): string {
+  const now = new Date();
+  return `${dateStr}T${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}Z`;
+}


### PR DESCRIPTION
## What does this PR do?

Changes date fields to date only, convert to 8601 date time behind the scenes before sending to the API. 
Pre-fill all dates with defaults

## How was it tested?

<!-- Describe how you verified the change works. -->

## Checklist

- [ ] Tests added or updated
- [ ] All tests pass (`npm test` in `frollz-api/` and `frollz-ui/`)
- [ ] Lint passes (`npm run lint` in both)
- [ ] No `console.log` left in committed code
- [ ] PR targets the `development` branch (not `main`)
