### PR TITLE
refactor(ui): move emulsion list filter state into emulsion store

### DIFF
--- a/apps/ui/src/pages/emulsions/black-and-white-reversal.vue
+++ b/apps/ui/src/pages/emulsions/black-and-white-reversal.vue
@@ -1,38 +1,15 @@
 <!-- eslint-disable vue/multi-word-component-names -->
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue';
+import { onMounted } from 'vue';
 import { useRoute } from 'vue-router';
-import type { Emulsion } from '@frollz2/schema';
 import EmulsionTable from '../../components/EmulsionTable.vue';
 import { useEmulsionStore } from '../../stores/emulsions.js';
 
 const route = useRoute();
 const emulsionStore = useEmulsionStore();
-const search = ref<string | null>('');
-
-const processFilterCode = computed(() => {
-  const value = route.meta.developmentProcessFilter;
-  return typeof value === 'string' ? value : null;
-});
-
-const rows = computed(() => {
-  const query = (search.value ?? '').trim().toLowerCase();
-
-  return emulsionStore.emulsions.filter((emulsion) => {
-    if (processFilterCode.value && emulsion.developmentProcess.code !== processFilterCode.value) {
-      return false;
-    }
-
-    if (!query) {
-      return true;
-    }
-
-    const haystack = `${emulsion.manufacturer} ${emulsion.brand} ${emulsion.developmentProcess.label} ${emulsion.isoSpeed}`.toLowerCase();
-    return haystack.includes(query);
-  });
-});
 
 onMounted(async () => {
+  emulsionStore.setProcessFilterFromMeta(route.meta.developmentProcessFilter);
   await emulsionStore.loadAll();
 });
 </script>
@@ -46,8 +23,8 @@ onMounted(async () => {
       </div>
     </div>
 
-    <q-input v-model="search" filled label="Search emulsions" clearable />
+    <q-input v-model="emulsionStore.emulsionSearch" filled label="Search emulsions" clearable />
 
-    <EmulsionTable :rows="rows" :is-loading="emulsionStore.isLoading" />
+    <EmulsionTable :rows="emulsionStore.filteredEmulsions" :is-loading="emulsionStore.isLoading" />
   </q-page>
 </template>

--- a/apps/ui/src/pages/emulsions/black-and-white.vue
+++ b/apps/ui/src/pages/emulsions/black-and-white.vue
@@ -1,38 +1,15 @@
 <!-- eslint-disable vue/multi-word-component-names -->
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue';
+import { onMounted } from 'vue';
 import { useRoute } from 'vue-router';
-import type { Emulsion } from '@frollz2/schema';
 import EmulsionTable from '../../components/EmulsionTable.vue';
 import { useEmulsionStore } from '../../stores/emulsions.js';
 
 const route = useRoute();
 const emulsionStore = useEmulsionStore();
-const search = ref<string | null>('');
-
-const processFilterCode = computed(() => {
-  const value = route.meta.developmentProcessFilter;
-  return typeof value === 'string' ? value : null;
-});
-
-const rows = computed(() => {
-  const query = (search.value ?? '').trim().toLowerCase();
-
-  return emulsionStore.emulsions.filter((emulsion) => {
-    if (processFilterCode.value && emulsion.developmentProcess.code !== processFilterCode.value) {
-      return false;
-    }
-
-    if (!query) {
-      return true;
-    }
-
-    const haystack = `${emulsion.manufacturer} ${emulsion.brand} ${emulsion.developmentProcess.label} ${emulsion.isoSpeed}`.toLowerCase();
-    return haystack.includes(query);
-  });
-});
 
 onMounted(async () => {
+  emulsionStore.setProcessFilterFromMeta(route.meta.developmentProcessFilter);
   await emulsionStore.loadAll();
 });
 </script>
@@ -46,8 +23,8 @@ onMounted(async () => {
       </div>
     </div>
 
-    <q-input v-model="search" filled label="Search emulsions" clearable />
+    <q-input v-model="emulsionStore.emulsionSearch" filled label="Search emulsions" clearable />
 
-    <EmulsionTable :rows="rows" :is-loading="emulsionStore.isLoading" />
+    <EmulsionTable :rows="emulsionStore.filteredEmulsions" :is-loading="emulsionStore.isLoading" />
   </q-page>
 </template>

--- a/apps/ui/src/pages/emulsions/cine-ecn2.vue
+++ b/apps/ui/src/pages/emulsions/cine-ecn2.vue
@@ -1,38 +1,15 @@
 <!-- eslint-disable vue/multi-word-component-names -->
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue';
+import { onMounted } from 'vue';
 import { useRoute } from 'vue-router';
-import type { Emulsion } from '@frollz2/schema';
 import EmulsionTable from '../../components/EmulsionTable.vue';
 import { useEmulsionStore } from '../../stores/emulsions.js';
 
 const route = useRoute();
 const emulsionStore = useEmulsionStore();
-const search = ref<string | null>('');
-
-const processFilterCode = computed(() => {
-  const value = route.meta.developmentProcessFilter;
-  return typeof value === 'string' ? value : null;
-});
-
-const rows = computed(() => {
-  const query = (search.value ?? '').trim().toLowerCase();
-
-  return emulsionStore.emulsions.filter((emulsion) => {
-    if (processFilterCode.value && emulsion.developmentProcess.code !== processFilterCode.value) {
-      return false;
-    }
-
-    if (!query) {
-      return true;
-    }
-
-    const haystack = `${emulsion.manufacturer} ${emulsion.brand} ${emulsion.developmentProcess.label} ${emulsion.isoSpeed}`.toLowerCase();
-    return haystack.includes(query);
-  });
-});
 
 onMounted(async () => {
+  emulsionStore.setProcessFilterFromMeta(route.meta.developmentProcessFilter);
   await emulsionStore.loadAll();
 });
 </script>
@@ -46,8 +23,8 @@ onMounted(async () => {
       </div>
     </div>
 
-    <q-input v-model="search" filled label="Search emulsions" clearable />
+    <q-input v-model="emulsionStore.emulsionSearch" filled label="Search emulsions" clearable />
 
-    <EmulsionTable :rows="rows" :is-loading="emulsionStore.isLoading" />
+    <EmulsionTable :rows="emulsionStore.filteredEmulsions" :is-loading="emulsionStore.isLoading" />
   </q-page>
 </template>

--- a/apps/ui/src/pages/emulsions/color-negative-c41.vue
+++ b/apps/ui/src/pages/emulsions/color-negative-c41.vue
@@ -1,38 +1,15 @@
 <!-- eslint-disable vue/multi-word-component-names -->
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue';
+import { onMounted } from 'vue';
 import { useRoute } from 'vue-router';
-import type { Emulsion } from '@frollz2/schema';
 import EmulsionTable from '../../components/EmulsionTable.vue';
 import { useEmulsionStore } from '../../stores/emulsions.js';
 
 const route = useRoute();
 const emulsionStore = useEmulsionStore();
-const search = ref<string | null>('');
-
-const processFilterCode = computed(() => {
-  const value = route.meta.developmentProcessFilter;
-  return typeof value === 'string' ? value : null;
-});
-
-const rows = computed(() => {
-  const query = (search.value ?? '').trim().toLowerCase();
-
-  return emulsionStore.emulsions.filter((emulsion) => {
-    if (processFilterCode.value && emulsion.developmentProcess.code !== processFilterCode.value) {
-      return false;
-    }
-
-    if (!query) {
-      return true;
-    }
-
-    const haystack = `${emulsion.manufacturer} ${emulsion.brand} ${emulsion.developmentProcess.label} ${emulsion.isoSpeed}`.toLowerCase();
-    return haystack.includes(query);
-  });
-});
 
 onMounted(async () => {
+  emulsionStore.setProcessFilterFromMeta(route.meta.developmentProcessFilter);
   await emulsionStore.loadAll();
 });
 </script>
@@ -46,8 +23,8 @@ onMounted(async () => {
       </div>
     </div>
 
-    <q-input v-model="search" filled label="Search emulsions" clearable />
+    <q-input v-model="emulsionStore.emulsionSearch" filled label="Search emulsions" clearable />
 
-    <EmulsionTable :rows="rows" :is-loading="emulsionStore.isLoading" />
+    <EmulsionTable :rows="emulsionStore.filteredEmulsions" :is-loading="emulsionStore.isLoading" />
   </q-page>
 </template>

--- a/apps/ui/src/pages/emulsions/color-positive-e6.vue
+++ b/apps/ui/src/pages/emulsions/color-positive-e6.vue
@@ -1,38 +1,15 @@
 <!-- eslint-disable vue/multi-word-component-names -->
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue';
+import { onMounted } from 'vue';
 import { useRoute } from 'vue-router';
-import type { Emulsion } from '@frollz2/schema';
 import EmulsionTable from '../../components/EmulsionTable.vue';
 import { useEmulsionStore } from '../../stores/emulsions.js';
 
 const route = useRoute();
 const emulsionStore = useEmulsionStore();
-const search = ref<string | null>('');
-
-const processFilterCode = computed(() => {
-  const value = route.meta.developmentProcessFilter;
-  return typeof value === 'string' ? value : null;
-});
-
-const rows = computed(() => {
-  const query = (search.value ?? '').trim().toLowerCase();
-
-  return emulsionStore.emulsions.filter((emulsion) => {
-    if (processFilterCode.value && emulsion.developmentProcess.code !== processFilterCode.value) {
-      return false;
-    }
-
-    if (!query) {
-      return true;
-    }
-
-    const haystack = `${emulsion.manufacturer} ${emulsion.brand} ${emulsion.developmentProcess.label} ${emulsion.isoSpeed}`.toLowerCase();
-    return haystack.includes(query);
-  });
-});
 
 onMounted(async () => {
+  emulsionStore.setProcessFilterFromMeta(route.meta.developmentProcessFilter);
   await emulsionStore.loadAll();
 });
 </script>
@@ -46,8 +23,8 @@ onMounted(async () => {
       </div>
     </div>
 
-    <q-input v-model="search" filled label="Search emulsions" clearable />
+    <q-input v-model="emulsionStore.emulsionSearch" filled label="Search emulsions" clearable />
 
-    <EmulsionTable :rows="rows" :is-loading="emulsionStore.isLoading" />
+    <EmulsionTable :rows="emulsionStore.filteredEmulsions" :is-loading="emulsionStore.isLoading" />
   </q-page>
 </template>

--- a/apps/ui/src/pages/emulsions/index.vue
+++ b/apps/ui/src/pages/emulsions/index.vue
@@ -1,7 +1,6 @@
 <!-- eslint-disable vue/multi-word-component-names -->
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue';
-import { useRoute } from 'vue-router';
+import { onMounted, ref } from 'vue';
 import type { Emulsion } from '@frollz2/schema';
 import CreateEmulsionDialog from '../../components/CreateEmulsionDialog.vue';
 import EditEmulsionDialog from '../../components/EditEmulsionDialog.vue';
@@ -9,39 +8,16 @@ import EmulsionTable from '../../components/EmulsionTable.vue';
 import { useUiFeedback } from '../../composables/useUiFeedback.js';
 import { useEmulsionStore } from '../../stores/emulsions.js';
 
-const route = useRoute();
 const emulsionStore = useEmulsionStore();
 const feedback = useUiFeedback();
-const search = ref<string | null>('');
 const isCreateDialogOpen = ref(false);
 const isEditDialogOpen = ref(false);
 const editingEmulsion = ref<Emulsion | null>(null);
 const deletingEmulsion = ref<Emulsion | null>(null);
 const isDeleting = ref(false);
 
-const processFilterCode = computed(() => {
-  const value = route.meta.developmentProcessFilter;
-  return typeof value === 'string' ? value : null;
-});
-
-const rows = computed(() => {
-  const query = (search.value ?? '').trim().toLowerCase();
-
-  return emulsionStore.emulsions.filter((emulsion) => {
-    if (processFilterCode.value && emulsion.developmentProcess.code !== processFilterCode.value) {
-      return false;
-    }
-
-    if (!query) {
-      return true;
-    }
-
-    const haystack = `${emulsion.manufacturer} ${emulsion.brand} ${emulsion.developmentProcess.label} ${emulsion.isoSpeed}`.toLowerCase();
-    return haystack.includes(query);
-  });
-});
-
 onMounted(async () => {
+  emulsionStore.emulsionProcessFilter = null;
   await emulsionStore.loadAll();
 });
 
@@ -81,9 +57,9 @@ async function confirmDelete(): Promise<void> {
       </div>
     </div>
 
-    <q-input v-model="search" filled label="Search emulsions" clearable />
+    <q-input v-model="emulsionStore.emulsionSearch" filled label="Search emulsions" clearable />
 
-    <EmulsionTable :rows="rows" :is-loading="emulsionStore.isLoading">
+    <EmulsionTable :rows="emulsionStore.filteredEmulsions" :is-loading="emulsionStore.isLoading">
       <template #actions="{ row }">
         <q-btn flat dense color="primary" label="Edit" data-testid="emulsion-row-edit" @click="openEditDialog(row)" />
         <q-btn flat dense color="negative" label="Delete" data-testid="emulsion-row-delete" @click="openDeleteDialog(row)" />

--- a/apps/ui/src/pages/emulsions/instant.vue
+++ b/apps/ui/src/pages/emulsions/instant.vue
@@ -1,38 +1,15 @@
 <!-- eslint-disable vue/multi-word-component-names -->
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue';
+import { onMounted } from 'vue';
 import { useRoute } from 'vue-router';
-import type { Emulsion } from '@frollz2/schema';
 import EmulsionTable from '../../components/EmulsionTable.vue';
 import { useEmulsionStore } from '../../stores/emulsions.js';
 
 const route = useRoute();
 const emulsionStore = useEmulsionStore();
-const search = ref<string | null>('');
-
-const processFilterCode = computed(() => {
-  const value = route.meta.developmentProcessFilter;
-  return typeof value === 'string' ? value : null;
-});
-
-const rows = computed(() => {
-  const query = (search.value ?? '').trim().toLowerCase();
-
-  return emulsionStore.emulsions.filter((emulsion) => {
-    if (processFilterCode.value && emulsion.developmentProcess.code !== processFilterCode.value) {
-      return false;
-    }
-
-    if (!query) {
-      return true;
-    }
-
-    const haystack = `${emulsion.manufacturer} ${emulsion.brand} ${emulsion.developmentProcess.label} ${emulsion.isoSpeed}`.toLowerCase();
-    return haystack.includes(query);
-  });
-});
 
 onMounted(async () => {
+  emulsionStore.setProcessFilterFromMeta(route.meta.developmentProcessFilter);
   await emulsionStore.loadAll();
 });
 </script>
@@ -46,8 +23,8 @@ onMounted(async () => {
       </div>
     </div>
 
-    <q-input v-model="search" filled label="Search emulsions" clearable />
+    <q-input v-model="emulsionStore.emulsionSearch" filled label="Search emulsions" clearable />
 
-    <EmulsionTable :rows="rows" :is-loading="emulsionStore.isLoading" />
+    <EmulsionTable :rows="emulsionStore.filteredEmulsions" :is-loading="emulsionStore.isLoading" />
   </q-page>
 </template>

--- a/apps/ui/src/stores/emulsions.ts
+++ b/apps/ui/src/stores/emulsions.ts
@@ -21,6 +21,8 @@ export const useEmulsionStore = defineStore('emulsions', () => {
   const isLoadingEmulsionDetail = ref(false);
   const loadError = ref<string | null>(null);
   const emulsionDetailError = ref<string | null>(null);
+  const emulsionSearch = ref<string>('');
+  const emulsionProcessFilter = ref<string | null>(null);
   let loadAllInFlight: Promise<void> | null = null;
   let loadEmulsionInFlight: Promise<void> | null = null;
   let loadEmulsionInFlightId: number | null = null;
@@ -131,6 +133,20 @@ export const useEmulsionStore = defineStore('emulsions', () => {
     }
   }
 
+  function setProcessFilterFromMeta(value: unknown): void {
+    emulsionProcessFilter.value = typeof value === 'string' ? value : null;
+  }
+
+  const filteredEmulsions = computed(() => {
+    const query = emulsionSearch.value.trim().toLowerCase();
+    return emulsions.value.filter((emulsion) => {
+      if (emulsionProcessFilter.value && emulsion.developmentProcess.code !== emulsionProcessFilter.value) return false;
+      if (!query) return true;
+      const haystack = `${emulsion.manufacturer} ${emulsion.brand} ${emulsion.developmentProcess.label} ${emulsion.isoSpeed}`.toLowerCase();
+      return haystack.includes(query);
+    });
+  });
+
   return {
     emulsions,
     currentEmulsion,
@@ -139,10 +155,14 @@ export const useEmulsionStore = defineStore('emulsions', () => {
     isLoadingEmulsionDetail,
     loadError,
     emulsionDetailError,
+    emulsionSearch,
+    emulsionProcessFilter,
+    filteredEmulsions,
     loadAll,
     loadEmulsion,
     createEmulsion,
     updateEmulsion,
-    deleteEmulsion
+    deleteEmulsion,
+    setProcessFilterFromMeta
   };
 });


### PR DESCRIPTION
## Summary

- Adds `emulsionSearch`, `emulsionProcessFilter`, and `filteredEmulsions` to the emulsion store
- Removes duplicate `search`, `processFilterCode`, and `rows` computed from all 7 emulsion pages
- Format pages set `emulsionProcessFilter` on mount from `route.meta.developmentProcessFilter`
- Filter state now persists when navigating between emulsion category tabs

## Test plan
- [ ] `pnpm exec vue-tsc --noEmit` passes
- [ ] `pnpm run test` passes
- [ ] `pnpm run build` succeeds