### PR TITLE
refactor(ui): delete dead composable wrappers and extract shared deviceLabel

### DIFF
--- a/apps/ui/src/components/DeviceList.vue
+++ b/apps/ui/src/components/DeviceList.vue
@@ -3,7 +3,7 @@
 import { computed, onMounted, ref } from 'vue';
 import { useRoute } from 'vue-router';
 import { type FilmDevice, filmFormatDefinitions } from '@frollz2/schema';
-import { useDeviceStore } from '../stores/devices.js';
+import { useDeviceStore, deviceLabel } from '../stores/devices.js';
 import { useReferenceStore } from '../stores/reference.js';
 import CreateDeviceDialog from './CreateDeviceDialog.vue';
 
@@ -66,18 +66,6 @@ const columns = [
     align: 'left'
   }
 ];
-
-function deviceLabel(device: FilmDevice): string {
-  if (device.deviceTypeCode === 'camera') {
-    return `${device.make} ${device.model}`;
-  }
-
-  if (device.deviceTypeCode === 'film_holder') {
-    return `${device.brand} ${device.name}`;
-  }
-
-  return device.name;
-}
 
 onMounted(async () => {
   await Promise.allSettled([referenceStore.loadAll(), deviceStore.loadDevices()]);

--- a/apps/ui/src/components/film-event-forms/LoadedEventForm.vue
+++ b/apps/ui/src/components/film-event-forms/LoadedEventForm.vue
@@ -4,7 +4,7 @@ import { useRegleSchema } from '@regle/schemas';
 import type { CreateFilmJourneyEventRequest } from '@frollz2/schema';
 import { z } from 'zod';
 import { idSchema } from '@frollz2/schema';
-import { useDeviceStore } from '../../stores/devices.js';
+import { useDeviceStore, deviceLabel } from '../../stores/devices.js';
 import { useReferenceStore } from '../../stores/reference.js';
 
 interface Props {
@@ -41,14 +41,8 @@ const deviceOptions = computed(() => {
       const typeLabel = referenceStore.deviceTypes.find(
         (t) => t.code === d.deviceTypeCode
       )?.label ?? d.deviceTypeCode;
-      let displayName = '';
-      if (d.deviceTypeCode === 'camera') {
-        displayName = `${d.make} ${d.model}`;
-      } else {
-        displayName = d.name;
-      }
       return {
-        label: `${displayName} (${typeLabel})`,
+        label: `${deviceLabel(d)} (${typeLabel})`,
         value: d.id,
       };
     });

--- a/apps/ui/src/composables/useAuth.ts
+++ b/apps/ui/src/composables/useAuth.ts
@@ -1,9 +1,0 @@
-import { useAuthStore } from '../stores/auth.js';
-
-export function useAuth() {
-  const authStore = useAuthStore();
-
-  return {
-    authStore
-  };
-}

--- a/apps/ui/src/composables/useEmulsionStore.ts
+++ b/apps/ui/src/composables/useEmulsionStore.ts
@@ -1,5 +1,0 @@
-import { useEmulsionStore } from '../stores/emulsions.js';
-
-export function useEmulsions() {
-  return useEmulsionStore();
-}

--- a/apps/ui/src/composables/useReferenceStore.ts
+++ b/apps/ui/src/composables/useReferenceStore.ts
@@ -1,5 +1,0 @@
-import { useReferenceStore } from '../stores/reference.js';
-
-export function useReferenceData() {
-  return useReferenceStore();
-}

--- a/apps/ui/src/pages/devices/[id].vue
+++ b/apps/ui/src/pages/devices/[id].vue
@@ -3,12 +3,15 @@
 import { computed, onMounted, watch } from 'vue';
 import { useRoute } from 'vue-router';
 import type { DeviceLoadTimelineEvent, FilmHolderSlot } from '@frollz2/schema';
-import { useDeviceStore } from '../../stores/devices.js';
+import { useDeviceStore, deviceLabel } from '../../stores/devices.js';
 
 const route = useRoute();
 const deviceStore = useDeviceStore();
 
 const deviceId = computed(() => Number(route.params.id));
+const currentDeviceLabel = computed(() =>
+  deviceStore.currentDevice ? deviceLabel(deviceStore.currentDevice) : ''
+);
 
 const timelineColumns = [
   {
@@ -59,24 +62,6 @@ const slotColumns = [
   }
 ];
 
-function deviceLabel(): string {
-  const device = deviceStore.currentDevice;
-
-  if (!device) {
-    return '';
-  }
-
-  if (device.deviceTypeCode === 'camera') {
-    return `${device.make} ${device.model}`;
-  }
-
-  if (device.deviceTypeCode === 'film_holder') {
-    return `${device.brand} ${device.name}`;
-  }
-
-  return device.name;
-}
-
 async function load(): Promise<void> {
   if (!Number.isFinite(deviceId.value)) {
     return;
@@ -99,7 +84,7 @@ watch(deviceId, load);
 
     <q-card v-if="deviceStore.currentDevice" flat bordered>
       <q-card-section>
-        <div class="text-h5">{{ deviceLabel() }}</div>
+        <div class="text-h5">{{ currentDeviceLabel }}</div>
         <div class="text-subtitle2 text-grey-7">{{ deviceStore.currentDevice.deviceTypeCode }}</div>
       </q-card-section>
       <q-separator />

--- a/apps/ui/src/stores/devices.ts
+++ b/apps/ui/src/stores/devices.ts
@@ -151,3 +151,9 @@ export const useDeviceStore = defineStore('device', () => {
     deleteDevice
   };
 });
+
+export function deviceLabel(device: FilmDevice): string {
+  if (device.deviceTypeCode === 'camera') return `${device.make} ${device.model}`;
+  if (device.deviceTypeCode === 'film_holder') return `${device.brand} ${device.name}`;
+  return device.name;
+}


### PR DESCRIPTION
## Summary

- Deletes three never-imported thin-wrapper composables: `useAuth.ts`, `useEmulsionStore.ts`, `useReferenceStore.ts`
- Extracts the copy-pasted `deviceLabel` function into a named export on `stores/devices.ts`
- Updates `DeviceList.vue`, `pages/devices/[id].vue`, and `LoadedEventForm.vue` to import the shared helper

## Test plan
- [ ] `pnpm exec vue-tsc --noEmit` passes
- [ ] `pnpm run test` passes
- [ ] `pnpm run build` succeeds