### PR TITLE
refactor(ui): extract useCrudDialog, film filter state, and cost formatting composable

### DIFF
--- a/apps/ui/src/composables/useCrudDialog.ts
+++ b/apps/ui/src/composables/useCrudDialog.ts
@@ -1,0 +1,40 @@
+import { ref } from 'vue';
+
+export function useCrudDialog() {
+  const isDialogOpen = ref(false);
+  const isSaving = ref(false);
+  const archiveTarget = ref<{ id: number; name: string } | null>(null);
+
+  function openForCreate(reset: () => void): void {
+    reset();
+    isDialogOpen.value = true;
+  }
+
+  function openForEdit(populate: () => void): void {
+    populate();
+    isDialogOpen.value = true;
+  }
+
+  function closeDialog(): void {
+    isDialogOpen.value = false;
+  }
+
+  function beginArchive(id: number, name: string): void {
+    archiveTarget.value = { id, name };
+  }
+
+  function cancelArchive(): void {
+    archiveTarget.value = null;
+  }
+
+  return {
+    isDialogOpen,
+    isSaving,
+    archiveTarget,
+    openForCreate,
+    openForEdit,
+    closeDialog,
+    beginArchive,
+    cancelArchive,
+  };
+}

--- a/apps/ui/src/composables/useFilmCostFormatting.ts
+++ b/apps/ui/src/composables/useFilmCostFormatting.ts
@@ -1,0 +1,26 @@
+import type { FilmSummary } from '@frollz2/schema';
+
+type CostFields = Pick<FilmSummary, 'purchaseCostAllocated' | 'developmentCost'>;
+
+export function useFilmCostFormatting() {
+  function formatCost(cost: { amount: number; currencyCode: string } | null | undefined): string {
+    if (!cost) return 'Not recorded';
+    return `${cost.currencyCode} ${cost.amount.toFixed(2)}`;
+  }
+
+  function formatKnownCost(film: CostFields): string {
+    const purchase = film.purchaseCostAllocated;
+    const development = film.developmentCost;
+    if (!purchase && !development) return 'Not recorded';
+
+    if (purchase && development && purchase.currencyCode === development.currencyCode) {
+      return formatCost({ amount: purchase.amount + development.amount, currencyCode: purchase.currencyCode });
+    }
+    if (purchase && development) {
+      return `${formatCost(purchase)} + ${formatCost(development)}`;
+    }
+    return formatCost(purchase ?? development);
+  }
+
+  return { formatCost, formatKnownCost };
+}

--- a/apps/ui/src/pages/admin/film-labs.vue
+++ b/apps/ui/src/pages/admin/film-labs.vue
@@ -3,13 +3,22 @@
 import { computed, onMounted, reactive, ref } from 'vue';
 import { useFilmLabsStore } from '../../stores/film-labs.js';
 import { useUiFeedback } from '../../composables/useUiFeedback.js';
+import { useCrudDialog } from '../../composables/useCrudDialog.js';
 
 const filmLabsStore = useFilmLabsStore();
 const feedback = useUiFeedback();
+const {
+  isDialogOpen: isLabDialogOpen,
+  isSaving,
+  archiveTarget,
+  openForCreate,
+  openForEdit,
+  closeDialog,
+  beginArchive,
+  cancelArchive,
+} = useCrudDialog();
 const includeInactive = ref(false);
 const query = ref('');
-const isLabDialogOpen = ref(false);
-const archiveTarget = ref<{ id: number; name: string } | null>(null);
 const form = reactive({
   id: null as number | null,
   name: '',
@@ -20,7 +29,6 @@ const form = reactive({
   notes: '',
   rating: null as number | null
 });
-const isSaving = ref(false);
 const ratingModel = computed({
   get: () => form.rating ?? 0,
   set: (value: number) => {
@@ -33,29 +41,31 @@ async function loadLabs(): Promise<void> {
 }
 
 function beginCreate(): void {
-  form.id = null;
-  form.name = '';
-  form.contact = '';
-  form.email = '';
-  form.website = '';
-  form.defaultProcesses = '';
-  form.notes = '';
-  form.rating = null;
-  isLabDialogOpen.value = true;
+  openForCreate(() => {
+    form.id = null;
+    form.name = '';
+    form.contact = '';
+    form.email = '';
+    form.website = '';
+    form.defaultProcesses = '';
+    form.notes = '';
+    form.rating = null;
+  });
 }
 
 function beginEdit(id: number): void {
   const lab = filmLabsStore.filmLabs.find((item) => item.id === id);
   if (!lab) return;
-  form.id = lab.id;
-  form.name = lab.name;
-  form.contact = lab.contact ?? '';
-  form.email = lab.email ?? '';
-  form.website = lab.website ?? '';
-  form.defaultProcesses = lab.defaultProcesses ?? '';
-  form.notes = lab.notes ?? '';
-  form.rating = lab.rating;
-  isLabDialogOpen.value = true;
+  openForEdit(() => {
+    form.id = lab.id;
+    form.name = lab.name;
+    form.contact = lab.contact ?? '';
+    form.email = lab.email ?? '';
+    form.website = lab.website ?? '';
+    form.defaultProcesses = lab.defaultProcesses ?? '';
+    form.notes = lab.notes ?? '';
+    form.rating = lab.rating;
+  });
 }
 
 async function save(): Promise<void> {
@@ -77,7 +87,7 @@ async function save(): Promise<void> {
     } else {
       await filmLabsStore.createFilmLab(payload);
     }
-    isLabDialogOpen.value = false;
+    closeDialog();
     form.id = null;
     feedback.success(isEditing ? 'Lab updated.' : 'Lab created.');
     await loadLabs();
@@ -88,16 +98,16 @@ async function save(): Promise<void> {
   }
 }
 
-function beginArchive(id: number): void {
+function startArchive(id: number): void {
   const lab = filmLabsStore.filmLabs.find((item) => item.id === id);
   if (!lab) return;
-  archiveTarget.value = { id, name: lab.name };
+  beginArchive(id, lab.name);
 }
 
 async function confirmArchive(): Promise<void> {
   if (!archiveTarget.value) return;
   const { id } = archiveTarget.value;
-  archiveTarget.value = null;
+  cancelArchive();
   try {
     await filmLabsStore.updateFilmLab(id, { active: false });
     await loadLabs();
@@ -161,7 +171,7 @@ onMounted(async () => {
       <template #body-cell-actions="props">
         <q-td :props="props" class="row q-gutter-xs">
           <q-btn flat dense color="primary" label="Edit" @click="beginEdit(props.row.id)" />
-          <q-btn v-if="props.row.active" flat dense color="negative" label="Archive" @click="beginArchive(props.row.id)" />
+          <q-btn v-if="props.row.active" flat dense color="negative" label="Archive" @click="startArchive(props.row.id)" />
           <q-btn v-else flat dense color="positive" label="Restore" @click="restore(props.row.id)" />
         </q-td>
       </template>
@@ -188,14 +198,14 @@ onMounted(async () => {
       </q-card>
     </q-dialog>
 
-    <q-dialog :model-value="archiveTarget !== null" @update:model-value="archiveTarget = null">
+    <q-dialog :model-value="archiveTarget !== null" @update:model-value="cancelArchive">
       <q-card>
         <q-card-section class="text-h6">Archive lab</q-card-section>
         <q-card-section>
           Archive <strong>{{ archiveTarget?.name }}</strong>? It will be hidden but can be restored later.
         </q-card-section>
         <q-card-actions align="right">
-          <q-btn flat label="Cancel" @click="archiveTarget = null" />
+          <q-btn flat label="Cancel" @click="cancelArchive" />
           <q-btn color="negative" label="Archive" @click="confirmArchive" />
         </q-card-actions>
       </q-card>

--- a/apps/ui/src/pages/admin/film-suppliers.vue
+++ b/apps/ui/src/pages/admin/film-suppliers.vue
@@ -4,13 +4,22 @@ import { computed, onMounted, reactive, ref } from 'vue';
 import { useFilmSuppliersStore } from '../../stores/film-suppliers.js';
 import { useUiFeedback } from '../../composables/useUiFeedback.js';
 import { createIdempotencyKey } from '../../composables/idempotency.js';
+import { useCrudDialog } from '../../composables/useCrudDialog.js';
 
 const filmSuppliersStore = useFilmSuppliersStore();
 const feedback = useUiFeedback();
+const {
+  isDialogOpen: isSupplierDialogOpen,
+  isSaving,
+  archiveTarget,
+  openForCreate,
+  openForEdit,
+  closeDialog,
+  beginArchive,
+  cancelArchive,
+} = useCrudDialog();
 const includeInactive = ref(false);
 const query = ref('');
-const isSupplierDialogOpen = ref(false);
-const archiveTarget = ref<{ id: number; name: string } | null>(null);
 const form = reactive({
   id: null as number | null,
   name: '',
@@ -20,7 +29,6 @@ const form = reactive({
   notes: '',
   rating: null as number | null
 });
-const isSaving = ref(false);
 const createIdempotency = ref(createIdempotencyKey());
 const ratingModel = computed({
   get: () => form.rating ?? 0,
@@ -34,28 +42,30 @@ async function loadSuppliers(): Promise<void> {
 }
 
 function beginCreate(): void {
-  form.id = null;
-  form.name = '';
-  form.contact = '';
-  form.email = '';
-  form.website = '';
-  form.notes = '';
-  form.rating = null;
-  createIdempotency.value = createIdempotencyKey();
-  isSupplierDialogOpen.value = true;
+  openForCreate(() => {
+    form.id = null;
+    form.name = '';
+    form.contact = '';
+    form.email = '';
+    form.website = '';
+    form.notes = '';
+    form.rating = null;
+    createIdempotency.value = createIdempotencyKey();
+  });
 }
 
 function beginEdit(id: number): void {
   const supplier = filmSuppliersStore.filmSuppliers.find((item) => item.id === id);
   if (!supplier) return;
-  form.id = supplier.id;
-  form.name = supplier.name;
-  form.contact = supplier.contact ?? '';
-  form.email = supplier.email ?? '';
-  form.website = supplier.website ?? '';
-  form.notes = supplier.notes ?? '';
-  form.rating = supplier.rating;
-  isSupplierDialogOpen.value = true;
+  openForEdit(() => {
+    form.id = supplier.id;
+    form.name = supplier.name;
+    form.contact = supplier.contact ?? '';
+    form.email = supplier.email ?? '';
+    form.website = supplier.website ?? '';
+    form.notes = supplier.notes ?? '';
+    form.rating = supplier.rating;
+  });
 }
 
 async function save(): Promise<void> {
@@ -77,7 +87,7 @@ async function save(): Promise<void> {
     } else {
       await filmSuppliersStore.createFilmSupplier(payload, createIdempotency.value);
     }
-    isSupplierDialogOpen.value = false;
+    closeDialog();
     form.id = null;
     feedback.success(isEditing ? 'Supplier updated.' : 'Supplier created.');
     await loadSuppliers();
@@ -88,16 +98,16 @@ async function save(): Promise<void> {
   }
 }
 
-function beginArchive(id: number): void {
+function startArchive(id: number): void {
   const supplier = filmSuppliersStore.filmSuppliers.find((item) => item.id === id);
   if (!supplier) return;
-  archiveTarget.value = { id, name: supplier.name };
+  beginArchive(id, supplier.name);
 }
 
 async function confirmArchive(): Promise<void> {
   if (!archiveTarget.value) return;
   const { id } = archiveTarget.value;
-  archiveTarget.value = null;
+  cancelArchive();
   try {
     await filmSuppliersStore.updateFilmSupplier(id, { active: false });
     if (!includeInactive.value) {
@@ -161,7 +171,7 @@ onMounted(async () => {
       <template #body-cell-actions="props">
         <q-td :props="props" class="row q-gutter-xs">
           <q-btn flat dense color="primary" label="Edit" @click="beginEdit(props.row.id)" />
-          <q-btn v-if="props.row.active" flat dense color="negative" label="Archive" @click="beginArchive(props.row.id)" />
+          <q-btn v-if="props.row.active" flat dense color="negative" label="Archive" @click="startArchive(props.row.id)" />
           <q-btn v-else flat dense color="positive" label="Restore" @click="restore(props.row.id)" />
         </q-td>
       </template>
@@ -188,14 +198,14 @@ onMounted(async () => {
       </q-card>
     </q-dialog>
 
-    <q-dialog :model-value="archiveTarget !== null" @update:model-value="archiveTarget = null">
+    <q-dialog :model-value="archiveTarget !== null" @update:model-value="cancelArchive">
       <q-card>
         <q-card-section class="text-h6">Archive supplier</q-card-section>
         <q-card-section>
           Archive <strong>{{ archiveTarget?.name }}</strong>? It will be hidden but can be restored later.
         </q-card-section>
         <q-card-actions align="right">
-          <q-btn flat label="Cancel" @click="archiveTarget = null" />
+          <q-btn flat label="Cancel" @click="cancelArchive" />
           <q-btn color="negative" label="Archive" @click="confirmArchive" />
         </q-card-actions>
       </q-card>

--- a/apps/ui/src/pages/film/35mm.vue
+++ b/apps/ui/src/pages/film/35mm.vue
@@ -1,12 +1,13 @@
 <!-- eslint-disable vue/multi-word-component-names -->
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue';
+import { computed, onMounted } from 'vue';
 import type { FilmSummary } from '@frollz2/schema';
 import FilmCreateDialog from '../../components/FilmCreateDialog.vue';
 import FilmInventoryTable from '../../components/FilmInventoryTable.vue';
 import { useFilmStore } from '../../stores/film.js';
 import { useReferenceStore } from '../../stores/reference.js';
 import { useFilmCreateForm } from '../../composables/useFilmCreateForm.js';
+import { useFilmCostFormatting } from '../../composables/useFilmCostFormatting.js';
 
 const filmStore = useFilmStore();
 const referenceStore = useReferenceStore();
@@ -20,8 +21,7 @@ const {
   handleCreate,
 } = useFilmCreateForm();
 
-const search = ref<string | null>('');
-const stateFilter = ref<string | null>(null);
+const { formatKnownCost } = useFilmCostFormatting();
 
 const subtitle = computed(() =>
   lockedFormatFilters.value.length > 0
@@ -29,49 +29,11 @@ const subtitle = computed(() =>
     : 'Track film stock and move rolls through state transitions.'
 );
 
-const rows = computed(() => {
-  const query = (search.value ?? '').trim().toLowerCase();
-
-  return filmStore.films.filter((film) => {
-    if (lockedFormatFilters.value.length > 0 && !lockedFormatFilters.value.includes(film.filmFormat.code)) {
-      return false;
-    }
-
-    if (stateFilter.value && film.currentStateCode !== stateFilter.value) {
-      return false;
-    }
-
-    if (!query) {
-      return true;
-    }
-
-    const haystack = `${film.name} ${film.emulsion.manufacturer} ${film.emulsion.brand} ${film.currentState.label}`.toLowerCase();
-    return haystack.includes(query);
-  });
-});
-
 const extractName = (row: FilmSummary) => row.name;
 const extractState = (row: FilmSummary) => row.currentState.label;
 const extractEmulsion = (row: FilmSummary) => `${row.emulsion.manufacturer} ${row.emulsion.brand}`;
 const extractFormat = (row: FilmSummary) => row.filmFormat.label;
 const extractIso = (row: FilmSummary) => row.emulsion.isoSpeed.toString();
-const extractKnownCost = (row: FilmSummary) => {
-  const purchase = row.purchaseCostAllocated;
-  const development = row.developmentCost;
-  if (!purchase && !development) {
-    return 'Not recorded';
-  }
-
-  const format = (amount: number, code: string) => `${code} ${amount.toFixed(2)}`;
-  if (purchase && development && purchase.currencyCode === development.currencyCode) {
-    return format(purchase.amount + development.amount, purchase.currencyCode);
-  }
-  if (purchase && development) {
-    return `${format(purchase.amount, purchase.currencyCode)} + ${format(development.amount, development.currencyCode)}`;
-  }
-  const value = purchase ?? development;
-  return value ? format(value.amount, value.currencyCode) : 'Not recorded';
-};
 
 const stateOptions = computed(() =>
   referenceStore.filmStates.map((state) => ({
@@ -81,6 +43,7 @@ const stateOptions = computed(() =>
 );
 
 onMounted(async () => {
+  filmStore.filmListLockedFormats = lockedFormatFilters.value;
   await Promise.allSettled([referenceStore.loadAll(), filmStore.loadFilms()]);
 });
 </script>
@@ -103,23 +66,23 @@ onMounted(async () => {
 
     <div class="row q-pa-md q-col-gutter-md">
       <div class="col-xs-12 col-lg-6">
-        <q-input v-model="search" filled clearable label="Search films" />
+        <q-input v-model="filmStore.filmListSearch" filled clearable label="Search films" />
       </div>
       <div class="col-xs-12 col-lg-6">
-        <q-select v-model="stateFilter" filled clearable emit-value map-options :options="stateOptions"
+        <q-select v-model="filmStore.filmListStateFilter" filled clearable emit-value map-options :options="stateOptions"
           label="Filter by state" />
       </div>
     </div>
 
     <FilmInventoryTable
-      :rows="rows"
+      :rows="filmStore.filteredFilms"
       :is-loading="filmStore.isLoading"
       :extract-name="extractName"
       :extract-state="extractState"
       :extract-emulsion="extractEmulsion"
       :extract-format="extractFormat"
       :extract-iso="extractIso"
-      :extract-known-cost="extractKnownCost"
+      :extract-known-cost="formatKnownCost"
     />
 
     <FilmCreateDialog

--- a/apps/ui/src/pages/film/[id].vue
+++ b/apps/ui/src/pages/film/[id].vue
@@ -8,6 +8,7 @@ import { useReferenceStore } from '../../stores/reference.js';
 import { useDeviceStore } from '../../stores/devices.js';
 import FilmEventForm from '../../components/FilmEventForm.vue';
 import { filmTransitionMap } from '@frollz2/schema';
+import { useFilmCostFormatting } from '../../composables/useFilmCostFormatting.js';
 
 const route = useRoute();
 const filmStore = useFilmStore();
@@ -21,28 +22,7 @@ const frameColumns = [
   { name: 'state', label: 'State', field: (row: FilmFrame) => row.currentStateCode, align: 'left' as const }
 ];
 
-function formatCost(cost: { amount: number; currencyCode: string } | null): string {
-  if (!cost) {
-    return 'Not recorded';
-  }
-  return `${cost.currencyCode} ${cost.amount.toFixed(2)}`;
-}
-
-function formatKnownCost(): string {
-  const film = filmStore.currentFilm;
-  if (!film) {
-    return 'Not recorded';
-  }
-  const purchase = film.purchaseCostAllocated;
-  const development = film.developmentCost;
-  if (!purchase && !development) {
-    return 'Not recorded';
-  }
-  if (purchase && development && purchase.currencyCode === development.currencyCode) {
-    return `${purchase.currencyCode} ${(purchase.amount + development.amount).toFixed(2)}`;
-  }
-  return `${formatCost(purchase)} + ${formatCost(development)}`;
-}
+const { formatCost, formatKnownCost } = useFilmCostFormatting();
 
 async function load(): Promise<void> {
   if (!Number.isFinite(filmId.value)) {
@@ -89,7 +69,7 @@ watch(filmId, load);
           formatCost(filmStore.currentFilm.purchaseCostAllocated) }}</div>
         <div class="col-12 col-md-6"><span class="text-grey-7">Development cost:</span> {{
           formatCost(filmStore.currentFilm.developmentCost) }}</div>
-        <div class="col-12 col-md-6"><span class="text-grey-7">Known total cost:</span> {{ formatKnownCost() }}</div>
+        <div class="col-12 col-md-6"><span class="text-grey-7">Known total cost:</span> {{ formatKnownCost(filmStore.currentFilm!) }}</div>
       </q-card-section>
     </q-card>
 

--- a/apps/ui/src/pages/film/index.vue
+++ b/apps/ui/src/pages/film/index.vue
@@ -1,12 +1,13 @@
 <!-- eslint-disable vue/multi-word-component-names -->
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue';
+import { computed, onMounted } from 'vue';
 import type { FilmSummary } from '@frollz2/schema';
 import FilmCreateDialog from '../../components/FilmCreateDialog.vue';
 import FilmInventoryTable from '../../components/FilmInventoryTable.vue';
 import { useFilmStore } from '../../stores/film.js';
 import { useReferenceStore } from '../../stores/reference.js';
 import { useFilmCreateForm } from '../../composables/useFilmCreateForm.js';
+import { useFilmCostFormatting } from '../../composables/useFilmCostFormatting.js';
 import { useFilmSuppliersStore } from '../../stores/film-suppliers.js';
 
 const filmStore = useFilmStore();
@@ -22,9 +23,7 @@ const {
   handleCreate,
 } = useFilmCreateForm();
 
-const search = ref<string | null>('');
-const stateFilter = ref<string | null>(null);
-const supplierFilter = ref<number | null>(null);
+const { formatKnownCost } = useFilmCostFormatting();
 
 const subtitle = computed(() =>
   lockedFormatFilters.value.length > 0
@@ -32,52 +31,11 @@ const subtitle = computed(() =>
     : 'Track film stock and move rolls through state transitions.'
 );
 
-const rows = computed(() => {
-  const query = (search.value ?? '').trim().toLowerCase();
-
-  return filmStore.films.filter((film) => {
-    if (lockedFormatFilters.value.length > 0 && !lockedFormatFilters.value.includes(film.filmFormat.code)) {
-      return false;
-    }
-
-    if (stateFilter.value && film.currentStateCode !== stateFilter.value) {
-      return false;
-    }
-    if (supplierFilter.value && film.supplierId !== supplierFilter.value) {
-      return false;
-    }
-
-    if (!query) {
-      return true;
-    }
-
-    const haystack = `${film.name} ${film.emulsion.manufacturer} ${film.emulsion.brand} ${film.currentState.label}`.toLowerCase();
-    return haystack.includes(query);
-  });
-});
-
 const extractName = (row: FilmSummary) => row.name;
 const extractState = (row: FilmSummary) => row.currentState.label;
 const extractEmulsion = (row: FilmSummary) => `${row.emulsion.manufacturer} ${row.emulsion.brand}`;
 const extractFormat = (row: FilmSummary) => row.filmFormat.label;
 const extractIso = (row: FilmSummary) => row.emulsion.isoSpeed.toString();
-const extractKnownCost = (row: FilmSummary) => {
-  const purchase = row.purchaseCostAllocated;
-  const development = row.developmentCost;
-  if (!purchase && !development) {
-    return 'Not recorded';
-  }
-
-  const format = (amount: number, code: string) => `${code} ${amount.toFixed(2)}`;
-  if (purchase && development && purchase.currencyCode === development.currencyCode) {
-    return format(purchase.amount + development.amount, purchase.currencyCode);
-  }
-  if (purchase && development) {
-    return `${format(purchase.amount, purchase.currencyCode)} + ${format(development.amount, development.currencyCode)}`;
-  }
-  const value = purchase ?? development;
-  return value ? format(value.amount, value.currencyCode) : 'Not recorded';
-};
 
 const stateOptions = computed(() =>
   referenceStore.filmStates.map((state) => ({ label: state.label, value: state.code }))
@@ -87,6 +45,7 @@ const supplierOptions = computed(() =>
 );
 
 onMounted(async () => {
+  filmStore.filmListLockedFormats = lockedFormatFilters.value;
   await Promise.allSettled([referenceStore.loadAll(), filmStore.loadFilms(), filmSuppliersStore.loadFilmSuppliers()]);
 });
 </script>
@@ -109,27 +68,27 @@ onMounted(async () => {
 
     <div class="row q-col-gutter-md">
       <div class="col-xs-12 col-lg-6">
-        <q-input v-model="search" filled clearable label="Search films" />
+        <q-input v-model="filmStore.filmListSearch" filled clearable label="Search films" />
       </div>
       <div class="col-xs-12 col-lg-6">
-        <q-select v-model="stateFilter" filled clearable emit-value map-options :options="stateOptions"
+        <q-select v-model="filmStore.filmListStateFilter" filled clearable emit-value map-options :options="stateOptions"
           label="Filter by state" />
       </div>
       <div class="col-xs-12 col-lg-6">
-        <q-select v-model="supplierFilter" filled clearable emit-value map-options :options="supplierOptions"
+        <q-select v-model="filmStore.filmListSupplierFilter" filled clearable emit-value map-options :options="supplierOptions"
           label="Filter by supplier" />
       </div>
     </div>
 
     <FilmInventoryTable
-      :rows="rows"
+      :rows="filmStore.filteredFilms"
       :is-loading="filmStore.isLoading"
       :extract-name="extractName"
       :extract-state="extractState"
       :extract-emulsion="extractEmulsion"
       :extract-format="extractFormat"
       :extract-iso="extractIso"
-      :extract-known-cost="extractKnownCost"
+      :extract-known-cost="formatKnownCost"
     />
 
     <FilmCreateDialog

--- a/apps/ui/src/pages/film/instant.vue
+++ b/apps/ui/src/pages/film/instant.vue
@@ -1,12 +1,13 @@
 <!-- eslint-disable vue/multi-word-component-names -->
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue';
+import { computed, onMounted } from 'vue';
 import type { FilmSummary } from '@frollz2/schema';
 import FilmCreateDialog from '../../components/FilmCreateDialog.vue';
 import FilmInventoryTable from '../../components/FilmInventoryTable.vue';
 import { useFilmStore } from '../../stores/film.js';
 import { useReferenceStore } from '../../stores/reference.js';
 import { useFilmCreateForm } from '../../composables/useFilmCreateForm.js';
+import { useFilmCostFormatting } from '../../composables/useFilmCostFormatting.js';
 
 const filmStore = useFilmStore();
 const referenceStore = useReferenceStore();
@@ -20,8 +21,7 @@ const {
   handleCreate,
 } = useFilmCreateForm();
 
-const search = ref<string | null>('');
-const stateFilter = ref<string | null>(null);
+const { formatKnownCost } = useFilmCostFormatting();
 
 const subtitle = computed(() =>
   lockedFormatFilters.value.length > 0
@@ -29,49 +29,11 @@ const subtitle = computed(() =>
     : 'Track film stock and move rolls through state transitions.'
 );
 
-const rows = computed(() => {
-  const query = (search.value ?? '').trim().toLowerCase();
-
-  return filmStore.films.filter((film) => {
-    if (lockedFormatFilters.value.length > 0 && !lockedFormatFilters.value.includes(film.filmFormat.code)) {
-      return false;
-    }
-
-    if (stateFilter.value && film.currentStateCode !== stateFilter.value) {
-      return false;
-    }
-
-    if (!query) {
-      return true;
-    }
-
-    const haystack = `${film.name} ${film.emulsion.manufacturer} ${film.emulsion.brand} ${film.currentState.label}`.toLowerCase();
-    return haystack.includes(query);
-  });
-});
-
 const extractName = (row: FilmSummary) => row.name;
 const extractState = (row: FilmSummary) => row.currentState.label;
 const extractEmulsion = (row: FilmSummary) => `${row.emulsion.manufacturer} ${row.emulsion.brand}`;
 const extractFormat = (row: FilmSummary) => row.filmFormat.label;
 const extractIso = (row: FilmSummary) => row.emulsion.isoSpeed.toString();
-const extractKnownCost = (row: FilmSummary) => {
-  const purchase = row.purchaseCostAllocated;
-  const development = row.developmentCost;
-  if (!purchase && !development) {
-    return 'Not recorded';
-  }
-
-  const format = (amount: number, code: string) => `${code} ${amount.toFixed(2)}`;
-  if (purchase && development && purchase.currencyCode === development.currencyCode) {
-    return format(purchase.amount + development.amount, purchase.currencyCode);
-  }
-  if (purchase && development) {
-    return `${format(purchase.amount, purchase.currencyCode)} + ${format(development.amount, development.currencyCode)}`;
-  }
-  const value = purchase ?? development;
-  return value ? format(value.amount, value.currencyCode) : 'Not recorded';
-};
 
 const stateOptions = computed(() =>
   referenceStore.filmStates.map((state) => ({
@@ -81,6 +43,7 @@ const stateOptions = computed(() =>
 );
 
 onMounted(async () => {
+  filmStore.filmListLockedFormats = lockedFormatFilters.value;
   await Promise.allSettled([referenceStore.loadAll(), filmStore.loadFilms()]);
 });
 </script>
@@ -103,23 +66,23 @@ onMounted(async () => {
 
     <div class="row q-pa-md q-col-gutter-md">
       <div class="col-xs-12 col-lg-6">
-        <q-input v-model="search" filled clearable label="Search films" />
+        <q-input v-model="filmStore.filmListSearch" filled clearable label="Search films" />
       </div>
       <div class="col-xs-12 col-lg-6">
-        <q-select v-model="stateFilter" filled clearable emit-value map-options :options="stateOptions"
+        <q-select v-model="filmStore.filmListStateFilter" filled clearable emit-value map-options :options="stateOptions"
           label="Filter by state" />
       </div>
     </div>
 
     <FilmInventoryTable
-      :rows="rows"
+      :rows="filmStore.filteredFilms"
       :is-loading="filmStore.isLoading"
       :extract-name="extractName"
       :extract-state="extractState"
       :extract-emulsion="extractEmulsion"
       :extract-format="extractFormat"
       :extract-iso="extractIso"
-      :extract-known-cost="extractKnownCost"
+      :extract-known-cost="formatKnownCost"
     />
 
     <FilmCreateDialog

--- a/apps/ui/src/pages/film/large-format.vue
+++ b/apps/ui/src/pages/film/large-format.vue
@@ -1,12 +1,13 @@
 <!-- eslint-disable vue/multi-word-component-names -->
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue';
+import { computed, onMounted } from 'vue';
 import type { FilmSummary } from '@frollz2/schema';
 import FilmCreateDialog from '../../components/FilmCreateDialog.vue';
 import FilmInventoryTable from '../../components/FilmInventoryTable.vue';
 import { useFilmStore } from '../../stores/film.js';
 import { useReferenceStore } from '../../stores/reference.js';
 import { useFilmCreateForm } from '../../composables/useFilmCreateForm.js';
+import { useFilmCostFormatting } from '../../composables/useFilmCostFormatting.js';
 
 const filmStore = useFilmStore();
 const referenceStore = useReferenceStore();
@@ -20,8 +21,7 @@ const {
   handleCreate,
 } = useFilmCreateForm();
 
-const search = ref<string | null>('');
-const stateFilter = ref<string | null>(null);
+const { formatKnownCost } = useFilmCostFormatting();
 
 const subtitle = computed(() =>
   lockedFormatFilters.value.length > 0
@@ -29,49 +29,11 @@ const subtitle = computed(() =>
     : 'Track film stock and move rolls through state transitions.'
 );
 
-const rows = computed(() => {
-  const query = (search.value ?? '').trim().toLowerCase();
-
-  return filmStore.films.filter((film) => {
-    if (lockedFormatFilters.value.length > 0 && !lockedFormatFilters.value.includes(film.filmFormat.code)) {
-      return false;
-    }
-
-    if (stateFilter.value && film.currentStateCode !== stateFilter.value) {
-      return false;
-    }
-
-    if (!query) {
-      return true;
-    }
-
-    const haystack = `${film.name} ${film.emulsion.manufacturer} ${film.emulsion.brand} ${film.currentState.label}`.toLowerCase();
-    return haystack.includes(query);
-  });
-});
-
 const extractName = (row: FilmSummary) => row.name;
 const extractState = (row: FilmSummary) => row.currentState.label;
 const extractEmulsion = (row: FilmSummary) => `${row.emulsion.manufacturer} ${row.emulsion.brand}`;
 const extractFormat = (row: FilmSummary) => row.filmFormat.label;
 const extractIso = (row: FilmSummary) => row.emulsion.isoSpeed.toString();
-const extractKnownCost = (row: FilmSummary) => {
-  const purchase = row.purchaseCostAllocated;
-  const development = row.developmentCost;
-  if (!purchase && !development) {
-    return 'Not recorded';
-  }
-
-  const format = (amount: number, code: string) => `${code} ${amount.toFixed(2)}`;
-  if (purchase && development && purchase.currencyCode === development.currencyCode) {
-    return format(purchase.amount + development.amount, purchase.currencyCode);
-  }
-  if (purchase && development) {
-    return `${format(purchase.amount, purchase.currencyCode)} + ${format(development.amount, development.currencyCode)}`;
-  }
-  const value = purchase ?? development;
-  return value ? format(value.amount, value.currencyCode) : 'Not recorded';
-};
 
 const stateOptions = computed(() =>
   referenceStore.filmStates.map((state) => ({
@@ -81,6 +43,7 @@ const stateOptions = computed(() =>
 );
 
 onMounted(async () => {
+  filmStore.filmListLockedFormats = lockedFormatFilters.value;
   await Promise.allSettled([referenceStore.loadAll(), filmStore.loadFilms()]);
 });
 </script>
@@ -103,23 +66,23 @@ onMounted(async () => {
 
     <div class="row q-pa-md q-col-gutter-md">
       <div class="col-xs-12 col-lg-6">
-        <q-input v-model="search" filled clearable label="Search films" />
+        <q-input v-model="filmStore.filmListSearch" filled clearable label="Search films" />
       </div>
       <div class="col-xs-12 col-lg-6">
-        <q-select v-model="stateFilter" filled clearable emit-value map-options :options="stateOptions"
+        <q-select v-model="filmStore.filmListStateFilter" filled clearable emit-value map-options :options="stateOptions"
           label="Filter by state" />
       </div>
     </div>
 
     <FilmInventoryTable
-      :rows="rows"
+      :rows="filmStore.filteredFilms"
       :is-loading="filmStore.isLoading"
       :extract-name="extractName"
       :extract-state="extractState"
       :extract-emulsion="extractEmulsion"
       :extract-format="extractFormat"
       :extract-iso="extractIso"
-      :extract-known-cost="extractKnownCost"
+      :extract-known-cost="formatKnownCost"
     />
 
     <FilmCreateDialog

--- a/apps/ui/src/pages/film/medium-format.vue
+++ b/apps/ui/src/pages/film/medium-format.vue
@@ -1,12 +1,13 @@
 <!-- eslint-disable vue/multi-word-component-names -->
 <script setup lang="ts">
-import { computed, onMounted, ref } from 'vue';
+import { computed, onMounted } from 'vue';
 import type { FilmSummary } from '@frollz2/schema';
 import FilmCreateDialog from '../../components/FilmCreateDialog.vue';
 import FilmInventoryTable from '../../components/FilmInventoryTable.vue';
 import { useFilmStore } from '../../stores/film.js';
 import { useReferenceStore } from '../../stores/reference.js';
 import { useFilmCreateForm } from '../../composables/useFilmCreateForm.js';
+import { useFilmCostFormatting } from '../../composables/useFilmCostFormatting.js';
 
 const filmStore = useFilmStore();
 const referenceStore = useReferenceStore();
@@ -20,8 +21,7 @@ const {
   handleCreate,
 } = useFilmCreateForm();
 
-const search = ref<string | null>('');
-const stateFilter = ref<string | null>(null);
+const { formatKnownCost } = useFilmCostFormatting();
 
 const subtitle = computed(() =>
   lockedFormatFilters.value.length > 0
@@ -29,49 +29,11 @@ const subtitle = computed(() =>
     : 'Track film stock and move rolls through state transitions.'
 );
 
-const rows = computed(() => {
-  const query = (search.value ?? '').trim().toLowerCase();
-
-  return filmStore.films.filter((film) => {
-    if (lockedFormatFilters.value.length > 0 && !lockedFormatFilters.value.includes(film.filmFormat.code)) {
-      return false;
-    }
-
-    if (stateFilter.value && film.currentStateCode !== stateFilter.value) {
-      return false;
-    }
-
-    if (!query) {
-      return true;
-    }
-
-    const haystack = `${film.name} ${film.emulsion.manufacturer} ${film.emulsion.brand} ${film.currentState.label}`.toLowerCase();
-    return haystack.includes(query);
-  });
-});
-
 const extractName = (row: FilmSummary) => row.name;
 const extractState = (row: FilmSummary) => row.currentState.label;
 const extractEmulsion = (row: FilmSummary) => `${row.emulsion.manufacturer} ${row.emulsion.brand}`;
 const extractFormat = (row: FilmSummary) => row.filmFormat.label;
 const extractIso = (row: FilmSummary) => row.emulsion.isoSpeed.toString();
-const extractKnownCost = (row: FilmSummary) => {
-  const purchase = row.purchaseCostAllocated;
-  const development = row.developmentCost;
-  if (!purchase && !development) {
-    return 'Not recorded';
-  }
-
-  const format = (amount: number, code: string) => `${code} ${amount.toFixed(2)}`;
-  if (purchase && development && purchase.currencyCode === development.currencyCode) {
-    return format(purchase.amount + development.amount, purchase.currencyCode);
-  }
-  if (purchase && development) {
-    return `${format(purchase.amount, purchase.currencyCode)} + ${format(development.amount, development.currencyCode)}`;
-  }
-  const value = purchase ?? development;
-  return value ? format(value.amount, value.currencyCode) : 'Not recorded';
-};
 
 const stateOptions = computed(() =>
   referenceStore.filmStates.map((state) => ({
@@ -81,6 +43,7 @@ const stateOptions = computed(() =>
 );
 
 onMounted(async () => {
+  filmStore.filmListLockedFormats = lockedFormatFilters.value;
   await Promise.allSettled([referenceStore.loadAll(), filmStore.loadFilms()]);
 });
 </script>
@@ -103,18 +66,18 @@ onMounted(async () => {
 
     <div class="row q-pa-md q-col-gutter-md">
       <div class="col-xs-12 col-lg-6">
-        <q-input v-model="search" filled clearable label="Search films" />
+        <q-input v-model="filmStore.filmListSearch" filled clearable label="Search films" />
       </div>
       <div class="col-xs-12 col-lg-6">
-        <q-select v-model="stateFilter" filled clearable emit-value map-options :options="stateOptions"
+        <q-select v-model="filmStore.filmListStateFilter" filled clearable emit-value map-options :options="stateOptions"
           label="Filter by state" />
       </div>
     </div>
 
-    <FilmInventoryTable :rows="rows" :is-loading="filmStore.isLoading" :extract-name="extractName"
+    <FilmInventoryTable :rows="filmStore.filteredFilms" :is-loading="filmStore.isLoading" :extract-name="extractName"
       :extract-state="extractState" :extract-emulsion="extractEmulsion" :extract-format="extractFormat"
       :extract-iso="extractIso"
-      :extract-known-cost="extractKnownCost" />
+      :extract-known-cost="formatKnownCost" />
 
     <FilmCreateDialog v-model="isCreateDialogOpen" :is-format-locked="isFormatLocked"
       :locked-format-filters="lockedFormatFilters" :is-creating="isCreating" @submit="handleCreate" />

--- a/apps/ui/src/stores/film.ts
+++ b/apps/ui/src/stores/film.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia';
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 import {
   createFrameJourneyEventRequestSchema,
   createFilmJourneyEventRequestSchema,
@@ -35,6 +35,23 @@ export const useFilmStore = defineStore('film', () => {
   const isDetailLoading = ref(false);
   const filmsError = ref<string | null>(null);
   const detailError = ref<string | null>(null);
+
+  const filmListSearch = ref<string>('');
+  const filmListStateFilter = ref<string | null>(null);
+  const filmListSupplierFilter = ref<number | null>(null);
+  const filmListLockedFormats = ref<string[]>([]);
+
+  const filteredFilms = computed(() => {
+    const query = filmListSearch.value.trim().toLowerCase();
+    return films.value.filter((film) => {
+      if (filmListLockedFormats.value.length > 0 && !filmListLockedFormats.value.includes(film.filmFormat.code)) return false;
+      if (filmListStateFilter.value && film.currentStateCode !== filmListStateFilter.value) return false;
+      if (filmListSupplierFilter.value !== null && film.supplierId !== filmListSupplierFilter.value) return false;
+      if (!query) return true;
+      const haystack = `${film.name} ${film.emulsion.manufacturer} ${film.emulsion.brand} ${film.currentState.label}`.toLowerCase();
+      return haystack.includes(query);
+    });
+  });
   let loadFilmsInFlight: Promise<void> | null = null;
   let loadFilmInFlight: Promise<void> | null = null;
   let loadFilmInFlightId: number | null = null;
@@ -210,6 +227,11 @@ export const useFilmStore = defineStore('film', () => {
     isDetailLoading,
     filmsError,
     detailError,
+    filmListSearch,
+    filmListStateFilter,
+    filmListSupplierFilter,
+    filmListLockedFormats,
+    filteredFilms,
     loadFilms,
     loadFilm,
     createFilm,

--- a/turbo.json
+++ b/turbo.json
@@ -20,10 +20,12 @@
       "persistent": true
     },
     "test": {
+      "cache": false,
       "dependsOn": ["build"],
       "outputs": []
     },
     "check-types": {
+      "cache": false,
       "dependsOn": ["^check-types"],
       "outputs": []
     },


### PR DESCRIPTION
## Summary

**Unit 4 — `useCrudDialog` composable:**
- New composable with `isDialogOpen`, `isSaving`, `archiveTarget`, `openForCreate`, `openForEdit`, `closeDialog`, `beginArchive`, `cancelArchive`
- Applied to `film-labs.vue` and `film-suppliers.vue`, removing ~40 lines of duplicated dialog/archive state per page

**Units 1+3 — Film filter state + cost formatting:**
- Adds `filmListSearch`, `filmListStateFilter`, `filmListSupplierFilter`, `filmListLockedFormats`, and `filteredFilms` computed to the film store
- All six film list pages bind to shared store state instead of maintaining local copies
- New `useFilmCostFormatting` composable with `formatCost` and `formatKnownCost`, replacing identical inline functions across all film pages
- Net: ~254 lines removed, 93 added across 8 files

**Misc:** Disables turbo cache for `test` and `check-types` tasks.

## Test plan

- [ ] Film inventory list — search, state filter, and supplier filter all work
- [ ] Format tabs (35mm, medium-format, large-format, instant) — locked format filter applies, cost column renders
- [ ] Film detail — cost display renders correctly
- [ ] Admin film labs — create, edit, archive, restore
- [ ] Admin film suppliers — create, edit, archive, restore
- [ ] `pnpm exec vue-tsc --noEmit` passes