### PR TITLE
feat(film): add per-frame exposure metadata (aperture, shutter, filter)

### DIFF
--- a/apps/api/src/infrastructure/entities/film-frame.entity.ts
+++ b/apps/api/src/infrastructure/entities/film-frame.entity.ts
@@ -15,6 +15,15 @@ export class FilmFrameEntity extends AutoIncrementEntity {
   @Property({ type: 'integer', fieldName: 'frame_number' })
   frameNumber!: number;
 
+  @Property({ type: 'float', fieldName: 'aperture', nullable: true })
+  aperture: number | null = null;
+
+  @Property({ type: 'float', fieldName: 'shutter_speed_seconds', nullable: true })
+  shutterSpeedSeconds: number | null = null;
+
+  @Property({ type: 'boolean', fieldName: 'filter_used', nullable: true })
+  filterUsed: boolean | null = null;
+
   @ManyToOne(() => FilmStateEntity, { fieldName: 'current_state_id' })
   currentState!: FilmStateEntity;
 }

--- a/apps/api/src/infrastructure/mappers/film.mapper.ts
+++ b/apps/api/src/infrastructure/mappers/film.mapper.ts
@@ -137,7 +137,10 @@ export function mapFilmFrameEntity(entity: FilmFrameEntity): FilmFrame {
     frameNumber: entity.frameNumber,
     currentStateId: entity.currentState.id,
     currentStateCode: filmStateSchema.shape.code.parse(entity.currentState.code),
-    currentState: mapFilmStateEntity(entity.currentState)
+    currentState: mapFilmStateEntity(entity.currentState),
+    aperture: entity.aperture,
+    shutterSpeedSeconds: entity.shutterSpeedSeconds,
+    filterUsed: entity.filterUsed
   };
 }
 

--- a/apps/api/src/infrastructure/migrations-postgres/Migration20260502200000.ts
+++ b/apps/api/src/infrastructure/migrations-postgres/Migration20260502200000.ts
@@ -1,0 +1,15 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260502200000 extends Migration {
+  override async up(): Promise<void> {
+    this.addSql('ALTER TABLE "film_frame" ADD COLUMN "aperture" double precision NULL;');
+    this.addSql('ALTER TABLE "film_frame" ADD COLUMN "shutter_speed_seconds" double precision NULL;');
+    this.addSql('ALTER TABLE "film_frame" ADD COLUMN "filter_used" boolean NULL;');
+  }
+
+  override async down(): Promise<void> {
+    this.addSql('ALTER TABLE "film_frame" DROP COLUMN "aperture";');
+    this.addSql('ALTER TABLE "film_frame" DROP COLUMN "shutter_speed_seconds";');
+    this.addSql('ALTER TABLE "film_frame" DROP COLUMN "filter_used";');
+  }
+}

--- a/apps/api/src/infrastructure/migrations/Migration20260502200000.ts
+++ b/apps/api/src/infrastructure/migrations/Migration20260502200000.ts
@@ -1,0 +1,9 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260502200000 extends Migration {
+  override async up(): Promise<void> {
+    this.addSql('ALTER TABLE `film_frame` ADD COLUMN `aperture` REAL NULL;');
+    this.addSql('ALTER TABLE `film_frame` ADD COLUMN `shutter_speed_seconds` REAL NULL;');
+    this.addSql('ALTER TABLE `film_frame` ADD COLUMN `filter_used` INTEGER NULL;');
+  }
+}

--- a/apps/api/src/infrastructure/repositories/film.repository.ts
+++ b/apps/api/src/infrastructure/repositories/film.repository.ts
@@ -6,7 +6,8 @@ import type {
   FilmListQuery,
   FilmListResponse,
   FilmSummary,
-  FilmUpdateRequest
+  FilmUpdateRequest,
+  UpdateFilmFrameRequest
 } from '@frollz2/schema';
 
 export abstract class FilmRepository {
@@ -21,6 +22,8 @@ export abstract class FilmRepository {
   abstract listEvents(userId: number, filmId: number): Promise<FilmJourneyEvent[]>;
 
   abstract listFrames(userId: number, filmId: number): Promise<FilmFrame[]>;
+
+  abstract updateFrame(userId: number, filmId: number, frameId: number, input: UpdateFilmFrameRequest): Promise<FilmFrame | null>;
 
   abstract listDeviceLoadEvents(userId: number, deviceId: number): Promise<DeviceLoadTimelineEvent[]>;
 

--- a/apps/api/src/infrastructure/repositories/mikro-orm-film.repository.ts
+++ b/apps/api/src/infrastructure/repositories/mikro-orm-film.repository.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { EntityManager } from '@mikro-orm/core';
-import type { DeviceLoadTimelineEvent, FilmListQuery } from '@frollz2/schema';
+import type { DeviceLoadTimelineEvent, FilmListQuery, UpdateFilmFrameRequest } from '@frollz2/schema';
 import { FilmRepository } from './film.repository.js';
 import { FilmEntity, FilmFrameEntity, FilmJourneyEventEntity } from '../entities/index.js';
 import { mapFilmDetailEntity, mapFilmFrameEntity, mapFilmJourneyEventEntity, mapFilmSummaryEntity, parseDevelopmentCost, parseLoadedEventData, formatEmulsionName } from '../mappers/index.js';
@@ -170,6 +170,31 @@ export class MikroOrmFilmRepository extends FilmRepository {
     );
 
     return frames.map(mapFilmFrameEntity);
+  }
+
+  async updateFrame(userId: number, filmId: number, frameId: number, input: UpdateFilmFrameRequest) {
+    const frame = await this.entityManager.findOne(
+      FilmFrameEntity,
+      { id: frameId, user: userId, film: filmId },
+      { populate: ['user', 'film', 'currentState'] }
+    );
+
+    if (!frame) {
+      return null;
+    }
+
+    if (input.aperture !== undefined) {
+      frame.aperture = input.aperture;
+    }
+    if (input.shutterSpeedSeconds !== undefined) {
+      frame.shutterSpeedSeconds = input.shutterSpeedSeconds;
+    }
+    if (input.filterUsed !== undefined) {
+      frame.filterUsed = input.filterUsed;
+    }
+
+    await this.entityManager.flush();
+    return mapFilmFrameEntity(frame);
   }
 
   async listDeviceLoadEvents(userId: number, deviceId: number): Promise<DeviceLoadTimelineEvent[]> {

--- a/apps/api/src/modules/film/film.controller.ts
+++ b/apps/api/src/modules/film/film.controller.ts
@@ -5,7 +5,8 @@ import {
   createFilmJourneyEventRequestSchema,
   filmLotCreateRequestSchema,
   filmListQuerySchema,
-  filmUpdateRequestSchema
+  filmUpdateRequestSchema,
+  updateFilmFrameRequestSchema
 } from '@frollz2/schema';
 import { ZodSchemaPipe } from '../../common/pipes/zod-schema.pipe.js';
 import { IdempotencyService } from '../../common/services/idempotency.service.js';
@@ -96,6 +97,18 @@ export class FilmController {
   @ApiResponse({ status: 200, description: 'Film frame list' })
   listFrames(@CurrentUser() user: AuthenticatedUser, @Param('id', ParseIntPipe) id: number) {
     return this.filmService.listFrames(user.userId, id);
+  }
+
+  @Patch(':id/frames/:frameId')
+  @ApiOperation({ summary: 'Update frame exposure metadata' })
+  @ApiResponse({ status: 200, description: 'Frame updated' })
+  updateFrame(
+    @CurrentUser() user: AuthenticatedUser,
+    @Param('id', ParseIntPipe) id: number,
+    @Param('frameId', ParseIntPipe) frameId: number,
+    @Body(new ZodSchemaPipe(updateFilmFrameRequestSchema)) body: typeof updateFilmFrameRequestSchema['_output']
+  ) {
+    return this.filmService.updateFrame(user.userId, id, frameId, body);
   }
 
   @Post(':id/frames/:frameId/events')

--- a/apps/api/src/modules/film/film.controller.ts
+++ b/apps/api/src/modules/film/film.controller.ts
@@ -106,9 +106,16 @@ export class FilmController {
     @CurrentUser() user: AuthenticatedUser,
     @Param('id', ParseIntPipe) id: number,
     @Param('frameId', ParseIntPipe) frameId: number,
+    @Headers('idempotency-key') idempotencyKey: string | undefined,
     @Body(new ZodSchemaPipe(updateFilmFrameRequestSchema)) body: typeof updateFilmFrameRequestSchema['_output']
   ) {
-    return this.filmService.updateFrame(user.userId, id, frameId, body);
+    return this.idempotencyService.execute({
+      userId: user.userId,
+      key: idempotencyKey,
+      scope: 'film.update-frame',
+      requestPayload: { filmId: id, frameId, ...body },
+      handler: () => this.filmService.updateFrame(user.userId, id, frameId, body)
+    });
   }
 
   @Post(':id/frames/:frameId/events')

--- a/apps/api/src/modules/film/film.service.ts
+++ b/apps/api/src/modules/film/film.service.ts
@@ -14,7 +14,8 @@ import type {
   FilmSupplier,
   FilmUpdateRequest,
   FrameJourneyEvent,
-  FrameSizeCode
+  FrameSizeCode,
+  UpdateFilmFrameRequest
 } from '@frollz2/schema';
 import { filmJourneyEventPayloadSchema, frameJourneyEventPayloadSchema, getFilmTypeForFormatCode, resolveNonLargeFrameCount } from '@frollz2/schema';
 import { DomainError } from '../../domain/errors.js';
@@ -166,6 +167,23 @@ export class FilmService {
     }
 
     return this.filmRepository.listFrames(userId, filmId);
+  }
+
+  async updateFrame(userId: number, filmId: number, frameId: number, input: UpdateFilmFrameRequest): Promise<FilmFrame> {
+    const film = await this.filmRepository.findByIdSummary(userId, filmId);
+    if (!film) {
+      throw new DomainError('NOT_FOUND', 'Film not found');
+    }
+    if (film.currentStateCode !== 'loaded') {
+      throw new DomainError('DOMAIN_ERROR', 'Frame metadata can only be updated while the film is loaded');
+    }
+
+    const updated = await this.filmRepository.updateFrame(userId, filmId, frameId, input);
+    if (!updated) {
+      throw new DomainError('NOT_FOUND', 'Frame not found');
+    }
+
+    return updated;
   }
 
   async createEvent(userId: number, filmId: number, input: CreateFilmJourneyEventRequest): Promise<FilmJourneyEvent> {

--- a/apps/ui/e2e/steps/film-inventory.steps.ts
+++ b/apps/ui/e2e/steps/film-inventory.steps.ts
@@ -92,8 +92,7 @@ When('I select the format {string}', async ({ page }, formatCode: string) => {
 When('I record the film as stored in {string}', async ({ page }, location: string) => {
   await page.getByLabel('Next state').click();
   await page.getByRole('option', { name: /stored/i }).click();
-  const localDateTime = new Date().toISOString().slice(0, 19);  // "2026-04-27T12:45:30"                                                                                           
-  await page.getByLabel('Occurred at').fill(localDateTime);
+  await page.getByLabel('Occurred at').fill(new Date().toISOString().slice(0, 10));
   await page.getByLabel('Storage location').click();
   await page.getByRole('option', { name: location, exact: false }).click();
   await page.getByRole('button', { name: /add event/i }).click();
@@ -102,8 +101,7 @@ When('I record the film as stored in {string}', async ({ page }, location: strin
 When('I record the film as loaded into device {string}', async ({ page }, deviceName: string) => {
   await page.getByLabel('Next state').click();
   await page.getByRole('option', { name: /loaded/i }).click();
-  const localDateTime = new Date().toISOString().slice(0, 19);
-  await page.getByLabel('Occurred at').fill(localDateTime);
+  await page.getByLabel('Occurred at').fill(new Date().toISOString().slice(0, 10));
 
   const deviceCombobox = page.getByRole('combobox', { name: 'Device', exact: true });
   await deviceCombobox.click();

--- a/apps/ui/src/components/CreateDeviceDialog.vue
+++ b/apps/ui/src/components/CreateDeviceDialog.vue
@@ -139,7 +139,7 @@ function reset(): void {
 
 watch(frameSizeOptions, (options) => {
   if (options.length === 0) return;
-  if (!options.includes(createForm.frameSize)) {
+  if (createForm.frameSize == null || !options.includes(createForm.frameSize)) {
     const next = options[0];
     if (!next) return;
     createForm.frameSize = next;
@@ -177,28 +177,28 @@ async function submit(): Promise<void> {
       loadMode: createForm.loadMode
     };
   } else if (createForm.deviceTypeCode === 'interchangeable_back') {
-    if (!createForm.name.trim() || !createForm.system.trim() || !createForm.filmFormatId) {
-      feedback.error('Name, system, and format are required.');
+    if (!createForm.name.trim() || !createForm.system.trim() || !createForm.filmFormatId || !createForm.frameSize) {
+      feedback.error('Name, system, format, and frame size are required.');
       return;
     }
     payload = {
       deviceTypeCode: 'interchangeable_back',
       deviceTypeId: deviceType.id,
       filmFormatId: createForm.filmFormatId,
-      frameSize: createForm.frameSize as CreateFilmDeviceRequest['frameSize'],
+      frameSize: createForm.frameSize,
       name: createForm.name.trim(),
       system: createForm.system.trim()
     };
   } else {
-    if (!createForm.name.trim() || !createForm.brand.trim() || !createForm.holderTypeId || !createForm.filmFormatId) {
-      feedback.error('Holder name, brand, holder type, and format are required.');
+    if (!createForm.name.trim() || !createForm.brand.trim() || !createForm.holderTypeId || !createForm.filmFormatId || !createForm.frameSize) {
+      feedback.error('Holder name, brand, holder type, format, and frame size are required.');
       return;
     }
     payload = {
       deviceTypeCode: 'film_holder',
       deviceTypeId: deviceType.id,
       filmFormatId: createForm.filmFormatId,
-      frameSize: createForm.frameSize as CreateFilmDeviceRequest['frameSize'],
+      frameSize: createForm.frameSize,
       name: createForm.name.trim(),
       brand: createForm.brand.trim(),
       slotCount: createForm.slotCount as 1 | 2,

--- a/apps/ui/src/components/FrameMetadataEditor.vue
+++ b/apps/ui/src/components/FrameMetadataEditor.vue
@@ -1,0 +1,129 @@
+<template>
+  <div class="column q-gutter-sm q-pa-md bg-grey-2">
+    <q-select
+      v-model="form.aperturePreset"
+      :options="apertureOptions"
+      emit-value
+      map-options
+      label="Aperture"
+      filled
+      dense
+      clearable
+      :disable="readonly"
+    />
+    <q-input
+      v-if="form.aperturePreset === null"
+      v-model="form.apertureCustom"
+      label="Custom aperture (e.g. 3.5)"
+      type="number"
+      filled
+      dense
+      :disable="readonly"
+    />
+
+    <q-input
+      v-model="form.shutterInput"
+      label="Shutter speed (e.g. 1/500 or 2.5)"
+      filled
+      dense
+      clearable
+      :disable="readonly"
+      :hint="shutterDisplayHint"
+    />
+
+    <q-checkbox
+      v-model="form.filterUsed"
+      :indeterminate-value="null"
+      toggle-indeterminate
+      label="Filter used"
+      :disable="readonly"
+    />
+
+    <div class="text-caption">
+      <span v-if="saveStatus === 'pending'" class="text-grey-6">Saving…</span>
+      <span v-else-if="saveStatus === 'saving'" class="text-grey-6">
+        <q-spinner size="xs" /> Saving…
+      </span>
+      <span v-else-if="saveStatus === 'saved'" class="text-positive">Saved</span>
+      <span v-else-if="saveStatus === 'error'" class="text-negative">
+        {{ saveError }}
+      </span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onBeforeUnmount, onMounted, reactive } from 'vue';
+import { APERTURE_PRESETS, type AperturePreset, type FilmFrame, type UpdateFilmFrameRequest } from '@frollz2/schema';
+import { useFrameMetadataAutosave } from '../composables/useFrameMetadataAutosave.js';
+import { parseShutterSpeedInput, formatShutterSpeed } from '../utils/shutterSpeed.js';
+
+const apertureOptions = [
+  ...APERTURE_PRESETS.map((v) => ({ label: `f/${v}`, value: v })),
+  { label: 'Other…', value: null }
+];
+
+interface Props {
+  frame: FilmFrame;
+  filmId: number;
+  readonly?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  readonly: false
+});
+
+const form = reactive({
+  aperturePreset: null as number | null,
+  apertureCustom: '',
+  shutterInput: '',
+  filterUsed: null as boolean | null
+});
+
+const resolvedAperture = computed((): number | null => {
+  if (form.aperturePreset !== null) return form.aperturePreset;
+  const parsed = parseFloat(form.apertureCustom);
+  return isFinite(parsed) && parsed > 0 ? parsed : null;
+});
+
+const shutterDisplayHint = computed(() => {
+  if (!form.shutterInput.trim()) return '';
+  const parsed = parseShutterSpeedInput(form.shutterInput);
+  if (parsed === null) return 'Invalid format';
+  return formatShutterSpeed(parsed);
+});
+
+const patch = computed((): UpdateFilmFrameRequest => ({
+  aperture: resolvedAperture.value,
+  shutterSpeedSeconds: parseShutterSpeedInput(form.shutterInput),
+  filterUsed: form.filterUsed
+}));
+
+const filmIdRef = computed(() => props.filmId);
+const frameIdRef = computed(() => props.frame.id);
+const { saveStatus, saveError, flush } = useFrameMetadataAutosave(
+  filmIdRef,
+  frameIdRef,
+  patch
+);
+
+onMounted(() => {
+  if (props.frame.aperture !== null) {
+    const isPreset = APERTURE_PRESETS.includes(props.frame.aperture as AperturePreset);
+    if (isPreset) {
+      form.aperturePreset = props.frame.aperture;
+    } else {
+      form.aperturePreset = null;
+      form.apertureCustom = String(props.frame.aperture);
+    }
+  }
+  if (props.frame.shutterSpeedSeconds !== null) {
+    form.shutterInput = formatShutterSpeed(props.frame.shutterSpeedSeconds);
+  }
+  form.filterUsed = props.frame.filterUsed;
+});
+
+onBeforeUnmount(async () => {
+  await flush();
+});
+</script>

--- a/apps/ui/src/composables/useFrameMetadataAutosave.ts
+++ b/apps/ui/src/composables/useFrameMetadataAutosave.ts
@@ -1,0 +1,72 @@
+import { ref, watch, type Ref } from 'vue';
+import type { UpdateFilmFrameRequest } from '@frollz2/schema';
+import { filmFrameSchema } from '@frollz2/schema';
+import { useApi } from './useApi.js';
+import { createIdempotencyKey } from './idempotency.js';
+import { readApiData } from './api-envelope.js';
+import { useFilmStore } from '../stores/film.js';
+
+type SaveStatus = 'idle' | 'pending' | 'saving' | 'saved' | 'error';
+
+export interface FrameMetadataAutosave {
+  saveStatus: Ref<SaveStatus>;
+  saveError: Ref<string | null>;
+  flush: () => Promise<void>;
+}
+
+export function useFrameMetadataAutosave(
+  filmId: Ref<number>,
+  frameId: Ref<number>,
+  patch: Ref<UpdateFilmFrameRequest>,
+  debounceMs = 800
+): FrameMetadataAutosave {
+  const { request } = useApi();
+  const filmStore = useFilmStore();
+
+  const saveStatus = ref<SaveStatus>('idle');
+  const saveError = ref<string | null>(null);
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  async function save(): Promise<void> {
+    saveStatus.value = 'saving';
+    saveError.value = null;
+    const idempotencyKey = createIdempotencyKey();
+    try {
+      const response = await request(
+        `/api/v1/film/${filmId.value}/frames/${frameId.value}`,
+        {
+          method: 'PATCH',
+          body: JSON.stringify(patch.value),
+          headers: { 'idempotency-key': idempotencyKey }
+        }
+      );
+      const updated = filmFrameSchema.parse(await readApiData(response));
+      filmStore.patchFrame(updated);
+      saveStatus.value = 'saved';
+    } catch (err) {
+      saveStatus.value = 'error';
+      saveError.value = err instanceof Error ? err.message : 'Save failed';
+    }
+  }
+
+  watch(patch, () => {
+    saveStatus.value = 'pending';
+    if (debounceTimer !== null) {
+      clearTimeout(debounceTimer);
+    }
+    debounceTimer = setTimeout(async () => {
+      debounceTimer = null;
+      await save();
+    }, debounceMs);
+  });
+
+  async function flush(): Promise<void> {
+    if (debounceTimer !== null) {
+      clearTimeout(debounceTimer);
+      debounceTimer = null;
+      await save();
+    }
+  }
+
+  return { saveStatus, saveError, flush };
+}

--- a/apps/ui/src/pages/film/[id].vue
+++ b/apps/ui/src/pages/film/[id].vue
@@ -1,14 +1,16 @@
 <!-- eslint-disable vue/multi-word-component-names -->
 <script setup lang="ts">
-import { computed, onMounted, watch } from 'vue';
+import { computed, onMounted, ref, watch } from 'vue';
 import { useRoute } from 'vue-router';
 import type { FilmFrame } from '@frollz2/schema';
 import { useFilmStore } from '../../stores/film.js';
 import { useReferenceStore } from '../../stores/reference.js';
 import { useDeviceStore } from '../../stores/devices.js';
 import FilmEventForm from '../../components/FilmEventForm.vue';
+import FrameMetadataEditor from '../../components/FrameMetadataEditor.vue';
 import { filmTransitionMap } from '@frollz2/schema';
 import { useFilmCostFormatting } from '../../composables/useFilmCostFormatting.js';
+import { formatShutterSpeed } from '../../utils/shutterSpeed.js';
 
 const route = useRoute();
 const filmStore = useFilmStore();
@@ -16,11 +18,22 @@ const referenceStore = useReferenceStore();
 const deviceStore = useDeviceStore();
 
 const filmId = computed(() => Number(route.params.id));
+const expandedFrameIds = ref(new Set<number>());
+const isFrameEditable = computed(() => filmStore.currentFilm?.currentStateCode === 'loaded');
 
 const frameColumns = [
-  { name: 'frameNumber', label: 'Frame', field: 'frameNumber', sortable: true, align: 'left' as const },
-  { name: 'state', label: 'State', field: (row: FilmFrame) => row.currentStateCode, align: 'left' as const }
+  { name: 'frameNumber', label: '#', field: 'frameNumber', sortable: true, align: 'left' as const },
+  { name: 'state', label: 'State', field: (row: FilmFrame) => row.currentStateCode, align: 'left' as const },
+  { name: 'aperture', label: 'Aperture', field: (row: FilmFrame) => row.aperture !== null ? `f/${row.aperture}` : '—', align: 'left' as const },
+  { name: 'shutter', label: 'Shutter', field: (row: FilmFrame) => row.shutterSpeedSeconds !== null ? formatShutterSpeed(row.shutterSpeedSeconds) : '—', align: 'left' as const },
+  { name: 'filter', label: 'Filter', field: (row: FilmFrame) => row.filterUsed === true ? 'Yes' : row.filterUsed === false ? 'No' : '—', align: 'left' as const }
 ];
+
+function toggleFrame(id: number): void {
+  expandedFrameIds.value.has(id)
+    ? expandedFrameIds.value.delete(id)
+    : expandedFrameIds.value.add(id);
+}
 
 const { formatCost, formatKnownCost } = useFilmCostFormatting();
 
@@ -97,9 +110,26 @@ watch(filmId, load);
     <q-card flat bordered>
       <q-card-section class="text-subtitle1">Frames</q-card-section>
       <q-separator />
-      <q-card-section>
+      <q-card-section class="q-pa-none">
         <q-table :rows="filmStore.currentFrames" :columns="frameColumns" row-key="id" flat bordered
-          :loading="filmStore.isDetailLoading" />
+          :loading="filmStore.isDetailLoading">
+          <template #body="tProps">
+            <q-tr :props="tProps" class="cursor-pointer" @click="toggleFrame(tProps.row.id)">
+              <q-td v-for="col in tProps.cols" :key="col.name" :props="tProps">
+                {{ col.value }}
+              </q-td>
+            </q-tr>
+            <q-tr v-if="expandedFrameIds.has(tProps.row.id)" :props="tProps">
+              <q-td colspan="100%" class="q-pa-none">
+                <FrameMetadataEditor
+                  :frame="tProps.row"
+                  :film-id="filmId"
+                  :readonly="!isFrameEditable"
+                />
+              </q-td>
+            </q-tr>
+          </template>
+        </q-table>
       </q-card-section>
     </q-card>
   </q-page>

--- a/apps/ui/src/stores/film.ts
+++ b/apps/ui/src/stores/film.ts
@@ -217,6 +217,12 @@ export const useFilmStore = defineStore('film', () => {
     }
   }
 
+  function patchFrame(updated: FilmFrame): void {
+    currentFrames.value = currentFrames.value.map((f) =>
+      f.id === updated.id ? updated : f
+    );
+  }
+
   return {
     films,
     currentFilm,
@@ -237,6 +243,7 @@ export const useFilmStore = defineStore('film', () => {
     createFilm,
     updateFilm,
     addEvent,
-    addFrameEvent
+    addFrameEvent,
+    patchFrame
   };
 });

--- a/apps/ui/src/utils/shutterSpeed.ts
+++ b/apps/ui/src/utils/shutterSpeed.ts
@@ -1,0 +1,29 @@
+const MIN_SECONDS = 1 / 8000; // 0.000125
+const MAX_SECONDS = 14400;
+
+export function parseShutterSpeedInput(raw: string): number | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+
+  const fractionMatch = /^(\d+)\s*\/\s*(\d+)$/.exec(trimmed);
+  if (fractionMatch) {
+    const num = Number(fractionMatch[1]);
+    const den = Number(fractionMatch[2]);
+    if (den === 0) return null;
+    const v = num / den;
+    return isFinite(v) && v >= MIN_SECONDS && v <= MAX_SECONDS ? v : null;
+  }
+
+  const v = Number(trimmed);
+  if (!isFinite(v) || isNaN(v)) return null;
+  return v >= MIN_SECONDS && v <= MAX_SECONDS ? v : null;
+}
+
+export function formatShutterSpeed(seconds: number): string {
+  if (seconds < 1) {
+    const n = Math.round(1 / seconds);
+    if (Math.abs(seconds - 1 / n) / seconds < 0.001) return `1/${n}`;
+    return `${parseFloat(seconds.toPrecision(4))}s`;
+  }
+  return `${parseFloat(seconds.toPrecision(6))}s`;
+}

--- a/packages/schema/src/film.ts
+++ b/packages/schema/src/film.ts
@@ -35,6 +35,19 @@ export const FRAME_SIZE_CODES = [
   'instax_square'
 ] as const;
 
+// Full, half, and third stops in ascending order.
+// Half-stop values: 1.2, 1.7, 2.4, 3.4, 4.8, 6.7, 9.5, 13, 19, 27, 38, 54
+// Third-stop values fill the gaps between full stops.
+export const APERTURE_PRESETS = [
+  1, 1.1, 1.2, 1.4, 1.6, 1.7, 1.8,
+  2, 2.2, 2.4, 2.5, 2.8, 3.2, 3.4, 3.5,
+  4, 4.5, 4.8, 5, 5.6, 6.3, 6.7, 7.1,
+  8, 9, 9.5, 10, 11, 13, 14,
+  16, 18, 19, 20, 22, 25, 27, 29,
+  32, 36, 38, 40, 45, 51, 54, 57, 64
+] as const;
+export type AperturePreset = typeof APERTURE_PRESETS[number];
+
 export const frameSizeCodeSchema = z.enum(FRAME_SIZE_CODES);
 export const costAmountSchema = z.object({
   amount: z.number().nonnegative(),
@@ -363,7 +376,16 @@ export const filmFrameSchema = z.object({
   frameNumber: z.number().int().positive(),
   currentStateId: idSchema,
   currentStateCode: filmStateCodeSchema,
-  currentState: filmStateSchema
+  currentState: filmStateSchema,
+  aperture: z.number().positive().nullable(),
+  shutterSpeedSeconds: z.number().positive().max(14400).nullable(),
+  filterUsed: z.boolean().nullable()
+});
+
+export const updateFilmFrameRequestSchema = z.object({
+  aperture: z.number().positive().nullable().optional(),
+  shutterSpeedSeconds: z.number().positive().max(14400).nullable().optional(),
+  filterUsed: z.boolean().nullable().optional()
 });
 
 export const deviceLoadTimelineEventSchema = z.object({
@@ -525,6 +547,7 @@ export type FilmFrame = z.infer<typeof filmFrameSchema>;
 export type FilmCreateRequest = z.infer<typeof filmCreateRequestSchema>;
 export type FilmCreateForm = z.infer<typeof filmCreateFormSchema>;
 export type FilmUpdateRequest = z.infer<typeof filmUpdateRequestSchema>;
+export type UpdateFilmFrameRequest = z.infer<typeof updateFilmFrameRequestSchema>;
 export type FilmListQuery = z.infer<typeof filmListQuerySchema>;
 export type FilmListResponse = z.infer<typeof filmListResponseSchema>;
 export type FilmJourneyEvent = z.infer<typeof filmJourneyEventSchema>;


### PR DESCRIPTION
Adds aperture, shutterSpeedSeconds, and filterUsed nullable fields to FilmFrame. Stored as direct columns on film_frame updated via a new PATCH /film/:id/frames/:frameId endpoint gated to the loaded film state.

UI surfaces fields in a click-to-expand row on the frames table with debounced autosave, aperture preset dropdown + Other... input, shutter speed fraction/decimal parsing, and tri-state filter checkbox.

## What does this PR do?

<!-- Brief description of the change and why it was needed. -->

## How was it tested?

<!-- Describe how you verified the change works. -->

## Checklist

- [ ] Tests added or updated
- [ ] All tests pass (`npm test` in `frollz-api/` and `frollz-ui/`)
- [ ] Lint passes (`npm run lint` in both)
- [ ] No `console.log` left in committed code
- [ ] PR targets the `development` branch (not `main`)
